### PR TITLE
Add reporting hub alignment meeting and Anthony Guevarra profile

### DIFF
--- a/entities/meetings/2026-02-17-reporting-hub-alignment.md
+++ b/entities/meetings/2026-02-17-reporting-hub-alignment.md
@@ -1,0 +1,30 @@
+---
+type: meeting
+date: 2026-02-17
+attendees: [[Anthony Guevarra]]
+projects: []
+businesses: []
+tags: [reporting, alignment, operations]
+---
+
+# Reporting Hub Alignment
+
+Alignment meeting with [[Anthony Guevarra]] (US-based consultant) on conforming to the reporting hub.
+
+## Agenda
+
+### 1. Reporting Hub Overview
+- Current reporting hub structure and requirements
+- What conformance looks like
+
+### 2. Alignment & Next Steps
+- What Anthony needs to adjust/deliver
+- Timeline and deliverables
+
+## Notes
+
+_Meeting notes to be added after the call._
+
+## Action Items
+
+- [ ] _(to be filled post-meeting)_

--- a/entities/people/anthony-guevarra.md
+++ b/entities/people/anthony-guevarra.md
@@ -1,0 +1,12 @@
+---
+type: person
+name: Anthony Guevarra
+aliases: []
+businesses: []
+locations: [[United States]]
+tags: [consultant]
+---
+
+# Anthony Guevarra
+
+Consultant based in the States. Works on reporting and operational alignment.


### PR DESCRIPTION
## Summary
This PR adds documentation for a reporting hub alignment meeting and creates a new person profile for Anthony Guevarra, a US-based consultant involved in reporting and operational alignment work.

## Changes
- **New meeting document**: `entities/meetings/2026-02-17-reporting-hub-alignment.md`
  - Documents an alignment meeting with Anthony Guevarra on reporting hub conformance
  - Includes agenda items covering reporting hub overview and next steps
  - Structured with placeholder sections for notes and action items to be filled post-meeting

- **New person profile**: `entities/people/anthony-guevarra.md`
  - Creates profile for Anthony Guevarra, a US-based consultant
  - Tags him as a consultant with focus on reporting and operational alignment
  - Links to United States location

## Implementation Details
Both documents follow the established entity structure with YAML frontmatter for metadata and markdown content. The meeting document is set up as a template ready for post-meeting notes and action items to be populated.

https://claude.ai/code/session_01WvAEn1tZV5Tqvxiyf8PT4p