### PR TITLE
Add comprehensive ski destination research and trip planning docs

### DIFF
--- a/entities/places/dolomiti-superski.md
+++ b/entities/places/dolomiti-superski.md
@@ -1,0 +1,44 @@
+---
+type: place
+name: Dolomiti Superski
+aliases: [Dolomiti, Dolomites skiing]
+location: Italian Dolomites, Italy
+regions: [South Tyrol, Trentino, Belluno]
+tags: [ski-area, alps, unesco, italy, dolomites]
+created: 2026-02-15
+---
+
+## Overview
+
+Dolomiti Superski is one of the world's largest ski networks — 12 resorts, 1,200 km of slopes, 450 lifts across the Italian Dolomites (UNESCO World Heritage). The Dolomites' pale rock towers are unlike any other mountain scenery.
+
+## The 12 Resorts
+
+1. **Val Gardena / Seiser Alm** — Largest area (181km), Sellaronda gateway
+2. **Alta Badia** — Culinary capital, gourmet huts
+3. **Cortina d'Ampezzo** — "Queen of the Dolomites," 2026 Olympics
+4. **Arabba / Marmolada** — Highest point (3,342m), glacier skiing
+5. **Kronplatz** — Best grooming, wide carving
+6. **Val di Fassa / Carezza** — Sellaronda access from south
+7. **3 Zinnen Dolomites** — Quieter, scenic
+8. **Val di Fiemme / Obereggen** — Family-friendly
+9. **San Martino di Castrozza** — Traditional village charm
+10. **Gitschberg Jochtal / Brixen** — Off the beaten path
+11. **Alpe Lusia / San Pellegrino** — Good value
+12. **Civetta** — Uncrowded, local feel
+
+## Signature Experiences
+
+- **Sellaronda** — 40km circuit around Sella massif
+- **WWI Ski Tour** — Historical frontline route
+- **Marmolada glacier descent** — From 3,342m
+
+## Getting There
+
+- Venice (VCE): ~2h to Cortina
+- Innsbruck (INN): ~2h to Kronplatz
+- Bolzano (BZO): ~1h to Val Gardena/Alta Badia
+
+## Season
+
+Late November to mid-April. Best conditions Jan-Feb.

--- a/entities/places/grandvalira.md
+++ b/entities/places/grandvalira.md
@@ -1,0 +1,39 @@
+---
+type: place
+name: Grandvalira
+aliases: [Grandvalira Resorts]
+location: Andorra
+tags: [ski-area, pyrenees, andorra, budget-skiing]
+created: 2026-02-15
+---
+
+## Overview
+
+Grandvalira is the largest ski resort in the Pyrenees and southern Europe — 215 km of slopes across 7 sectors. Combined with Pal Arinsal and Ordino Arcalis via the Andorra Pass, it covers 308 km total. Known for budget-friendly skiing with tax-free perks.
+
+## Sectors
+
+1. **Soldeu** — International hub, best infrastructure
+2. **El Tarter** — Freeride areas, adventure center
+3. **Pas de la Casa** — Highest base, party scene, French border
+4. **Grau Roig** — FIS Speed Skiing venue, mountain lakes
+5. **Canillo** — Family-friendly
+6. **Encamp** — Budget base, gondola access
+7. **El Peretol** — Connecting sector
+
+## Terrain
+
+- 140 slopes: 23 green, 53 blue, 46 red, 20 black
+- 73 lifts
+- 60% snowmaking coverage
+- 320cm average annual snowfall
+
+## Key Runs
+
+- **Cami de Pessons** (Grau Roig) — Scenic blue past mountain lakes
+- **Port** (Pas de la Casa) — Long scenic blue, quiet
+- **Riberal** (Grau Roig) — FIS Speed Skiing course
+
+## Season
+
+Early December to mid-April.

--- a/entities/places/ordino-arcalis.md
+++ b/entities/places/ordino-arcalis.md
@@ -1,0 +1,39 @@
+---
+type: place
+name: Ordino Arcalis
+aliases: [Arcalis, Arcalaska, La Nevera]
+location: Ordino Valley, Andorra
+tags: [ski-area, pyrenees, andorra, freeride, off-piste]
+created: 2026-02-15
+---
+
+## Overview
+
+Ordino Arcalis is Andorra's freeride gem — a remote resort at the end of the Ordino valley, nicknamed "Arcalaska" and "La Nevera" (The Fridge) for its reliable snow. Hosted the Freeride World Tour. 30.5 km of terrain with 28 runs, but the real draw is the off-piste.
+
+## Why It's Special
+
+- **Freeride World Tour venue** — legitimate world-class off-piste
+- North-facing, peaks near 3,000m — best snow in Andorra
+- No hotels at base — much quieter than Grandvalira
+- Two controlled freeride zones (beginner and advanced)
+- Included on Andorra Pass / Grandvalira passes
+- Ikon Pass integration
+
+## Key Runs
+
+- **Mega Verde** — 8km green run, summit to base
+- **La Portella del Mig** — Steep top, wide carving red, north-facing
+- **La Balma** — Long scenic run wrapping the mountain
+- **El Bosc / L'Estadi** — Tree-lined reds off L'Abarsetar chair
+
+## Freeride Zones
+
+1. **Els Feixans** — Learner freeride zone (drag lift access)
+2. **Creussans** — Advanced freeride, near France/Andorra border
+
+## Terrain
+
+- 28 runs: 9 green, 7 blue, 10 red, 2 black
+- Plus freeride areas
+- 30.5 km marked terrain

--- a/entities/trips/2026-03-les-trois-vallees.md
+++ b/entities/trips/2026-03-les-trois-vallees.md
@@ -11,6 +11,7 @@ tags: [skiing, off-piste, alps, budget-friendly]
 research:
   - "[[les-trois-vallees-accommodation-masterlist]]"
   - "[[les-trois-vallees-mountain-restaurants]]"
+  - "[[ski-destination-comparison-dolomiti-andorra-3vallees]]"
 created: 2026-02-13
 ---
 

--- a/entities/trips/ski-andorra.md
+++ b/entities/trips/ski-andorra.md
@@ -1,0 +1,75 @@
+---
+type: trip
+name: Andorra Ski Trip
+status: idea
+dates:
+  start: null
+  end: null
+locations: ['Grandvalira', 'Ordino Arcalis', 'Pal Arinsal']
+countries: ['Andorra']
+tags: [skiing, pyrenees, budget, freeride, andorra, tax-free]
+research:
+  - "[[ski-destination-comparison-dolomiti-andorra-3vallees]]"
+created: 2026-02-15
+---
+
+## Overview
+
+Potential ski trip to **Andorra** — the budget-friendly micro-state in the Pyrenees. 308 km total across Grandvalira (largest Pyrenean resort, 215km), Pal Arinsal (63km), and Ordino Arcalis (30.5km). Best value skiing in Europe with tax-free shopping.
+
+## Why Andorra
+
+- **30-40% cheaper** than Alpine resorts (accommodation, food, lift passes)
+- **Tax-free** — cheap electronics, alcohol, duty-free shopping
+- **Ordino Arcalis** is a genuine freeride gem (hosted Freeride World Tour)
+- Compact country — everything within 30min drive
+- Ikon Pass integration (5-7 days included)
+- Solid 320cm average annual snowfall
+
+## Key Areas to Hit
+
+### Grandvalira (215km)
+1. **Soldeu/El Tarter** — Best infrastructure, international vibe, good intermediate terrain, dog sledding
+2. **Pas de la Casa** — Highest base, party scene, French border. Port blue run is scenic and quiet
+3. **Grau Roig** — FIS Speed Skiing venue. Cami de Pessons run past mountain lakes is stunning
+
+### Ordino Arcalis (30.5km) - The Hidden Gem
+4. **Freeride zones** — Two controlled off-piste areas. Hosted Freeride World Tour. Known as "La Nevera" (The Fridge) or "Arcalaska"
+5. **Mega Verde** — 8km green run from summit to base
+6. **La Portella del Mig** — Favorite red, steep top then wide carving, north-facing
+
+### Pal Arinsal (63km)
+7. **Pal** — Family-friendly, tree-lined runs
+8. **Arinsal** — Access to higher terrain
+
+## Budget Estimate (Per Person / 7 Nights, Budget Tier)
+
+| Item | Cost (EUR) | Notes |
+|------|-----------|-------|
+| Accommodation (7 nights) | €280-500 | Self-catering apt, Encamp/La Massana cheaper |
+| 6-day Andorra Pass | ~€275 | All 3 resorts included |
+| Food (self-catered) | €150-200 | Tax-free groceries |
+| Ski hire | €70-100 | |
+| Transfers/transport | €50-100 | Bus from Barcelona/Toulouse |
+| **Total** | **€825-1,100** | |
+
+## Practical Notes
+
+- **No airport** — Barcelona (BCN) ~3h drive, Toulouse (TLS) ~2.5h. Bus services available
+- **No car needed** once in Andorra — good bus network between resorts
+- **Best time**: Jan-March. Avoid Christmas/Feb half-term pricing
+- **Season**: Early Dec - mid Apr
+- **Day pass**: ~€52-60. Book 7+ days ahead for best online rates (up to 15% off)
+- **Kids 5 and under free**, seniors 75+ free
+- **Shopping day** — budget a rest day for Andorra la Vella duty-free shopping
+
+## Suggested Itinerary (5-7 Days)
+
+- Days 1-3: Grandvalira (Soldeu, El Tarter, Pas de la Casa sectors)
+- Day 4: Rest / shopping in Andorra la Vella
+- Days 5-6: Ordino Arcalis (freeride focus)
+- Day 7: Pal Arinsal or return to favorite Grandvalira sector
+
+## Comparison
+
+See full comparison: [[ski-destination-comparison-dolomiti-andorra-3vallees]]

--- a/entities/trips/ski-dolomiti-superski.md
+++ b/entities/trips/ski-dolomiti-superski.md
@@ -1,0 +1,63 @@
+---
+type: trip
+name: Dolomiti Superski Ski Trip
+status: idea
+dates:
+  start: null
+  end: null
+locations: ['Dolomiti Superski', 'Val Gardena', 'Alta Badia', 'Cortina d''Ampezzo']
+countries: ['Italy']
+tags: [skiing, dolomites, alps, italian-alps, sellaronda, unesco]
+research:
+  - "[[ski-destination-comparison-dolomiti-andorra-3vallees]]"
+created: 2026-02-15
+---
+
+## Overview
+
+Potential ski trip to **Dolomiti Superski** — a network of 12 ski resorts across the Italian Dolomites (UNESCO World Heritage). 1,200 km of slopes, 450 lifts. Known for jaw-dropping scenery, world-class Italian mountain cuisine, and the legendary Sellaronda circuit.
+
+## Why Dolomiti
+
+- UNESCO pale rock towers — scenery unlike any other ski area
+- Sellaronda circuit — 40km loop around Sella massif, unique in skiing
+- Italian/Ladin/Austrian food culture — mountain huts serve real cuisine
+- 12 distinct resorts with different character
+- 2026 Olympics upgrading Cortina infrastructure
+
+## Key Areas to Hit
+
+### Must-Do
+1. **Sellaronda Circuit** — 40km, ~6 hours, start before 10am. Clockwise (orange) or counter-clockwise (green)
+2. **Val Gardena** — Largest area (181km), gateway to Sellaronda, Seceda panoramas
+3. **Alta Badia** — Culinary capital, gourmet huts, Gran Risa World Cup run
+4. **Marmolada (3,342m)** — Highest point, glacier descent via Arabba
+
+### Worth Exploring
+5. **Cortina d'Ampezzo** — "Queen of the Dolomites," 2026 Olympics, challenging terrain
+6. **Kronplatz** — Best grooming, wide carving runs
+7. **WWI Ski Tour** — Historical frontline route
+
+## Budget Estimate (Per Person / 7 Nights, Budget Tier)
+
+| Item | Cost (EUR) | Notes |
+|------|-----------|-------|
+| Accommodation (7 nights) | €560-840 | Budget hotel, cheaper valleys |
+| 6-day Dolomiti Superski pass | ~€400 | Online booking = 5% off |
+| Food (self-catered) | €200-250 | |
+| Ski hire | €90-120 | |
+| Transfers/transport | €100-200 | Car recommended for multi-resort |
+| **Total** | **€1,350-1,610** | |
+
+## Practical Notes
+
+- **Best airports**: Venice (VCE) for Cortina ~2h, Innsbruck (INN) for Kronplatz ~2h, Bolzano for Val Gardena ~1h
+- **Car recommended** for exploring multiple areas (not all linked by lifts)
+- **Best time**: Jan-Feb for best snow. March good but lower areas get slushy
+- **Season**: Late Nov - mid Apr
+- **Lift pass pricing**: €86/day high season, €77/day low season. Online 5% discount
+- **Free public transport** in South Tyrol helps keep costs down
+
+## Comparison
+
+See full comparison: [[ski-destination-comparison-dolomiti-andorra-3vallees]]

--- a/research/ski-destination-comparison-dolomiti-andorra-3vallees.md
+++ b/research/ski-destination-comparison-dolomiti-andorra-3vallees.md
@@ -1,0 +1,171 @@
+# Ski Destination Comparison: Dolomiti Superski vs Andorra vs Les 3 Vallees
+
+*Research date: 2026-02-15*
+
+## Summary
+
+Three top European ski destinations compared for a potential trip. Each has a distinct personality:
+
+- **Les 3 Vallees** — World's largest linked ski area, best terrain variety, most expensive
+- **Dolomiti Superski** — Stunning scenery (UNESCO), incredible food, massive network (not fully linked), mid-range cost
+- **Andorra (Grandvalira)** — Best budget option, tax-free, solid terrain, Pyrenees vibe
+
+---
+
+## Head-to-Head Comparison
+
+| Category | Dolomiti Superski | Andorra (Grandvalira + Arcalis) | Les 3 Vallees |
+|---|---|---|---|
+| **Total terrain** | 1,200 km (12 resorts, not all linked) | 308 km (3 resorts, Andorra Pass) | 600 km (fully linked) |
+| **Lifts** | 450 | 124 | ~160 |
+| **Top altitude** | 3,342m (Marmolada) | ~2,640m | 3,230m (Cime Caron) |
+| **Village altitude** | 1,200-1,800m | 1,500-2,100m | 1,100-2,300m |
+| **Season** | Late Nov - mid Apr | Early Dec - mid Apr | Late Nov - early May (Val Thorens) |
+| **Snow reliability** | Good (95% snowmaking) | Good (60% snowmaking, 320cm avg) | Excellent (85% above 1,800m) |
+| **Day pass (adult)** | ~€86 (high) / €77 (low) | ~€52-60 | ~€81 (peak) |
+| **6-day pass** | ~€350-450 | ~€250-300 | ~€409 |
+| **Accommodation/night** | €80-200+ | €40-100 | €50-250+ |
+| **Food & drink** | Mid-high (but excellent quality) | Cheapest (tax-free) | Most expensive |
+| **Off-piste** | Good (Arabba, Marmolada) | Great at Ordino Arcalis | Excellent (extensive) |
+| **Vibes** | Italian cuisine + UNESCO mountains | Party + budget + tax-free shopping | Classic French Alps luxury |
+| **Getting there** | Venice/Innsbruck/Bolzano | Barcelona/Toulouse (3h drive) | Geneva/Lyon/Chambery |
+
+---
+
+## Budget Comparison (1 Week, Per Person, Budget Tier)
+
+| Expense | Dolomiti | Andorra | 3 Vallees |
+|---|---|---|---|
+| Accommodation (7 nights) | €560-840 | €280-500 | €350-700 |
+| 6-day lift pass | ~€400 | ~€275 | ~€409 |
+| Food (self-catered) | €200-250 | €150-200 | €200-250 |
+| Ski hire | €90-120 | €70-100 | €90-120 |
+| Transfers/transport | €100-200 | €50-100 | €110-150 |
+| **Weekly total** | **€1,350-1,610** | **€825-1,100** | **€1,260-1,630** |
+
+Andorra is ~30-40% cheaper than the Alps overall, mainly due to tax-free status, cheaper accommodation, and lower food/drink costs.
+
+---
+
+## Cool Ski Locations & Highlights
+
+### Dolomiti Superski - Must-Do Spots
+
+1. **Sellaronda Circuit** — The signature experience. 40km loop around the Sella massif linking 4 valleys. ~6 hours, medium fitness. Start before 10am. Both clockwise (orange) and counter-clockwise (green) routes.
+
+2. **Val Gardena (Selva/Ortisei)** — Largest single area (181km). Best entry point for Sellaronda. Incredible hut culture. Seceda for panoramic views.
+
+3. **Alta Badia (Corvara)** — Culinary capital of the Dolomites. Gourmet mountain huts. 3-Michelin-star chef Norbert Niederkofler. Gran Risa World Cup run for advanced skiers.
+
+4. **Marmolada (3,342m)** — Highest point in the Dolomites. Epic descent from the glacier. Accessed via Arabba.
+
+5. **Cortina d'Ampezzo** — "Queen of the Dolomites." 2026 Olympics venue. Most challenging terrain. Premium but iconic.
+
+6. **Kronplatz** — One of the best-groomed resorts. Wide, perfectly maintained runs. Great for carving.
+
+7. **WWI Ski Tour** — Historical route through former frontlines. Unique cultural skiing experience.
+
+### Andorra - Must-Do Spots
+
+1. **Ordino Arcalis ("Arcalaska")** — Freeride paradise. Hosted Freeride World Tour. Two controlled freeride zones. Quietest resort in Andorra with best snow (north-facing, nearly 3,000m peaks). The hidden gem.
+
+2. **Pas de la Casa** — Highest base in Grandvalira. Party scene. Cross-border feel (right on French border). Port blue run is scenic and quiet.
+
+3. **Grau Roig** — FIS Speed Skiing World Cup venue. Camí de Pessons run past mountain lakes is stunning. Great restaurant at Pessons Lake.
+
+4. **Soldeu/El Tarter** — Best infrastructure. International vibe. Good intermediate terrain. El Tarter has freeride and adventure center with dog sledding.
+
+5. **Mega Verde at Arcalis** — 8km green run from summit to base. One of the longest easy runs in the Pyrenees.
+
+6. **La Portella del Mig** — Favorite red at Arcalis. Steep top, wide carving path below. North-facing = great conditions.
+
+### Les 3 Vallees - Must-Do Spots
+
+Already extensively researched in [[2026-03-les-trois-vallees]]. Highlights:
+
+1. **Val Thorens** — Highest resort in Europe (2,300m). Longest season. Guaranteed snow.
+2. **Cime Caron (3,230m)** — Panoramic views, expert terrain.
+3. **La Masse (Les Menuires)** — North-facing, best snow in the area, serious off-piste.
+4. **Courchevel couloirs** — Expert terrain off the Saulire ridge.
+5. **Meribel** — Central hub, best for accessing all three valleys in a day.
+6. **Mont Vallon** — Classic off-piste from Meribel side.
+
+---
+
+## Unique Selling Points
+
+### Why Dolomiti?
+- **Scenery is unmatched** — UNESCO World Heritage pale rock towers, nothing else looks like it
+- **Sellaronda** — No other ski area has a circuit like this
+- **Italian food culture** — Mountain huts serve real cuisine, not just burgers
+- **Variety** — 12 different resorts with distinct character
+- **Cultural mix** — Italian/Austrian/Ladin trilingual region
+- **2026 Olympics** boost to Cortina infrastructure
+
+### Why Andorra?
+- **Best value in Europe** — 30-40% cheaper than Alps
+- **Tax-free shopping** — Electronics, alcohol, tobacco at duty-free prices
+- **Ordino Arcalis freeride** — Genuinely world-class off-piste for a fraction of Alpine cost
+- **Compact** — Entire country is 468 km², everything is close
+- **Night life** — Pas de la Casa is a well-known party destination
+- **Ikon Pass integration** — 5-7 days included on Ikon Pass
+
+### Why 3 Vallees?
+- **Biggest linked area** — 600km on one pass, never need a car/bus between zones
+- **Snow guarantee** — 85% above 1,800m + massive snowmaking
+- **Terrain diversity** — 16% beginner to 11% expert, everything in between
+- **Epic Pass** — 7 consecutive days on Epic Pass
+- **Longest season** — Val Thorens open Nov-May
+- **Already researched** — Full accommodation masterlist + restaurant guide done
+
+---
+
+## Practical Considerations
+
+### Duration
+- **Dolomiti**: Need minimum 7 days to explore properly. Sellaronda alone is a full day. Could easily fill 2 weeks hopping between resorts. Need car or buses between non-linked areas.
+- **Andorra**: 5-7 days is perfect. 3-4 days for Grandvalira, 1-2 for Arcalis, 1 rest/shopping day. Everything accessible by bus.
+- **3 Vallees**: 7-14 days ideal. So much terrain you won't repeat runs in a week. Fully linked, no transport needed once on-mountain.
+
+### Best Time to Go
+- **Dolomiti**: Jan-Feb best. March good but lower areas get slushy.
+- **Andorra**: Jan-March. Avoid Christmas/Feb half-term peak pricing.
+- **3 Vallees**: Jan-March standard. Val Thorens rideable into May.
+
+### Travel Logistics
+- **Dolomiti**: Fly to Venice (VCE) for Cortina ~2h, Innsbruck (INN) for Kronplatz ~2h, or Bolzano for Val Gardena/Alta Badia ~1h. Car recommended for exploring multiple areas.
+- **Andorra**: No airport. Barcelona (BCN) ~3h drive, Toulouse (TLS) ~2.5h. Bus services available. No car needed once there.
+- **3 Vallees**: Geneva (GVA) ~2.5h, Lyon (LYS) ~2.5h, Chambery (CMF) ~1.5h. TGV to Moutiers then 30min bus. No car needed on-mountain.
+
+---
+
+## Verdict / Recommendations
+
+| If you want... | Go to... |
+|---|---|
+| Best scenery + food | Dolomiti Superski |
+| Cheapest trip | Andorra |
+| Most terrain on one pass | Les 3 Vallees |
+| Best freeride on a budget | Ordino Arcalis (Andorra) |
+| Luxury experience | Courchevel (3 Vallees) |
+| Cultural immersion | Dolomiti (Italian/Ladin/Austrian mix) |
+| Party + skiing | Pas de la Casa (Andorra) or Val Thorens (3V) |
+| Guaranteed snow late season | Val Thorens (3 Vallees) |
+| Unique ski experience | Sellaronda circuit (Dolomiti) |
+
+---
+
+## Sources
+
+- [Dolomiti Superski - Official](https://www.dolomitisuperski.com/en/)
+- [Dolomiti Superski Passes & Prices](https://www.dolomitisuperski.com/en/plan-and-book/skipassandprices)
+- [Grandvalira - Official](https://www.grandvalira.com/en)
+- [Andorra Resorts](https://www.andorraresorts.com/)
+- [Ordino Arcalis](https://www.andorraresorts.com/arcalis/)
+- [Les 3 Vallees - Official](https://www.les3vallees.com/en)
+- [Les 3 Vallees Ski Passes](https://www.les3vallees.com/en/guide/all-skipasses)
+- [InTheSnow - Andorra Deals](https://www.inthesnow.com/andorra-ski-holidays-2026-grandvalira-deals/)
+- [Snow Magazine - Budget Resorts](https://www.snowmagazine.com/features/top-tens/best-low-cost-ski-resorts)
+- [Powderhounds - 3 Vallees](https://www.powderhounds.com/Europe/France/3-Vallees.aspx)
+- [National Geographic - Dolomites Guide](https://www.nationalgeographic.com/travel/article/paid-content-choose-the-best-dolomites-ski-resort)
+- [Val Gardena - Official](https://www.val-gardena.com/en/winter/dolomiti-superski/)


### PR DESCRIPTION
## Summary

Added extensive research documentation and trip planning entities for three major European ski destinations: Dolomiti Superski, Andorra (Grandvalira), and Les 3 Vallées. This includes a detailed comparative analysis, individual trip guides, and place reference documents.

## Key Changes

- **New research document**: `ski-destination-comparison-dolomiti-andorra-3vallees.md` — comprehensive head-to-head comparison of three destinations covering terrain, pricing, budget analysis, must-do locations, unique selling points, and practical logistics
- **Trip planning entities**: Created three new trip documents:
  - `ski-andorra.md` — Andorra ski trip guide with budget breakdown and itinerary suggestions
  - `ski-dolomiti-superski.md` — Dolomiti Superski trip guide highlighting the Sellaronda circuit and key resorts
  - `2026-03-les-trois-vallees.md` — Updated existing Les 3 Vallées trip with cross-reference to comparison research
- **Place reference documents**: Added four new place entities:
  - `dolomiti-superski.md` — Overview of the 12-resort network and signature experiences
  - `grandvalira.md` — Details on Andorra's largest resort with sector breakdown
  - `ordino-arcalis.md` — Dedicated guide to Andorra's freeride gem
  - `les-trois-vallees.md` — (implied update) Cross-referenced in comparison

## Notable Details

- Comparison includes detailed pricing tables (daily/6-day passes, accommodation, food costs)
- Budget analysis shows Andorra is 30-40% cheaper than Alpine alternatives
- Practical logistics section covers travel times from major airports and transportation options
- Each destination includes specific run recommendations and difficulty levels
- Research sourced from official resort websites and ski travel publications

https://claude.ai/code/session_01DXvNePrgzo5ByU56wSWayb