### PR TITLE
Add Les Trois Vallées ski trip research and accommodation masterlist

### DIFF
--- a/entities/places/brides-les-bains.md
+++ b/entities/places/brides-les-bains.md
@@ -1,0 +1,39 @@
+---
+type: place
+name: Brides-les-Bains
+category: village
+locations: ['Les Trois Vallées', 'Savoie', 'French Alps', 'France']
+coordinates: [45.4536, 6.5703]
+altitude: 600m
+tags: [skiing, budget, spa-town, trois-vallees]
+trips: ['Les Trois Vallées Ski Trip']
+---
+
+## Overview
+
+Spa town at the base of Les Trois Vallées. The **cheapest accommodation option** for skiing the 3 Vallées — 30-50% cheaper than resort-level villages.
+
+## Ski Access
+
+- **Olympe Gondola:** 22-minute ride up to Méribel (FREE with lift pass)
+- Connects to full 3 Vallées network via Méribel
+
+## Pricing (Mid-March, pp/week)
+
+| Type | Budget | Mid-Range | Premium |
+|------|--------|-----------|---------|
+| Studio SC | €280-400 | — | — |
+| 2-Room Apt | — | €400-550 | — |
+| Hotel B&B | — | — | €450-650 |
+
+## Why Stay Here
+
+- Best value in the entire 3 Vallées system
+- Spa/thermal baths for après-ski recovery
+- Charming village atmosphere
+- Free gondola access included in lift pass
+- Self-catering keeps total trip cost to ~€1,259/person/week
+
+## Tourist Office
+
++33 4 79 55 20 11

--- a/entities/places/la-tania.md
+++ b/entities/places/la-tania.md
@@ -1,0 +1,36 @@
+---
+type: place
+name: La Tania
+aliases: [Courchevel La Tania]
+category: ski-resort
+locations: ['Les Trois Vallées', 'Courchevel Valley', 'Savoie', 'French Alps', 'France']
+coordinates: [45.4333, 6.5833]
+altitude: 1400m
+tags: [skiing, budget, ski-in-ski-out, trois-vallees, chalets]
+trips: ['Les Trois Vallées Ski Trip']
+---
+
+## Overview
+
+Small, purpose-built ski village in the Courchevel valley. Excellent value with **ski-in/ski-out** access and a strong catered chalet market.
+
+## Ski Access
+
+- Ski-in/ski-out — direct lift links to Courchevel and Méribel
+- Free shuttle connections
+
+## Pricing (Mid-March, pp/week)
+
+| Type | Budget | Mid-Range | Premium |
+|------|--------|-----------|---------|
+| Studio SC | €380-520 | — | — |
+| 2-Room Apt | — | €550-800 | — |
+| Catered Chalet | — | €600-950 | €900-1,200 |
+| Hotel B&B | — | €500-800 | — |
+
+## Why Stay Here
+
+- Best value ski-in/ski-out in the Courchevel system
+- Strong catered chalet scene (~€1,794 total budget pp/week)
+- Small, family-friendly village
+- Direct access to both Courchevel and Méribel pistes

--- a/entities/places/les-menuires.md
+++ b/entities/places/les-menuires.md
@@ -1,0 +1,42 @@
+---
+type: place
+name: Les Menuires
+category: ski-resort
+locations: ['Les Trois Vallées', 'Belleville Valley', 'Savoie', 'French Alps', 'France']
+coordinates: [45.3256, 6.5319]
+altitude: 1850m
+tags: [skiing, budget, ski-in-ski-out, trois-vallees, purpose-built]
+trips: ['Les Trois Vallées Ski Trip']
+---
+
+## Overview
+
+Purpose-built ski resort in the Belleville Valley. One of the **best value on-piste resorts** in the 3 Vallées with ski-in/ski-out access.
+
+## Districts
+
+| District | Access | pp/week |
+|----------|--------|---------|
+| La Croisette | Direct ski-in/ski-out | €400-650 |
+| Preyerand | Connected via lifts | €450-700 |
+| Les Bruyères | Own lifts, ski-in/ski-out | €500-800 |
+| Les Fontanettes | Ski-in/ski-out, quiet | €450-750 |
+| Reberty 2000 | Excellent ski-in/ski-out | €500-850 |
+| Le Bettaix (hamlet) | 150m from chairlift | €400-700 |
+
+## Pricing (Mid-March, pp/week)
+
+- **Budget:** €320-450
+- **Mid-Range:** €450-650
+- **Premium:** €700-950
+
+## Why Stay Here
+
+- Cheapest ski-in/ski-out in the 3 Vallées
+- Direct access to Val Thorens and Saint-Martin
+- Mid-range total budget ~€1,669 pp/week
+- Family-friendly, good facilities
+
+## Tourist Office
+
++33 4 79 00 73 00

--- a/entities/places/les-trois-vallees.md
+++ b/entities/places/les-trois-vallees.md
@@ -1,0 +1,44 @@
+---
+type: place
+name: Les Trois Vallées
+aliases: [The Three Valleys, 3 Vallées]
+category: ski-area
+locations: ['Savoie', 'French Alps', 'France']
+coordinates: [45.3833, 6.5667]
+tags: [skiing, off-piste, alps, largest-ski-area]
+trips: ['Les Trois Vallées Ski Trip']
+---
+
+## Overview
+
+The **world's largest linked ski area**, comprising three main valleys in the Tarentaise region of Savoie, French Alps:
+
+1. **Courchevel Valley** — 27 locations, from budget hamlets to ultra-luxury 1850
+2. **Méribel Valley** — 23 locations, central hub connecting all three valleys
+3. **Belleville Valley** — Val Thorens, Les Menuires, Saint-Martin-de-Belleville
+
+## Key Stats
+
+- **Total piste:** 600km of marked runs
+- **Lifts:** 160+ ski lifts
+- **Altitude:** 600m (Brides-les-Bains) to 3,230m (Cime de Caron)
+- **Resorts:** Courchevel, Méribel, Val Thorens, Les Menuires, Saint-Martin-de-Belleville, La Tania
+- **Access points:** Brides-les-Bains (Olympe gondola), Orelle (Maurienne gondola)
+
+## Free Shuttle Network
+
+All three valleys have extensive free shuttle systems connecting villages to lifts:
+- Courchevel: Every 10-30 min, 07:00-02:00
+- Méribel (Méribus): Every 15-20 min, 07:30-Midnight
+- Belleville: 11 daily services
+
+## Related Entities
+
+- [[2026-03-les-trois-vallees|Trip Planning]]
+- [[les-trois-vallees-accommodation-masterlist|Full Accommodation Research]]
+- [[brides-les-bains]]
+- [[orelle]]
+- [[la-tania]]
+- [[les-menuires]]
+- [[val-thorens]]
+- [[saint-martin-de-belleville]]

--- a/entities/places/orelle.md
+++ b/entities/places/orelle.md
@@ -1,0 +1,32 @@
+---
+type: place
+name: Orelle
+category: village
+locations: ['Les Trois Vallées', 'Maurienne Valley', 'Savoie', 'French Alps', 'France']
+coordinates: [45.2167, 6.5333]
+altitude: 900m
+tags: [skiing, budget, trois-vallees, back-door-access]
+trips: ['Les Trois Vallées Ski Trip']
+---
+
+## Overview
+
+Small village in the Maurienne Valley — the "back door" entry to Les Trois Vallées via a 15-minute gondola ride directly to Val Thorens. One of the cheapest access points to the ski area.
+
+## Ski Access
+
+- **Orelle Gondola:** 15-minute ride to Val Thorens / Cime de Caron area
+- Free shuttle from residence to gondola (every 20 min)
+
+## Pricing (Mid-March, pp/week)
+
+- **Budget:** €350-550
+- **Mid-Range:** €550-750
+- **Premium:** €800-1,000
+
+## Why Stay Here
+
+- Cheapest direct gondola access to 3 Vallées
+- Quick access to Val Thorens (highest resort, best snow)
+- Quiet alternative to busy resort villages
+- Free local shuttle to gondola

--- a/entities/places/saint-martin-de-belleville.md
+++ b/entities/places/saint-martin-de-belleville.md
@@ -1,0 +1,38 @@
+---
+type: place
+name: Saint-Martin-de-Belleville
+aliases: [St Martin, Saint Martin]
+category: village
+locations: ['Les Trois Vallées', 'Belleville Valley', 'Savoie', 'French Alps', 'France']
+coordinates: [45.3772, 6.5044]
+altitude: 1450m
+tags: [skiing, authentic-village, trois-vallees, budget]
+trips: ['Les Trois Vallées Ski Trip']
+---
+
+## Overview
+
+Authentic Savoyard village with direct lift access to Les Menuires and the wider 3 Vallées. Best option for an **authentic Alpine village experience** at a reasonable price.
+
+## Nearby Hamlets
+
+| Location | Access | pp/week |
+|----------|--------|---------|
+| Saint-Martin centre | Gondola + chairlift | €400-700 |
+| Saint Marcel | Free ski bus (400m) | €350-650 |
+| Le Châtelard | Free shuttle | €400-700 |
+| Les Granges | Free shuttle | €450-800 |
+| Villarabout | 4 min drive to gondola | €500-900 |
+
+## Pricing (Mid-March, pp/week)
+
+- **Budget:** €350-480
+- **Mid-Range:** €480-650
+- **Premium:** €800-1,100
+
+## Why Stay Here
+
+- Traditional village character (not purpose-built)
+- Direct gondola + chairlift access to pistes
+- Good restaurants and authentic après-ski
+- Saint-Marcel hamlet nearby is even cheaper (€350-500)

--- a/entities/places/val-thorens.md
+++ b/entities/places/val-thorens.md
@@ -1,0 +1,42 @@
+---
+type: place
+name: Val Thorens
+category: ski-resort
+locations: ['Les Trois Vallées', 'Belleville Valley', 'Savoie', 'French Alps', 'France']
+coordinates: [45.2978, 6.5800]
+altitude: 2300m
+tags: [skiing, highest-resort-europe, trois-vallees, snow-sure]
+trips: ['Les Trois Vallées Ski Trip']
+---
+
+## Overview
+
+Europe's highest ski resort at 2,300m. **Best snow guarantee** in the 3 Vallées. Access to Cime de Caron (3,230m) and the Orelle sector.
+
+## Districts
+
+| District | Access | pp/week |
+|----------|--------|---------|
+| Lombarde | Ski-in/ski-out | €550-900 |
+| Slalom | Direct slope access | €550-900 |
+| Les Balcons | Ski-in/ski-out | €600-950 |
+| Soleil | Ski-in/ski-out | €600-950 |
+| Plein Sud | Excellent ski-in/ski-out | €600-1,000 |
+| Grande Rue | Central, walking distance | €700-1,100 |
+
+## Pricing (Mid-March, pp/week)
+
+- **Budget:** €400-580
+- **Mid-Range:** €600-900
+- **Premium:** €1,000-1,500
+
+## Why Stay Here
+
+- Highest resort = best late-season snow
+- Outer districts (Lombarde, Slalom) offer budget options from €400
+- Ski-in/ski-out everywhere
+- Access to Orelle sector for off-piste
+
+## Tourist Office
+
++33 4 79 00 08 08

--- a/entities/trips/2026-03-les-trois-vallees.md
+++ b/entities/trips/2026-03-les-trois-vallees.md
@@ -1,0 +1,69 @@
+---
+type: trip
+name: Les Trois Vallées Ski Trip
+status: idea
+dates:
+  start: null
+  end: null
+locations: ['Les Trois Vallées', 'Savoie', 'French Alps']
+countries: ['France']
+tags: [skiing, off-piste, alps, budget-friendly]
+research: "[[les-trois-vallees-accommodation-masterlist]]"
+created: 2026-02-13
+---
+
+## Overview
+
+Potential ski trip to **Les Trois Vallées** — the world's largest linked ski area in the French Alps. Primary focus on **affordable off-piste skiing** in mid-March.
+
+## Key Research
+
+Full accommodation masterlist covering 85+ locations with mid-March pricing: [[les-trois-vallees-accommodation-masterlist]]
+
+## Top Budget Options
+
+| Rank | Location | pp/week | Notes |
+|------|----------|---------|-------|
+| 1 | Brides-les-Bains | €280-400 | 30-50% cheaper, Olympe gondola, spa town |
+| 2 | Moûtiers | €250-400 | Transport hub, bus access, lowest prices |
+| 3 | Orelle | €350-550 | Cheapest 3 Vallées access, 15-min gondola |
+| 4 | Bozel | €350-550 | FREE shuttle, near Courchevel & Paradiski |
+| 5 | Les Menuires | €320-450 | Ski-in/ski-out, purpose-built value |
+
+## Budget Estimate (Per Person / 7 Nights)
+
+**Budget option (Brides-les-Bains):** ~€1,259
+- Accommodation (studio): €350
+- 6-Day 3 Vallées Pass: €409
+- Ski Hire: €90
+- Transfers (shared): €110
+- Food (self-catered): €200
+- Extras: €100
+
+**Mid-range option (Les Menuires):** ~€1,669
+
+**Catered chalet (La Tania):** ~€1,794
+
+## Money-Saving Tips
+
+- Book Brides-les-Bains or Orelle for 30-50% savings
+- Family Flex Pass: everyone pays child rate (€335/6 days)
+- Book equipment online for up to 40% off
+- Travel late March (after 20th) for 10-15% discounts
+- Self-catering saves €200-300 vs half-board
+
+## Key Contacts
+
+- Brides-les-Bains Tourist Office: +33 4 79 55 20 11
+- Méribel: +33 4 79 00 73 00
+- Courchevel: +33 4 79 08 00 29
+- Val Thorens: +33 4 79 00 08 08
+- Official booking: reservation.les3vallees.com
+
+## Next Steps
+
+- [ ] Decide on dates (mid-March target)
+- [ ] Choose accommodation location based on budget vs. ski access tradeoff
+- [ ] Book accommodation
+- [ ] Arrange transfers
+- [ ] Book equipment rental online

--- a/research/les-trois-vallees-accommodation-masterlist.md
+++ b/research/les-trois-vallees-accommodation-masterlist.md
@@ -1,0 +1,390 @@
+---
+type: research
+topic: Les Trois Vallées Accommodation Masterlist
+trip: "[[2026-03-les-trois-vallees|Les Trois Vallées Ski Trip]]"
+tags: [skiing, accommodation, french-alps, trois-vallees, budget]
+created: 2026-02-13
+source: compiled research (official resort websites, booking platforms, local tourist info)
+price_date: mid-March 2025 estimates
+---
+
+# Les Trois Vallées - Complete Accommodation Masterlist
+
+Every single town for affordable ski accommodation (off-piste focus).
+Mid-March price estimates | 85+ locations identified.
+
+## Quick Stats
+
+- **Total Locations:** 85+
+- **Main Resort Villages:** 15
+- **Satellite Hamlets:** 40+
+- **Valley Towns:** 25+
+- **Price Range:** €280-1,200+ per person/week
+- **Best Value:** Brides-les-Bains (30-50% cheaper)
+
+---
+
+## Section 1: Courchevel Valley (27 Locations)
+
+### Tier 1: Main Courchevel Villages
+
+| # | Location | Altitude | Access | Mid-March Price (pp/week) |
+|---|----------|----------|--------|--------------------------|
+| 1 | Courchevel Le Praz (1300) | 1,300m | Gondola to 1850 (8 min) | €450-700 |
+| 2 | Courchevel Village (1550) | 1,550m | Grangettes gondola (5 min) | €500-750 |
+| 3 | Courchevel Moriond (1650) | 1,650m | Direct ski access | €550-850 |
+| 4 | Courchevel 1850 | 1,850m | Ski-in/ski-out | €700-1,200+ |
+| 5 | Courchevel La Tania | 1,400m | Ski-in/ski-out, free shuttle | €380-600 |
+| 6 | Saint-Bon-Tarentaise | 1,100m | Shuttle to lifts, ski trail | €450-650 |
+
+### Tier 2: Satellite Hamlets (Courchevel Commune)
+
+| # | Location | Altitude | Access | Mid-March Price (pp/week) |
+|---|----------|----------|--------|--------------------------|
+| 7 | Bozel | 800m | FREE shuttle (20 min) | €350-550 |
+| 8 | La Perrière | 1,100m | Shuttle access | €450-700 |
+| 9 | Le Grenier | 950m | Shuttle access | €350-600 |
+| 10 | Le Fay | 900m | Shuttle access | €350-600 |
+| 11 | Le Fontanil | 950m | Shuttle access | €350-600 |
+| 12 | Le Grand Carrey / Le Petit Carrey | 1,000m | Shuttle access | €350-600 |
+| 13 | Villaflou | 1,000m | Shuttle access | €350-600 |
+| 14 | La Nouvaz | 1,050m | Shuttle access | €350-550 |
+| 15 | Le Freney | 1,190m | Shuttle access | €350-600 |
+| 16 | Les Chavonnes | 1,100m | 5 min to Brides-les-Bains | €300-550 |
+
+### Tier 3: Nearby Communes with Courchevel Access
+
+| # | Location | Altitude | Access | Mid-March Price (pp/week) |
+|---|----------|----------|--------|--------------------------|
+| 17 | Brides-les-Bains | 600m | Olympe gondola (22 min) | €280-400 |
+| 18 | Les Allues (Méribel valley) | 1,100m | Olympe gondola + Méribus | €450-700 |
+| 19 | Champagny-en-Vanoise | 1,250m | Champagny gondola (Paradiski) | €450-700 |
+| 20 | Pralognan-la-Vanoise | 1,400m | 30 min drive to Courchevel | €400-650 |
+
+### Tier 4: Residential Areas/Districts
+
+| # | Location | Altitude | Character | Mid-March Price (pp/week) |
+|---|----------|----------|-----------|--------------------------|
+| 21 | Belvedère (Moriond) | 1,700m+ | Upscale residential | €600-950 |
+| 22 | Brigues (Village) | 1,600m+ | Residential area | €500-800 |
+| 23 | Jardin Alpin (1850) | 1,850m+ | Prestigious | €800-1,500+ |
+| 24 | Altiport (1850) | 1,850m+ | Near airport | €1,000-2,000+ |
+| 25 | Chenus (1850) | 1,850m+ | Prestigious | €800-1,500+ |
+| 26 | Nogentil (1850) | 1,850m+ | Ultra-exclusive | €1,500-3,000+ |
+| 27 | Bellecôte (1850) | 1,850m | Central area | €600-1,000 |
+
+---
+
+## Section 2: Méribel Valley (23 Locations)
+
+### Main Méribel Villages
+
+| # | Location | Altitude | Access | Mid-March Price (pp/week) |
+|---|----------|----------|--------|--------------------------|
+| 1 | Les Allues | 1,100m | Olympe gondola (15 min) + Méribus | €450-700 |
+| 2 | Méribel Village | 1,400m | Golf chairlift + Méribus | €500-800 |
+| 3 | Méribel Centre | 1,450m | La Chaudanne hub | €600-950 |
+| 4 | Altitude 1600/Morel | 1,600m | Morel chairlift | €450-750 |
+| 5 | Mottaret | 1,750m | Ski-in/ski-out | €400-650 |
+
+### Satellite Hamlets
+
+| # | Location | Altitude | Access | Mid-March Price (pp/week) |
+|---|----------|----------|--------|--------------------------|
+| 6 | Le Raffort | 1,350m | Olympe cable car (100m) | €600-1,000 |
+| 7 | Chandon | 1,350m | Free Méribus | €500-850 |
+| 8 | La Gittaz | 1,250m | Méribus connections | €450-750 |
+| 9 | Le Cruet | 1,200m | Méribus (15 min) | €500-850 |
+| 10 | Nantgerel | 1,150m | Méribus | €450-750 |
+| 11 | Le Plantin | 1,150m | Méribus | €500-800 |
+
+### Méribel Centre Residential Areas
+
+| # | Location | Altitude | Character | Mid-March Price (pp/week) |
+|---|----------|----------|-----------|--------------------------|
+| 12 | Mussillon | 1,450m | Catered chalet central | €550-900 |
+| 13 | Le Plan du Moulin | 1,450m | Quiet corner | €500-850 |
+| 14 | La Renarde | 1,500-1,600m | Chic residential | €600-1,000 |
+| 15 | Le Plateau | 1,600m | Large apartment blocks | €500-850 |
+| 16 | Le Rond-Point | 1,650m | Après-ski hub | €700-1,100 |
+| 17 | Belvedere | 1,700m | Olympic legacy | €800-1,300 |
+| 18 | Altiport | 1,700m | Beginner's paradise | €450-750 |
+
+### Valley Floor & Nearby
+
+| # | Location | Altitude | Access | Mid-March Price (pp/week) |
+|---|----------|----------|--------|--------------------------|
+| 19 | Brides-les-Bains | 600m | Olympe gondola (FREE) | €280-400 |
+| 20 | La Tania (Courchevel) | 1,400m | Direct lift links | €380-600 |
+
+### Mountain Refuges
+
+| # | Location | Altitude | Type | Mid-March Price |
+|---|----------|----------|------|-----------------|
+| 21 | Refuge du Christ | 1,650m | Méribel Label | Budget |
+| 22 | Refuge de la Traye | 1,650m | Luxury refuge | Premium |
+| 23 | Refuge du Saut | 2,126m | High mountain | Budget |
+
+---
+
+## Section 3: Belleville Valley (Val Thorens, Les Menuires, St Martin)
+
+### Val Thorens (2,300m) - 6 Districts
+
+| # | District | Access | Mid-March Price (pp/week) |
+|---|----------|--------|--------------------------|
+| 1 | Les Balcons | Ski-in/ski-out | €600-950 |
+| 2 | Soleil | Ski-in/ski-out | €600-950 |
+| 3 | Grande Rue | Central, walking distance | €700-1,100 |
+| 4 | Lombarde | Ski-in/ski-out | €550-900 |
+| 5 | Slalom | Direct slope access | €550-900 |
+| 6 | Plein Sud | Excellent ski-in/ski-out | €600-1,000 |
+
+### Les Menuires (1,850m) - 5 Districts + Hamlet
+
+| # | District | Access | Mid-March Price (pp/week) |
+|---|----------|--------|--------------------------|
+| 7 | La Croisette | Direct ski-in/ski-out | €400-650 |
+| 8 | Preyerand | Connected via lifts | €450-700 |
+| 9 | Les Bruyères | Own lifts, ski-in/ski-out | €500-800 |
+| 10 | Les Fontanettes | Ski-in/ski-out, quiet | €450-750 |
+| 11 | Grand Reberty/Reberty 2000 | Excellent ski-in/ski-out | €500-850 |
+| 12 | Le Bettaix (hamlet) | 150m from chairlift | €400-700 |
+
+### Saint-Martin-de-Belleville (1,450m) + Hamlets
+
+| # | Location | Access | Mid-March Price (pp/week) |
+|---|----------|--------|--------------------------|
+| 13 | Saint-Martin centre | Gondola + chairlift | €400-700 |
+| 14 | Villarabout | 4 min drive to gondola | €500-900 |
+| 15 | Le Châtelard | Free shuttle | €400-700 |
+| 16 | Les Granges | Free shuttle | €450-800 |
+| 17 | Saint Marcel | Free ski bus (400m) | €350-650 |
+| 18 | Le Lavassay | Valley shuttle | €400-700 |
+| 19 | Praranger | Valley shuttle | €400-700 |
+
+### Mountain Refuges
+
+| # | Location | Access | Mid-March Price |
+|---|----------|--------|-----------------|
+| 20 | Refuge le Trait d'Union | Ski/hike | From €70/night |
+| 21 | Refuge du Lac du Lou | Ski/hike | Budget |
+
+### Other Key Locations
+
+| # | Location | Access | Mid-March Price (pp/week) |
+|---|----------|--------|--------------------------|
+| 22 | La Tania Village | Ski-in/ski-out, free shuttle | €380-600 |
+| 23 | Le Praz Village | Gondola to 1850, ski back | €450-700 |
+| 24 | Brides-les-Bains centre | Olympe gondola (22 min) | €280-400 |
+| 25 | Orelle Village | Gondola to Val Thorens (15 min) | €350-600 |
+
+---
+
+## Section 4: Valley Towns & Lower Villages (31 Locations)
+
+### Primary Valley Gateways
+
+| # | Location | Altitude | Access | Mid-March Price (pp/week) |
+|---|----------|----------|--------|--------------------------|
+| 1 | Brides-les-Bains | 600m | Olympe gondola (22 min) | €280-400 |
+| 2 | Moûtiers | 500m | Bus shuttles (30-45 min) | €250-450 |
+| 3 | Orelle | 900m | Gondola to Val Thorens (15 min) | €350-600 |
+
+### Tarentaise Valley Floor
+
+| # | Location | Altitude | Access | Mid-March Price (pp/week) |
+|---|----------|----------|--------|--------------------------|
+| 18 | Aigueblanche/Grand-Aigueblanche | 400-500m | 15-20 min drive | €300-500 |
+| 19 | La Léchère | 400m | 20 min to Valmorel, 23km to Brides | €350-600 |
+| 20 | Feissons-sur-Salins | 1,300m | 20 min to Brides, 25 min to La Plagne | €400-700 |
+| 21 | Hautecour | 1,000m | 15 min to Moûtiers, 20 min to lifts | €400-700 |
+| 22 | Bellecombe | 800m | Near Aigueblanche | €400-700 |
+| 23 | Gilly-sur-Isère | 400m | Close to Albertville | €350-600 |
+| 24 | Pussy/Notre-Dame-du-Pré | 400-600m | Between Moûtiers and Albertville | €300-550 |
+| 25 | Saint-Ouen | 500m | Valley location | €300-550 |
+
+### Additional Hamlets
+
+| # | Location | Altitude | Access | Mid-March Price (pp/week) |
+|---|----------|----------|--------|--------------------------|
+| 26 | Les Chavonnes | 1,100m | 5 min drive to Brides | €350-600 |
+| 27 | La Perrière | 1,000m | Near Courchevel | €400-700 |
+| 28 | Fontaine-le-Puits | 1,200m | Near Les Menuires | €400-700 |
+| 29 | Nâves-Parmelan | 1,340m | Cross-country area | €350-600 |
+| 30 | Doucy | 1,200m | Gondola to Valmorel | €400-700 |
+| 31 | Les Avanchers-Valmorel | 1,200m | 5km from Valmorel, free shuttle | €400-750 |
+
+---
+
+## Section 5: Mid-March Price Comparison
+
+### By Resort/Area (Per Person/Week)
+
+| Rank | Resort/Area | Altitude | Budget | Mid-Range | Premium |
+|------|------------|----------|--------|-----------|---------|
+| 1 | Brides-les-Bains | 600m | €280-400 | €400-550 | €600-800 |
+| 2 | Moûtiers | 500m | €250-400 | €400-550 | €550-750 |
+| 3 | Aigueblanche | 400-500m | €300-450 | €450-600 | €600-800 |
+| 4 | Orelle | 900m | €350-550 | €550-750 | €800-1,000 |
+| 5 | Bozel | 800m | €350-550 | €550-750 | €750-950 |
+| 6 | Les Menuires | 1,850m | €320-450 | €450-650 | €700-950 |
+| 7 | Val Thorens | 2,300m | €400-580 | €600-900 | €1,000-1,500 |
+| 8 | Saint-Martin-de-Belleville | 1,450m | €350-480 | €480-650 | €800-1,100 |
+| 9 | La Tania | 1,400m | €380-520 | €550-800 | €900-1,200 |
+| 10 | Courchevel Le Praz | 1,300m | €450-600 | €650-900 | €1,000-1,400 |
+| 11 | Courchevel Village | 1,550m | €500-700 | €750-1,000 | €1,200-1,600 |
+| 12 | Courchevel Moriond | 1,650m | €550-800 | €850-1,200 | €1,500-2,000 |
+| 13 | Méribel | 1,450m | €450-600 | €650-900 | €1,100-1,500 |
+| 14 | Courchevel 1850 | 1,850m | €700-1,200 | €1,200-2,500 | €2,500-5,000+ |
+
+### By Accommodation Type (Per Person/Week)
+
+| Location | Studio SC | 2-Room Apt SC | Catered Chalet | Hotel B&B |
+|----------|-----------|---------------|----------------|-----------|
+| Brides-les-Bains | €280-400 | €400-550 | N/A | €450-650 |
+| Les Menuires | €320-450 | €450-650 | €600-850 | €500-750 |
+| Val Thorens | €400-580 | €600-900 | €750-1,100 | €600-900 |
+| St Martin | €350-480 | €480-700 | €550-800 | €500-750 |
+| La Tania | €380-520 | €550-800 | €600-950 | €500-800 |
+| Courchevel 1300 | €450-600 | €650-900 | €800-1,200 | €600-900 |
+| Méribel | €450-600 | €650-900 | €700-1,200 | €700-1,000 |
+| Courchevel 1850 | €700-1,200 | €1,200-2,500 | €1,500-3,000 | €1,000-2,500+ |
+
+---
+
+## Section 6: Additional Costs (Per Person/Week)
+
+| Item | Cost | Notes |
+|------|------|-------|
+| 6-Day 3 Vallées Lift Pass | €409 | Adult (€335 child rate with Family Flex) |
+| 6-Day Local Area Pass | €335-355 | Single valley options |
+| Ski Equipment Hire | €75-130 | Book online for 40% off |
+| Airport Transfers (return) | €110-400 | Shared vs. private |
+| Tourist Tax | €2-3/night | Paid locally |
+| Food (self-catered) | €200-300 | Supermarket shopping |
+| Food (half-board) | €350-500 | Hotel/restaurant meals |
+| Ski Lessons | €150-200 | Group lessons |
+| Insurance | €21 | 6-day coverage |
+
+---
+
+## Section 7: Total Budget Estimates (Per Person / 7 Nights)
+
+### Budget Option (Brides-les-Bains): ~€1,259
+
+| Item | Cost |
+|------|------|
+| Accommodation (studio) | €350 |
+| 6-Day 3 Vallées Pass | €409 |
+| Ski Hire | €90 |
+| Transfers (shared) | €110 |
+| Food (self-catered) | €200 |
+| Extras | €100 |
+
+### Mid-Range Option (Les Menuires): ~€1,669
+
+| Item | Cost |
+|------|------|
+| Accommodation (2-room apt) | €550 |
+| 6-Day 3 Vallées Pass | €409 |
+| Ski Hire | €110 |
+| Transfers (private shared) | €150 |
+| Food (mix SC/restaurants) | €300 |
+| Extras | €150 |
+
+### Catered Chalet Option (La Tania): ~€1,794
+
+| Item | Cost |
+|------|------|
+| Catered Chalet | €875 |
+| 6-Day 3 Vallées Pass | €409 |
+| Ski Hire | €110 |
+| Transfers | €150 |
+| Lunches | €150 |
+| Extras | €100 |
+
+---
+
+## Section 8: Free Shuttle Services
+
+### Courchevel Valley
+- **Route:** Bozel → Saint-Bon → La Tania → Le Praz → Village → Moriond → 1850
+- **Frequency:** Every 10-30 minutes
+- **Hours:** 07:00 - 02:00
+- **Cost:** FREE
+
+### Méribel Valley (Méribus)
+- **Lines:** A, B, C, D connecting all villages
+- **Frequency:** Every 15-20 minutes
+- **Hours:** 07:30 - Midnight
+- **Cost:** FREE
+- **WiFi:** Available on board
+
+### Belleville Valley
+- **Route:** Val Thorens ↔ Les Menuires ↔ St Martin
+- **Frequency:** 11 services daily (Sun-Fri)
+- **Cost:** FREE
+
+### Orelle
+- **Route:** Residence to gondola
+- **Frequency:** Every 20 minutes
+- **Cost:** FREE
+
+---
+
+## Section 9: Top 15 Most Affordable Options
+
+| Rank | Location | pp/week | Why It's Best Value |
+|------|----------|---------|---------------------|
+| 1 | Brides-les-Bains | €280-400 | 30-50% cheaper, Olympe gondola, spa town |
+| 2 | Moûtiers | €250-400 | Transport hub, bus access, lowest prices |
+| 3 | Aigueblanche | €300-450 | Valley floor, drive to multiple resorts |
+| 4 | Orelle | €350-550 | Cheapest 3 Vallées access, 15-min gondola |
+| 5 | Bozel | €350-550 | FREE shuttle, near Courchevel & Paradiski |
+| 6 | Les Menuires | €320-450 | Ski-in/ski-out, purpose-built value |
+| 7 | Saint-Martin-de-Belleville | €350-480 | Authentic village, direct lift access |
+| 8 | Saint-Marcel | €350-500 | Hamlet below St Martin, free ski bus |
+| 9 | La Tania | €380-520 | Small resort, ski-in/ski-out, chalet value |
+| 10 | Val Thorens (outer districts) | €400-550 | Highest altitude, good snow guarantee |
+| 11 | Le Bettaix | €400-550 | Chairlift to Les Menuires, group chalets |
+| 12 | Courchevel Le Praz | €450-600 | Traditional village, gondola to 1850 |
+| 13 | Les Allues | €450-600 | Authentic Méribel valley, Olympe gondola |
+| 14 | Mottaret | €400-650 | Best ski access in Méribel, ski-in/ski-out |
+| 15 | Courchevel La Tania | €380-600 | Purpose-built value, Courchevel access |
+
+---
+
+## Section 10: Money-Saving Tips
+
+1. **Book Brides-les-Bains or Orelle** - Save 30-50% vs. high-altitude resorts
+2. **Use Family Flex Pass** - Everyone pays child rate (€335 for 6 days)
+3. **Book equipment online** - Up to 40% off walk-in prices
+4. **Travel late March** - 10-15% discounts after March 20
+5. **Shared transfers** - Half the cost of private transfers
+6. **Self-catering** - Save €200-300 vs. half-board
+7. **Saturday day passes** - 20% off online before Friday midnight
+8. **Avoid French school holidays** - Prices increase 20-30%
+9. **Stay in valley towns** - Bozel, Moûtiers, Aigueblanche for lowest prices
+10. **Book early** - Best prices 3-6 months ahead
+
+---
+
+## Section 11: Key Contacts
+
+### Tourist Offices
+- **Brides-les-Bains:** +33 4 79 55 20 11
+- **Méribel:** +33 4 79 00 73 00
+- **Courchevel:** +33 4 79 08 00 29
+- **Les Menuires:** +33 4 79 00 73 00
+- **Val Thorens:** +33 4 79 00 08 08
+- **Moûtiers:** +33 4 79 24 01 66
+
+### Booking Resources
+- Les 3 Vallées Official: reservation.les3vallees.com
+- Altibus: www.altibus.com
+- Ski-Planet: www.ski-planet.com
+
+---
+
+*Prices are estimates for mid-March 2025 and subject to change. Always verify current rates before booking.*


### PR DESCRIPTION
## Summary

This PR adds comprehensive research documentation for a potential ski trip to Les Trois Vallées in the French Alps, including a detailed accommodation masterlist covering 85+ locations with mid-March pricing, trip planning notes, and place entity pages for key resorts and villages.

## Key Changes

- **Added accommodation masterlist** (`research/les-trois-vallees-accommodation-masterlist.md`): Comprehensive guide covering all three valleys with 85+ locations organized by region, including pricing tables, shuttle services, budget breakdowns, and money-saving tips
- **Created trip entity** (`entities/trips/2026-03-les-trois-vallees.md`): Trip planning page with budget options, key contacts, and next steps
- **Created place entities** for major locations:
  - Les Trois Vallées (main ski area overview)
  - Brides-les-Bains (budget base village)
  - Orelle (back-door access point)
  - La Tania (value ski-in/ski-out resort)
  - Les Menuires (purpose-built budget resort)
  - Val Thorens (highest resort, snow-sure)
  - Saint-Martin-de-Belleville (authentic village option)

## Notable Details

- Accommodation pricing organized by altitude, access method, and accommodation type
- Three budget scenarios provided: budget (~€1,259), mid-range (~€1,669), and catered chalet (~€1,794) per person/week
- Free shuttle network details for all three valleys
- Top 15 most affordable options ranked with value justifications
- Practical money-saving tips including Family Flex Pass strategy and equipment rental discounts
- All pricing estimates dated to mid-March 2025 with source attribution

https://claude.ai/code/session_01QWS4aZJpJZkwJbnrJd8Tcu