### PR TITLE
Add comprehensive Dolomiti Superski ski trip research and planning

### DIFF
--- a/entities/trips/2027-01-dolomiti-superski.md
+++ b/entities/trips/2027-01-dolomiti-superski.md
@@ -1,0 +1,436 @@
+---
+type: trip
+name: Dolomiti Superski 2-Week Ski Trip
+status: idea
+dates:
+  start: null
+  end: null
+locations: ['Dolomiti Superski', 'South Tyrol', 'Trentino', 'Italian Alps']
+countries: ['Italy']
+tags: [skiing, dolomites, alps, budget-friendly, sella-ronda]
+research:
+  - "[[dolomiti-superski-research]]"
+  - "[[dolomiti-superski-transport]]"
+compare_with: "[[2026-03-les-trois-vallees]]"
+created: 2026-02-16
+---
+
+## Overview
+
+Potential **2-week ski trip** to **Dolomiti Superski** — the world's largest ski pass area (1,246 km of pistes, 450 lifts, 12 ski zones). Built as a direct comparison to the [[2026-03-les-trois-vallees|Trois Vallées plan]]. Focus on self-catered budget accommodation with maximum skiing variety.
+
+## Key Research
+
+- Full accommodation + pricing research: [[dolomiti-superski-research]]
+- Transport comparison (car vs public): [[dolomiti-superski-transport]]
+
+---
+
+## Head-to-Head: Dolomiti Superski vs Les Trois Vallées
+
+### The Ski Areas
+
+| | Dolomiti Superski | Les Trois Vallées |
+|---|---|---|
+| **Total piste km** | 1,246 km | 600 km |
+| **Lifts** | 450 | 160+ |
+| **Altitude range** | 1,500–3,269 m | 600–3,230 m |
+| **Snowmaking** | 97% (1,160 km) | ~45% |
+| **Ski zones** | 12 separate areas | 1 seamless domain |
+| **Lift-linked km** | ~490 km (Sella Ronda core) | 600 km (everything) |
+| **Slope breakdown** | 360 blue / 720 red / 120 black | 258 blue / 265 red / 74 black |
+| **Structure** | Multiple valleys, some requiring driving | 3 valleys, all connected by lifts |
+| **Off-piste** | Good, varied, Liberty Ride equivalents less developed | Excellent, 5 Liberty Ride zones |
+| **Scenery** | Dramatic vertical Dolomite towers, UNESCO World Heritage | Beautiful alpine, classic French glacier scenery |
+| **Vibe** | Italian/Austrian/Ladin — rifugio culture, speck & dumplings, Aperol Spritz at €3 | French — wine, raclette, après-ski parties, La Folie Douce |
+
+### The Bottom Line on Skiing
+
+The 3 Vallées gives you 600 km in one seamless, lift-linked domain — you never touch a road. Dolomiti Superski is technically twice the size, but only ~490 km is lift-connected via the Sella Ronda circuit. The remaining 750 km is scattered across separate valleys requiring ground transport. For a pure "get on the lift and explore everything" experience, 3 Vallées wins. For sheer variety of scenery, cuisine, and the ability to ski a different valley every few days (with a car), Dolomiti is unmatched.
+
+---
+
+## 2-Week Budget: Manila → Dolomites (Solo)
+
+### Recommended Base: Canazei (Val di Fassa)
+
+**Why Canazei over Val Gardena or Alta Badia:**
+- 20–30% cheaper accommodation than Selva or Corvara
+- Lower tourist tax (Trentino: €1–3/night, capped 10 nights vs South Tyrol: €4/night uncapped)
+- Trentino Guest Card = free public transport
+- Direct Sella Ronda access via Belvedere cable car
+- Real town with supermarkets, restaurants, nightlife
+- Access to Marmolada (3,269 m — highest in Dolomiti Superski)
+
+### Option A: With Rental Car (Venice pickup)
+
+| Item | Cost (€) | Notes |
+|------|----------|-------|
+| Flights MNL↔VCE (round trip) | 650 | Via Gulf hub, 1–2 stops. Jan is off-peak |
+| Car rental — 14 days, economy (manual) | 350 | Venice airport. Winter tires included |
+| Full insurance / CDW waiver | 280 | Recommended for mountain roads |
+| Italian motorway tolls (round trip) | 40 | A4+A22 Venice↔Bolzano return |
+| Fuel (~600 km total) | 80 | Round trips + occasional valley driving |
+| Parking (14 days) | 50 | €0 if apartment has free parking, up to €10/day otherwise |
+| Accommodation — studio, 2 weeks | 900 | ~€450/wk self-catered in Canazei (Jan low season) |
+| Dolomiti Superski — 2 × 6-day (online -5%) | 828 | High season rate. Jan shoulder = €745 |
+| Snowboard hire — 2 weeks | 300 | Mid-range, booked online for 10–15% off |
+| Food — self-catered, 14 days | 400 | Supermarket + occasional rifugio lunch (~€15) |
+| Tourist tax — 14 nights | 20 | Trentino: ~€1.50/night, capped 10 nights |
+| Extras & incidentals | 150 | Après, rest day activities |
+| **TOTAL** | **~€4,048** | |
+
+**Car pros:** Explore all 12 ski zones (Cortina, Kronplatz, 3 Zinnen — impossible without a car). Supermarket runs to bigger stores. Rest-day trips to Bolzano, Bressanone, Brunico. Drive to different valleys each ski day if you want. Per-day car cost is ~€55/day all-in.
+
+### Option B: No Car (FlixBus/train + local buses)
+
+| Item | Cost (€) | Notes |
+|------|----------|-------|
+| Flights MNL↔VCE (round trip) | 650 | Same |
+| FlixBus VCE→Bolzano + SAD bus to Canazei (return) | 60 | €15–28 FlixBus + free bus with Guest Card |
+| Accommodation — studio, 2 weeks | 900 | Same |
+| Dolomiti Superski — 2 × 6-day (online -5%) | 828 | Same (or €745 if Jan shoulder) |
+| Snowboard hire — 2 weeks | 300 | Same |
+| Food — self-catered, 14 days | 400 | Same |
+| Tourist tax — 14 nights | 20 | Same |
+| Trentino Guest Card | 0 | Free from participating accommodation |
+| Local ski buses | 0 | Free with Guest Card / ski pass |
+| Extras & incidentals | 150 | Same |
+| **TOTAL** | **~€3,308** | |
+
+**No-car pros:** ~€740 cheaper. No driving stress on mountain passes. No parking hassle. Free ski buses handle daily in-valley transport. Sella Ronda circuit (490 km) accessible entirely on lifts from Canazei.
+
+**No-car cons:** Locked to Sella Ronda core (~490 km of 1,246 km). Can't day-trip to Cortina, Kronplatz, or 3 Zinnen without 4+ hour bus journeys. Grocery shopping limited to village supermarkets. Feels like you're not using the full Dolomiti Superski pass.
+
+### Option C: Season Pass + January Shoulder (Best Value)
+
+If dates fall in Jan 11–31 (shoulder/low season):
+
+| Item | Cost (€) | Notes |
+|------|----------|-------|
+| Flights MNL↔VCE | 650 | |
+| Car rental + insurance + tolls + fuel + parking | 800 | Same as Option A |
+| Accommodation — studio, 2 weeks, Jan low season | 750 | Canazei studios from ~€375/wk in Jan |
+| Dolomiti Superski **season pass** | 970 | Buy before Dec 24. Unlimited days |
+| Snowboard hire — 2 weeks | 300 | |
+| Food — self-catered, 14 days | 400 | |
+| Tourist tax | 20 | |
+| Extras | 150 | |
+| **TOTAL** | **~€4,040** | With car, unlimited ski days |
+
+The season pass at €970 costs only €142 more than 2× 6-day high-season passes (€828), but gives unlimited days. If you ski 12+ days it's better value. And if you buy it early (before Dec 24), it's locked in regardless of when you go.
+
+### Comparison Summary
+
+| | With Car | No Car | Season + Car (Jan) |
+|---|----------|--------|---------------------|
+| Transport costs | €1,450 | €710 | €1,450 |
+| On-mountain costs | €2,598 | €2,598 | €2,590 |
+| **Total** | **€4,048** | **€3,308** | **€4,040** |
+| Ski zones accessible | All 12 (1,246 km) | Sella Ronda core (490 km) | All 12 (1,246 km) |
+
+---
+
+## vs Trois Vallées: Full Price Comparison
+
+### With Car (both trips)
+
+| Item | Trois Vallées | Dolomiti Superski | Δ |
+|------|---------------|-------------------|---|
+| Flights (MNL round trip) | €700 (GVA) | €650 (VCE) | -€50 |
+| Car rental (14 days) | €500 | €350 | -€150 |
+| Insurance | incl. | €280 | +€280 |
+| Tolls + vignette | €82 | €40 | -€42 |
+| Fuel | €70 | €80 | +€10 |
+| Parking | €0 (free in Brides) | €50 | +€50 |
+| **Transport subtotal** | **€1,352** | **€1,450** | **+€98** |
+| Accommodation (2 wks) | €700 (Brides) | €900 (Canazei) | +€200 |
+| Lift pass (2×6-day) | €818 | €828 | +€10 |
+| Equipment rental (2 wks) | €180 | €300 | +€120 |
+| Food (14 days) | €450 | €400 | -€50 |
+| Tourist tax | €42 | €20 | -€22 |
+| Extras | €200 | €150 | -€50 |
+| **On-mountain subtotal** | **€2,390** | **€2,598** | **+€208** |
+| **GRAND TOTAL** | **€3,742** | **€4,048** | **+€306** |
+
+### Without Car (both trips)
+
+| Item | Trois Vallées | Dolomiti Superski | Δ |
+|------|---------------|-------------------|---|
+| Flights | €700 | €650 | -€50 |
+| Transfers | €110 (Ben's Bus) | €60 (FlixBus+bus) | -€50 |
+| **Transport subtotal** | **€810** | **€710** | **-€100** |
+| Accommodation (2 wks) | €700 | €900 | +€200 |
+| Lift pass (2×6-day) | €818 | €828 | +€10 |
+| Equipment rental | €180 | €300 | +€120 |
+| Food | €450 | €400 | -€50 |
+| Tourist tax | €42 | €20 | -€22 |
+| Extras | €200 | €150 | -€50 |
+| **On-mountain subtotal** | **€2,390** | **€2,598** | **+€208** |
+| **GRAND TOTAL** | **€3,200** | **€3,308** | **+€108** |
+
+### The Verdict
+
+| | Trois Vallées (with car) | Dolomiti (with car) | Trois Vallées (no car) | Dolomiti (no car) |
+|---|---|---|---|---|
+| **Total cost** | €3,742 | €4,048 | €3,200 | €3,308 |
+| **Skiable terrain** | 600 km (all linked) | 1,246 km (490 linked) | 600 km (all linked) | 490 km (linked only) |
+| **Cost per km of terrain** | €6.24/km | €3.25/km | €5.33/km | €6.75/km |
+| **Car necessity** | Nice-to-have | Strongly recommended | Not needed | Limits you to 39% of the pass |
+| **Best for** | All-in-one immersion | Multi-valley ski safari | Budget + simplicity | Budget, still 490 km |
+
+**Dolomiti is only €306 more with a car** (€108 without). The extra cost gets you double the piste km, dramatically different scenery, cheaper food and drink, and the Italian Dolomite experience. The trade-off: you need a car to use the full pass, and the skiing is spread out rather than seamless.
+
+**Trois Vallées is the better "no car" trip.** Without a car, you access 100% of the 600 km domain. In the Dolomites without a car, you only access ~490 km via the Sella Ronda — still excellent, but you're paying for a 1,246 km pass.
+
+---
+
+## Accommodation Recommendations
+
+### Top Pick: Canazei / Campitello (Val di Fassa) — Budget Base
+
+Best value for a 2-week self-catering stay with Sella Ronda access.
+
+| Property | Type | €/week (Jan) | Lifts | Notes |
+|----------|------|-------------|-------|-------|
+| **Campitello studio** | Studio, 28m² | €400–600 | 50m Col Rodella cable car | Cheapest option found. Center of Campitello |
+| **Marmolada Apt. 36** (Alba di Canazei) | Studio, 30m² | €400–700 | Ski bus 10m, 450m slopes | Double bed, kitchenette, balcony |
+| **Apartments Riz Diego** (Canazei) | 2-4 pax | €500–900 | 150m slopes, near Pecol cable car | Sunny, quiet, parking, balcony |
+| **CasaMau Bilo** (Pera/Pozza) | 2 pax, 50m² | €500–800 | Ski bus access | Renovated, dishwasher, on-site ski rental |
+| **Apartments Canazei** | 2-6 pax | €600–1,100 | Steps from Col Rodella & Belvedere | Well-furnished, good location |
+
+**Supermarkets:** Several in Canazei center — Coop, Famiglia Cooperativa. Decent for 2-week self-catering.
+**Ski bus:** Free with Trentino Guest Card. Tight network across all Val di Fassa.
+**Booking:** visitfassa.com (gives Trentino Guest Card with booking), canazei.com, Booking.com
+
+### Alternative: Ortisei (Val Gardena) — More Town, Slightly More $
+
+Better nightlife, restaurants, shopping. 10–20% more expensive than Canazei.
+
+| Property | Type | €/week (Jan) | Notes |
+|----------|------|-------------|-------|
+| **General studio/1-bed** | Various | €500–900 | Budget tier. Search on val-gardena.com |
+| **Residence Ciastel** | 4-star, 70m² | €800–1,200 | Spacious, wellness area |
+| **Petlin Apartments** | Multi-room | €1,200–1,800 | 6 min walk to Seceda/Alpe di Siusi. Washer, 2 baths. Good for long stays |
+
+**Supermarkets:** Valgardena Center DESPAR (large, bakery, butcher). Ortisei has the best shopping in the valleys.
+**Ski bus:** Free with Südtirol Guest Pass. Every 10–20 min.
+**Key note:** Ortisei is NOT directly on the Sella Ronda — you ski up to Seceda or take the bus to Selva for Sella Ronda access. This adds ~15 min each way.
+
+### Alternative: Corvara (Alta Badia) — Heart of the Sella Ronda
+
+Ski-in/ski-out options, Ladin culture, refined atmosphere. Similar price to Selva.
+
+| Property | Type | €/week (Jan) | Notes |
+|----------|------|-------------|-------|
+| **Apartments Bracun** | 2-4 pax | €600–1,000 | Budget option. Balcony, mountain views |
+| **Lisura Apartments** | 2-6 pax | €700–1,200 | Ski bus at door. Quiet, 5 min to center |
+| **Nei Y Suredl NeveSole** | 2-4 pax | €900–1,400 | 10m from Arlara lifts. Ski-in/ski-out. Free wellness |
+
+**Supermarkets:** Small alimentari only. Stock up in Bruneck (~30 min drive) for bigger shops.
+**Ski bus:** Free, connects all Alta Badia villages.
+**Best if:** You want to be in the physical center of the Sella Ronda and don't mind limited shopping.
+
+### Alternative: Arabba — Serious Skier's Choice
+
+Best snow, steepest terrain, most authentic. Tiny village.
+
+| Property | Type | €/week (Jan) | Notes |
+|----------|------|-------------|-------|
+| **Apartments Marisa** | 2-6 pax | €500–900 | Central, all utilities included |
+| **Home Service Apartments** | 2-6 pax | €500–900 | 100m from Burz chairlift |
+| **Residence Aspen** | 2-4 pax | €700–1,100 | Near lifts. Sauna + outdoor hot tub |
+
+**Tourist tax:** Only €1/night, capped 10 nights = €10 total (cheapest in Dolomites — Veneto region).
+**Downside:** Very limited grocery shopping. 2-week self-catering is harder without a car.
+
+---
+
+## Car vs Public Transport: The Real Difference
+
+### What a Car Unlocks
+
+With a car based in Canazei, you can drive to a different ski zone each day:
+
+| Day Trip | Drive Time | Km of Piste | Highlights |
+|----------|-----------|-------------|------------|
+| Sella Ronda (from Canazei) | 0 min (on lifts) | 490 km | The classic circuit, 4 valleys in one day |
+| Kronplatz | 1h 15min | 119 km | Wide cruising, modern lifts, Messner Mountain Museum |
+| Cortina d'Ampezzo | 1h 15min | 120 km | 2026 Olympic venue, Lagazuoi, Cinque Torri |
+| 3 Zinnen / Tre Cime | 1h 30min | 115 km | Most spectacular scenery in the Dolomites |
+| Marmolada glacier | 30 min | Part of Arabba zone | 3,269m — highest point in Dolomiti Superski |
+| Alpe di Siusi | 45 min | Part of Val Gardena zone | Europe's largest high-alpine meadow |
+
+**Without a car, you're limited to:**
+- Canazei / Val di Fassa slopes (direct)
+- Sella Ronda circuit via lifts (Val Gardena ↔ Alta Badia ↔ Arabba ↔ Val di Fassa)
+- Marmolada (accessible from Arabba on the Sella Ronda)
+
+That's still ~490 km — comparable to the entire 3 Vallées. But you miss Cortina, Kronplatz, and 3 Zinnen entirely.
+
+### The Fundamental Difference from Trois Vallées
+
+In **Trois Vallées**, the car question was simple: +€542 for convenience but you don't NEED it. The entire 600 km domain is accessible from the Olympe gondola in Brides-les-Bains.
+
+In **Dolomiti Superski**, the car question is structural: +€740 to access the full 1,246 km pass area. Without a car, you're effectively paying for a 1,246 km pass but only using 490 km of it. The economics:
+
+| | With Car | No Car |
+|---|----------|--------|
+| Trip cost | €4,048 | €3,308 |
+| Accessible piste km | 1,246 km | ~490 km |
+| **Cost per accessible km** | **€3.25/km** | **€6.75/km** |
+
+The car option is actually cheaper per km of accessible terrain. And if you buy just a Val di Fassa regional pass instead of the full Dolomiti Superski pass, the no-car trip gets even cheaper (but you lose Sella Ronda access).
+
+### Recommendation
+
+**Rent a car.** Unlike Trois Vallées where the car was a luxury, in the Dolomites the car is what makes the trip make sense. The Dolomites' appeal is the variety — different valleys, different vibes, different cuisine, different scenery. A car turns a "ski holiday in one valley" into a "two-week ski safari across the most dramatic mountains in Europe."
+
+---
+
+## Best Timing: 2026–2027 Season
+
+### Holidays to Avoid
+
+**Italian Carnival / Settimana Bianca (the big one):**
+
+| Region | Dates (est.) | Impact |
+|--------|-------------|--------|
+| Provincia di Bolzano (South Tyrol) | ~Feb 6–14, 2027 (9 days) | Biggest impact — local families flood every slope |
+| Trentino/Veneto | ~Feb 8–10, 2027 (3 days) | Moderate — long weekend |
+| Other Italian regions | Various, ~Feb 6–10 | Variable |
+
+**German Winterferien:** Bavaria typically 1 week in Feb/Mar — German tourists are a huge portion of Dolomites visitors.
+
+**Dutch Voorjaarsvakantie:** 1 week in Feb/Mar — Netherlands is another major source.
+
+**Austrian Semesterferien:** 1 week in Feb, varies by province.
+
+### Dolomiti Superski Season Periods (2025-2026, expect similar for 2026-2027)
+
+| Period | Dates | Pass Price (6-day) |
+|--------|-------|--------------------|
+| High season | Dec 21 – Jan 10, Feb 1 – Mar 21 | €436 |
+| **Shoulder/low season** | Nov 29 – Dec 20, **Jan 11 – Jan 31**, Mar 22 – Apr 10 | **€392** |
+
+### The Sweet Spots
+
+**★ Sat Jan 17 → Sat Jan 31, 2027** (Best value)
+
+| ✓ | Why |
+|---|-----|
+| Shoulder/low season pricing | 6-day pass €392 instead of €436 (10% off) |
+| Post-Epiphany lull | Italian Christmas/NY crowds gone by Jan 7 |
+| Before any February holidays | 3+ weeks before settimana bianca |
+| Cheapest accommodation | Jan is 20–40% cheaper than Feb across all villages |
+| Good snow at altitude | 97% snowmaking means coverage is guaranteed. Natural snow may be thinner at village level |
+| Quietest slopes | Midweek in January = nearly empty Sella Ronda |
+
+**Runner-up: Sat Feb 15 → Sat Mar 1, 2027** (Post-holiday, high season)
+
+| ✓ | Why |
+|---|-----|
+| After settimana bianca | Bolzano schools back Feb 15. Other regions' short breaks done by Feb 10 |
+| Before German/Austrian holidays | Check specific 2027 dates |
+| Longer days than January | ~1 hr more daylight for skiing |
+| Better natural snow | Mid-Feb usually has deeper snowpack than early Jan |
+| High season pricing | Passes and accommodation cost more |
+
+### Visual Calendar
+
+```
+         JANUARY 2027                    FEBRUARY 2027
+ Mo Tu We Th Fr Sa Su          Mo Tu We Th Fr Sa Su
+              1  2  3           1  2  3  4  5  6  7
+  4  5  6  7  8  9 10           8  9 10 11 12 13 14
+ 11 12 13 14 15 16 ★17         ★15 16 17 18 19 20 21
+ 18 19 20 21 22 23 24          22 23 24 25 26 27 ★28
+ 25 26 27 28 29 30 ★31
+
+ ███ = Settimana bianca (~Feb 6–14)
+ ★17–★31 Jan = Best value 2-week window
+ ★15–★28 Feb = Runner-up window
+```
+
+### Trois Vallées vs Dolomiti: Timing Comparison
+
+| | Trois Vallées | Dolomiti Superski |
+|---|---|---|
+| **Recommended window** | Mar 13–27 (post-French holidays) | Jan 17–31 (shoulder season) |
+| **Backup window** | Mar 6–20 | Feb 15–28 |
+| **Season** | Late season (spring snow) | Mid-season (deep winter) |
+| **Daylight** | ~11.5 hrs | ~9.5 hrs (Jan) / ~10.5 hrs (Feb) |
+| **Conditions** | Spring corn snow, warmer, longer days | Cold, potentially powder, shorter days |
+| **Crowds** | Post-holiday quiet | January = quietest month |
+| **Pricing** | Late-March discounts (10–15%) | Jan shoulder = cheapest all season |
+
+---
+
+## Lift Pass Strategy
+
+| Strategy | Cost (Jan shoulder) | Cost (Feb high) | Ski Days | Best For |
+|----------|--------------------|--------------------|----------|----------|
+| 2× 6-day pass | €784 | €872 | 12 | Standard 2-week trip, 2 rest days |
+| 2× 6-day (online -5%) | €745 | €828 | 12 | Same, booked 2+ days ahead each week |
+| Season pass (buy before Dec 24) | €970 | €970 | Unlimited | Skiing 12+ days. Flexibility for weather days |
+| Regional pass only (e.g., Val di Fassa) | ~€550–650 est. | ~€600–700 est. | 12 | No car, staying in one valley |
+
+**Recommendation for 2-week trip:** Season pass at €970 if purchased early. Only €142–225 more than two 6-day passes, gives unlimited flexibility. If the weather is bad one day, no pressure — ski the next day instead.
+
+---
+
+## Mountain Restaurants: What to Expect
+
+Italian rifugios are a different world from French mountain restaurants. Cheaper, more casual, better value.
+
+| | Dolomites Rifugios | Trois Vallées Restaurants |
+|---|---|---|
+| **Plat du jour / daily special** | €10–15 | €13–18 |
+| **Pasta dish** | €12–18 | €15–22 |
+| **Beer (pint)** | €5–8 | €6–10 |
+| **Coffee** | €3–4 | €4–6 |
+| **Aperol Spritz** | €3–5 | €8–12 |
+| **Budget daily lunch** | €12–18 | €15–25 |
+| **Vibe** | Rustic wood, panoramic terraces, speck boards, Kaiserschmarren | Self-service chains + occasional gems |
+
+The Dolomites win decisively on on-mountain dining. Cheaper, more atmospheric, better food variety (Italian/Austrian/Ladin fusion). The Aperol Spritz at €3 vs €10 in France sums it up.
+
+---
+
+## Tourist Tax Comparison
+
+| | Trois Vallées (France) | Canazei (Trentino) | Val Gardena (South Tyrol) | Arabba (Veneto) |
+|---|---|---|---|---|
+| Rate/night | ~€3 | €1–3 | €4 | €1 |
+| Cap | None | 10 nights | None | 10 nights |
+| 14-night total | €42 | €15–30 | €56 | €10 |
+
+Canazei and Arabba have the cheapest tourist tax. South Tyrol's new €4/night rate (from Jan 2026) adds up for longer stays.
+
+---
+
+## Getting There
+
+### Best Airport Strategy
+
+| Strategy | Route | Cost | Ease |
+|----------|-------|------|------|
+| **Best value (with car)** | MNL→VCE, rent car at Venice, drive 3 hrs | Flight €650 + car €630 all-in | Easy. A4+A22 motorway. Last 30 min is valley roads |
+| **Best value (no car)** | MNL→VCE, FlixBus to Bolzano, bus to valley | Flight €650 + buses €30–60 | 5–6 hrs total, 2–3 changes |
+| **Fastest (with car)** | MNL→INN, rent car at Innsbruck, drive 1.5 hrs | Flight €750 + car €700 + Austria tolls €50 | Quick last leg. Brenner Pass is straightforward |
+| **Cheapest flight** | MNL→MUC, FlixBus to Bolzano, bus to valley | Flight €550–700 + FlixBus €18–40 + bus | Cheapest air, 5–6 hrs ground |
+
+**Recommendation (with car):** Fly to Venice. Cheapest combination of flight + rental. The 3-hour drive is entirely on motorway except the last 30 minutes.
+
+**Recommendation (no car):** Fly to Munich. Cheapest flights from Manila. FlixBus to Bolzano (€18–40, 3.5 hrs), then free SAD bus to your valley with Guest Pass.
+
+---
+
+## Next Steps
+
+- [ ] Decide car vs no car (this comparison should help)
+- [ ] Lock in dates: Jan 17–31 (best value) or Feb 15–28 (better snow/daylight)
+- [ ] Check Dolomiti Superski season pass early-bird pricing when 2026-27 season announced
+- [ ] Book accommodation: check Canazei studios on visitfassa.com or canazei.com
+- [ ] Compare flights: MNL→VCE vs MNL→MUC for Jan/Feb 2027
+- [ ] Decide between this and Trois Vallées — or do both in consecutive seasons

--- a/research/dolomiti-superski-research.md
+++ b/research/dolomiti-superski-research.md
@@ -1,0 +1,675 @@
+# Dolomiti Superski -- 2-Week Ski Trip Research (Jan/Feb 2027)
+
+Research compiled: 2026-02-16
+Season reference: 2025-2026 (2026-2027 pricing not yet announced)
+
+---
+
+## 1. Lift Pass Prices (2025-2026 Season, Dolomiti Superski Area Pass)
+
+All prices in EUR, adult rates.
+
+### Standard Multi-Day Passes
+
+| Duration | High Season | Shoulder/Low Season |
+|----------|-------------|---------------------|
+| 1 day | 86.00 | 77.00 |
+| 3 days | 248.00 | 223.00 |
+| 4 days | 317.00 | 285.00 |
+| 6 days | 436.00 | 392.00 |
+| 7 days | 462.00 | 416.00 |
+
+### Season Periods (2025-2026)
+
+| Period | Dates |
+|--------|-------|
+| High season | 21 Dec 2025 - 10 Jan 2026, 1 Feb - 21 Mar 2026 |
+| Shoulder/low season | 29 Nov - 20 Dec 2025, 11 Jan - 31 Jan 2026, 22 Mar - 10 Apr 2026 |
+
+### Flexible / Long-Stay Options
+
+| Pass Type | Description | Price |
+|-----------|-------------|-------|
+| 5 of 6 Flexipass | Valid any 5 of 6 consecutive days | Use calculator |
+| 10 of 14 Optional | Valid any 10 of 14 consecutive days | Use calculator |
+| Dolomiti Superdays | Bundle of 10 non-consecutive days, valid all season | Use calculator |
+| Season Pass | Valid entire season (29 Nov - Apr) | EUR 970 (if bought before 24 Dec) |
+
+**Note:** Passes longer than 7 consecutive days are not listed on third-party sites. The official Dolomiti Superski website uses a dynamic price calculator. For exact prices on 10-of-14 and Superdays passes, use: https://www.dolomitisuperski.com/en/plan-and-book/skipassandprices
+
+### Best Strategy for 2-Week Trip
+
+| Strategy | Estimated Cost (High) | Ski Days | Notes |
+|----------|----------------------|----------|-------|
+| 2x 6-day passes | EUR 872 | 12 | 2 rest days built in |
+| 2x 6-day (online -5%) | EUR 828 | 12 | Buy 2+ days in advance each time |
+| Season pass | EUR 970 | Unlimited | Best if 12+ ski days; buy before late Dec |
+| 10 of 14 + separate days | TBD via calculator | 10-14 | Flexible approach |
+
+### Discounts
+
+- **5% online discount**: Purchase at least 2 days before first use
+- **3% discount**: If reusing existing My Dolomiti Card for online purchase
+- **Youth (born 2008-2017)**: 30% off adult prices on 1-31 day passes
+- **10% off daily passes**: From the 7th card onward
+- **Springdays offers**: Various deals from mid-March onward
+
+---
+
+## 2. Ski Area Overview
+
+### Key Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total piste km | 1,246 km |
+| Number of lifts | 450 |
+| Altitude range | 1,500 - 3,269 m |
+| Snowmaking coverage | 97% (1,160 km) |
+| Number of ski zones | 12 |
+| Slope breakdown | 360 km blue, 720 km red, 120 km black |
+| Cross-country trails | 1,177 km |
+| Snow parks | 30 |
+
+### The 12 Ski Zones
+
+| # | Zone | Notable Resorts | Key Feature |
+|---|------|----------------|-------------|
+| 1 | Cortina d'Ampezzo | Cortina | Olympic host 2026 |
+| 2 | Kronplatz (Plan de Corones) | Bruneck, San Vigilio | Family-friendly, wide slopes |
+| 3 | Alta Badia | Corvara, La Villa, Colfosco | Sella Ronda access, gourmet |
+| 4 | Val Gardena / Alpe di Siusi | Selva, Ortisei, Santa Cristina | Largest zone (181 km), Sella Ronda |
+| 5 | Val di Fassa / Carezza | Canazei, Campitello, Pozza | Budget-friendly, Sella Ronda |
+| 6 | Arabba / Marmolada | Arabba, Malga Ciapela | Highest point (3,269m), best snow |
+| 7 | 3 Zinnen Dolomites | Sesto, San Candido, Dobbiaco | Spectacular scenery |
+| 8 | Val di Fiemme / Obereggen | Cavalese, Obereggen | Good value, less crowded |
+| 9 | San Martino di Castrozza | San Martino, Passo Rolle | Southern, quieter |
+| 10 | Gitschberg Jochtal / Brixen | Rio Pusteria, Bressanone | Family area, uncrowded |
+| 11 | Alpe Lusia / San Pellegrino | Moena, Falcade | Off the beaten track |
+| 12 | Civetta | Alleghe, Selva di Cadore | Budget, authentic |
+
+### Sella Ronda Circuit
+
+The centerpiece of Dolomiti Superski. A ~40 km ski circuit around the Sella massif connecting 4 zones via lifts:
+- **Val Gardena** <-> **Alta Badia** <-> **Arabba** <-> **Val di Fassa**
+- Can be skied clockwise or anti-clockwise in one day
+- About half of the total 1,246 km is directly lift-connected
+
+### 2025-2026 Season Improvements
+
+- New 3S Col Rodella gondola (Val di Fassa) -- first tri-cable gondola in the Dolomites
+- New Lezuo-Belvedere gondola at Passo Pordoi (10 seats, 3,400 p/h)
+- New Franzin gondola in Carezza (10 seats, 2,400 p/h)
+- New Latemar gondola in Pampeago (10 seats, 2,700 p/h)
+- 13 lifts replaced/modernized across 9 zones total
+
+---
+
+## 3. Best Base Villages for Affordable Accommodation
+
+### Tier 1: Central + Affordable (Sella Ronda Direct Access)
+
+**Ortisei (Val Gardena)**
+- Largest town in Val Gardena with the most restaurants, shops, and services
+- Usually the most affordable accommodation in the valley due to size/competition
+- Direct Sella Ronda access via Seceda and connections through Santa Cristina/Selva
+- Free Val Gardena Guest Pass for public transport included with most accommodations
+- Good for a 2-week stay due to variety of amenities
+
+**Corvara / La Villa / Colfosco (Alta Badia)**
+- Family-run, authentic accommodations
+- Many ski-in/ski-out options
+- Heart of the Sella Ronda
+- Six villages clustered at the base of the Sella massif
+
+**Canazei / Campitello (Val di Fassa)**
+- Generally more affordable than Val Gardena or Alta Badia
+- Good base for the western Dolomites
+- Direct Sella Ronda access
+- Lively town with good facilities
+
+### Tier 2: Central but Higher Price or Less Convenient
+
+**Selva di Val Gardena**
+- Best lift access in Val Gardena (Ciampinoi, Dantercepies)
+- Premium location = slightly higher prices
+- Guesthouses offer budget options (e.g., Garni Sayonara)
+
+**Arabba**
+- Compact, authentic village with excellent snow quality
+- Steepest terrain in the Dolomites
+- Ski-in/ski-out
+- Can be cold and shady in deep winter
+
+### Tier 3: Budget but Less Central
+
+**Alleghe (Civetta)** -- Lower prices but not on the Sella Ronda
+**Sesto (3 Zinnen)** -- Charming, good skiing, but separate from the central areas
+**Val di Fiemme / Obereggen** -- Good value, less crowded, but further from Sella Ronda
+
+---
+
+## 4. Italian School Holiday Dates (Winter 2027 -- Settimana Bianca)
+
+### Key Dates
+
+Easter 2027 falls on **March 28**, which means:
+- **Giovedi Grasso (Fat Thursday)**: ~February 4, 2027
+- **Martedi Grasso (Shrove Tuesday)**: ~February 9, 2027
+- **Mercoledi delle Ceneri (Ash Wednesday)**: February 10, 2027
+
+### Carnival Break by Region (Estimated for 2027, Based on Historical Patterns)
+
+| Region | Typical Duration | Estimated 2027 Dates |
+|--------|-----------------|---------------------|
+| **Provincia di Bolzano (Alto Adige)** | ~9 days ("Settimana dello Sport") | ~Feb 6-14, 2027 (confirmed) |
+| Piemonte | ~4 days | ~Feb 6-9 |
+| Veneto, Friuli VG, Valle d'Aosta, Trentino | ~3 days | ~Feb 8-10 |
+| Lombardia, Campania, Liguria, Molise | ~2 days | ~Feb 8-9 |
+| Sardegna | ~1 day | ~Feb 9 |
+| Lazio, Toscana, Sicilia, and others | No official regional break | Individual school discretion |
+
+### Impact on Your Trip
+
+- **AVOID: ~Feb 4-14, 2027** -- This is peak settimana bianca period, especially in South Tyrol (Bolzano has a full 9-day break Feb 6-14)
+- **Best timing for January**: Any time in January is good; mid-to-late January avoids Christmas crowds
+- **Best timing for February**: After Feb 14 is better; Feb 15 onward should see reduced Italian holiday crowds
+- **Recommended window**: **Jan 10 - Jan 24** or **Jan 17 - Jan 31** or **Feb 14 - Feb 28**
+- January often falls in shoulder/low season = cheaper passes and accommodation
+
+### Also Check
+
+- German school holidays (Winterferien) vary by state; Bavaria typically has a 1-week break in Feb/Mar
+- Austrian Semesterferien: varies by province, typically 1 week in Feb
+- Dutch Voorjaarsvakantie: 1 week in Feb/Mar (major source of Dolomites visitors)
+
+---
+
+## 5. Ski Rental Prices
+
+### Cortina Pro Sport -- Example Price List (2025-2026)
+
+Full adult ski set (skis + boots + poles):
+
+| Tier | 1 Day | 7 Days | Est. 14 Days |
+|------|-------|--------|-------------|
+| SKI BASE (budget) | EUR 25 | EUR 140 | ~EUR 250-280 |
+| SKI MEDIUM (mid-range) | EUR 33 | EUR 164 | ~EUR 290-330 |
+| SKI TOP (premium) | EUR 43 | EUR 220 | ~EUR 390-440 |
+| SKI EXCLUSIVE / VOLANT | EUR 55 | EUR 343 | ~EUR 600-690 |
+
+### General Guidance
+
+- **Budget ski set (skis + boots + poles)**: ~EUR 20-25/day, ~EUR 140-170/week
+- **Mid-range set**: ~EUR 30-35/day, ~EUR 165-220/week
+- **Premium set**: ~EUR 40-55/day, ~EUR 220-350/week
+- **14-day rentals**: Expect significant multi-day discounts; roughly 1.7-2x the 7-day price
+- **Online booking discount**: 10-15% off if booked 2+ days in advance at most shops
+- **Children under 10**: Free rental with 2 paying adults at some shops, or 50% off with 1 adult
+
+### Key Rental Shops
+
+- **Dolomiti Adventures** (Selva di Val Gardena) -- near Ciampinoi cable car, 15% online discount
+- **Ski Rental Walter** (Selva Val Gardena) -- ski-snowboard.it
+- **Intersport Val Gardena** -- 3 locations, 10% online discount, free helmet with rental
+- **Cortina Pro Sport** (Cortina d'Ampezzo) -- detailed price list online
+- **SkiRent network** -- skirent.info, shops across all Dolomiti Superski zones
+
+### Springdays Deals (Mid-March onward)
+
+- SPRINGDAYS L: 6 days rental for price of 5 (14-21 Mar)
+- SPRINGDAYS S: 4 days rental for price of 3, or 8 for 6 (22 Mar - 6 Apr)
+
+---
+
+## 6. Accommodation Prices -- Detailed Area-by-Area Research
+
+*Prices are per apartment per week in EUR, for the 2025/26 season. Estimates marked (est.) are based on cross-referencing multiple sources; verified prices are from property websites.*
+
+### 6a. Val Gardena (Selva / Santa Cristina / Ortisei)
+
+**Selva di Val Gardena** (1,563m) -- Best lift access, most expensive in the valley
+
+| Property | Type | Capacity | Jan (Low) | Feb (High) | Lift Proximity | Notes |
+|----------|------|----------|-----------|------------|---------------|-------|
+| **Apartments Clivia** | 3-star apts | 3-4 pax | 1,200-1,600 | 1,600-2,800 | 250m Ciampinoi | Verified pricing. Garage, linen, ski storage, Mobilcard incl. Tax EUR 2.70/p/day. |
+| **Residence Crespeina** | 3-star residence | 2-6 pax | 700-1,200 (est.) | 900-1,500 (est.) | On Sellaronda, 3 min to center | Apts: Julia, David, Laurin, Stevia, Margareth, Cir. Wi-Fi, garage, linen incl. Tax EUR 2.80/p/day. |
+| **Garni Petra** | Garni + apts | 2-6 pax | 700-1,200 (est.) | 900-1,500 (est.) | Central | Apts: Puez, Sella, Cir, Stevia, Schlern. |
+| **Villa David Dolomites** | Apartments | 2-8 pax | 800-1,500 (est.) | 1,000-2,000 (est.) | Central | Studios to 130m2. Wellness (sauna, whirlpool). |
+| **Residence Antares** | Residence | 2+ pax | 900-1,400 (est.) | 1,200-1,800 (est.) | 200m Ciampinoi | Indoor pool, wellness center. |
+| **Residence Isabell** | Residence | 2+ pax | 900-1,400 (est.) | 1,200-1,800 (est.) | Central | Indoor pool, wellness. Mountain-view balconies. |
+| **Villa Solinda** | Apartments | 2-4 pax | 700-1,100 (est.) | 900-1,400 (est.) | Quiet position | Views of Langkofel and Sellaronda. |
+
+**Ortisei** (1,236m) -- Largest town, 10-20% cheaper, not directly on Sella Ronda
+
+| Property | Type | Capacity | Jan (Low) | Feb (High) | Notes |
+|----------|------|----------|-----------|------------|-------|
+| **Residence Ciastel** | 4-star | 2-4 pax (70m2) | 800-1,200 (est.) | 1,100-1,700 (est.) | Spacious, wellness. |
+| **Petlin Apartments** | Apts | up to 8 pax | 1,200-1,800 (est.) | 1,500-2,200 (est.) | 6 min walk to Seceda or Alpe di Siusi cable cars. Washer, 2 baths. Good for long stays. |
+| General studio/1-bed | Various | 1-2 pax | 500-900 | 700-1,300 | Budget tier. |
+
+**Supermarket**: Valgardena Center DESPAR (Selva center, near church square). Also Despar in S. Cristina. Ortisei has the most shopping variety.
+**Ski bus**: Free, connects all 3 villages, every 10-20 min.
+**Ski areas accessible on skis**: Val Gardena/Alpe di Siusi (175 km), Alta Badia, Arabba, Val di Fassa via Sella Ronda (~490 km connected).
+
+### 6b. Alta Badia (Corvara / La Villa / San Cassiano / Colfosco)
+
+Altitude: 1,568-1,645m. Ladin-speaking, refined atmosphere. 130 km local pistes.
+
+| Property | Type | Capacity | Jan (Low) | Feb (High) | Lift Proximity | Notes |
+|----------|------|----------|-----------|------------|---------------|-------|
+| **Lisura Apartments** | Apts | 2-6 pax | 700-1,200 (est.) | 1,000-1,600 (est.) | Ski bus at door | Corvara. Quiet, panoramic, 5 min walk to center. |
+| **Nei Y Suredl NeveSole** | Apts | 2-4 pax | 900-1,400 (est.) | 1,200-1,800 (est.) | 10m from Arlara lifts | Ski-in/ski-out. Free wellness (Turkish bath, sauna). |
+| **Movi Family Apart-Hotel** | 4-star apart-hotel | 2-6 pax | 1,000-1,500 (est.) | 1,400-2,000 (est.) | Near lifts | Rating 9.5/10. Family-oriented. |
+| **Apartments Chalet Ciufdlton** | Chalet apts | 2-6 pax | 900-1,400 (est.) | 1,200-1,800 (est.) | Near lifts | Rating 9.5/10, 159 reviews. |
+| **Apartments Bracun** | Apts | 2-4 pax | 600-1,000 (est.) | 800-1,400 (est.) | Corvara | Balcony, mountain views. |
+| **Residence Mugun** | Residence | 2-4 pax | 700-1,100 (est.) | 900-1,500 (est.) | Corvara | Steam room. |
+| **Residence Villa Al Sole** | Residence | 2-4 pax | 700-1,100 (est.) | 900-1,500 (est.) | Corvara | Sauna, fitness, steam room. |
+
+**Forum data point**: EUR 1,600 total for 8 people for 1 week in Corvara (SnowHeads) = EUR 200/person/week (large apartment shared).
+**Supermarket**: Small alimentari in Corvara and La Villa. Stock up in Bruneck with a car.
+**Ski bus**: Free, connects all Alta Badia villages.
+**Ski areas accessible on skis**: Alta Badia (130 km), Val Gardena (via Passo Gardena), Arabba (via Campolongo), full Sella Ronda.
+
+### 6c. Canazei / Val di Fassa
+
+Altitude: 1,465m. Trentino region (cheaper tourist tax). Italian-speaking.
+
+| Property | Type | Capacity | Jan (Low) | Feb (High) | Lift Proximity | Notes |
+|----------|------|----------|-----------|------------|---------------|-------|
+| **Apartments Riz Diego** | Apts | 2-4 pax | 500-900 (est.) | 700-1,200 (est.) | 150m to slopes, near Pecol cable car | East Canazei, sunny/quiet. Parking, SAT-TV, balcony. |
+| **Marmolada Apt. 36** | Studio | 2 pax (30m2) | 400-700 (est.) | 600-1,000 (est.) | 450m ski area, ski bus 10m from door | Alba di Canazei. Double bed, kitchenette, balcony. |
+| **CasaMau Bilo** | Apt | 2 pax (50m2) | 500-800 (est.) | 700-1,100 (est.) | Pera/Pozza di Fassa | Renovated. Dishwasher, Wi-Fi. On-site ski rental. |
+| **Apartments Canazei** (apartmentscanazei.com) | Apts | 2-6 pax | 600-1,100 (est.) | 800-1,500 (est.) | Steps from Col Rodella & Belvedere cable cars | Well-furnished. |
+| **Garni La Zondra** | B&B/Garni | 2 pax | 500-800 (est.) | 700-1,100 (est.) | 50m from Belvedere | Not self-catering. |
+| **Villa Hotel Agomer** | Hotel | 2 pax | 700-1,200 (est.) | 900-1,500 (est.) | Near 2 lifts, Sella Ronda direct | Alba/Penia. Half-board. Recommended by SnowHeads for long stays. |
+| **Campitello studio** | Studio | 2 pax (28m2) | 400-600 (est.) | 550-850 (est.) | 50m from Campitello center, near cable car | Budget option. |
+
+**Supermarket**: Several small supermarkets in Canazei center and surrounding villages.
+**Ski bus**: Free, tight network across Val di Fassa. Trentino Guest Card = free public transport.
+**Ski areas accessible on skis**: Val di Fassa/Carezza (Belvedere, Col Rodella, Buffaure, Ciampac, Catinaccio), Sella Ronda, Marmolada.
+**Key advantage**: Tourist tax only EUR 1-3/night (max 10 nights) vs EUR 4/night in South Tyrol.
+
+### 6d. Kronplatz / Plan de Corones (Bruneck / San Vigilio)
+
+Kronplatz: 119 km pistes, 2,275m summit. NOT lift-connected to Sella Ronda.
+
+| Property | Type | Capacity | Jan (Low) | Feb (High) | Lift Proximity | Notes |
+|----------|------|----------|-----------|------------|---------------|-------|
+| **A-Lunis** | 3-star aparthotel | 2-4 pax | 600-1,000 (est.) | 900-1,400 (est.) | Bruneck area | 1 bed, living room, kitchen. Mountain views, terrace. Ski storage + boot dryer. |
+| **Bellevue Bruneck Suites & Lofts** | 4-star luxury | 2-4 pax | 1,200-1,800 (est.) | 1,600-2,400 (est.) | Bruneck | Sauna, full kitchenette, terrace. |
+| **Residence Plan de Corones** | 3-star | 2-4 pax (40m2) | 700-1,100 | 1,000-1,890 | 50m from slopes, 700m from center | San Vigilio. Verified: EUR 100-270/night. |
+| **Ciasa Isidor** | Apts | 2-4 pax | 600-1,000 (est.) | 900-1,400 (est.) | San Vigilio | 4 mountain-style apartments. Tax EUR 2.70/p/day. |
+| **Garni Residence Diamant** | Garni + apts | 2-4 pax | 600-1,000 (est.) | 900-1,400 (est.) | 500m from lifts | Center of San Vigilio. Near Fanes-Senes-Braies park. |
+| **Residence Antina** | Residence | 2-4 pax | 600-1,000 (est.) | 900-1,400 (est.) | 150m from Miara lift | Late-season deal: "7 nights for price of 6." |
+
+**Supermarket**: Bruneck has full-size supermarkets (Eurospar, MPreis). San Vigilio has small village shops.
+**Ski bus**: Ski Pustertal Express train connects Kronplatz to 3 Zinnen (free with guest card).
+**Ski areas accessible on skis**: Kronplatz only (119 km). 3 Zinnen via train. NOT connected to Sella Ronda.
+
+### 6e. Arabba
+
+Altitude: 1,602m. Small village, excellent snow, direct Sella Ronda + Marmolada access.
+
+| Property | Type | Capacity | Jan (Low) | Feb (High) | Lift Proximity | Notes |
+|----------|------|----------|-----------|------------|---------------|-------|
+| **Appartamenti Dolomites (Settsass)** | Apt | 6 pax (105m2) | 2,730-3,640 | 3,150-4,200 | 150m from Burz & Porta Vescovo | **Verified pricing.** Kitchen, dishwasher, washer, Wi-Fi, balcony. Linen/cleaning incl. Deposit EUR 500. Per-person: ~EUR 455-700/wk. |
+| **Appartamenti Dolomites (Marmolada)** | Apt | 8 pax (140m2) | 3,640-4,095 | 4,200-4,725 | 150m from Burz & Porta Vescovo | **Verified pricing.** Same property, larger unit. Per-person: ~EUR 455-590/wk. |
+| **Apartments Daberto Fabiola** | Apts | 4-6 pax | From 55/p (est. 550-900 for 2) | From 85/night (est. 700-1,200 for 2) | 100m from center, on ski slopes | On Sella Ronda circuit. 2 bedrooms, kitchen. |
+| **Apartments Marisa** | Apts | 2-6 pax | 500-900 (est.) | 700-1,200 (est.) | Central | Sat-Sat only in high season. All utilities incl. Tax EUR 1/p/day (age 13+, max 10 days). |
+| **Home Service Apartments** | Apts | 2-6 pax | 500-900 (est.) | 700-1,200 (est.) | 100m from Burz chairlift | 500m from center. Quiet, sunny. |
+| **Residence Aspen** | Residence | 2-4 pax | 700-1,100 (est.) | 900-1,500 (est.) | Minutes from main lifts | Wellness center with sauna and outdoor hot tub. |
+| **Residence Campolongo** | 3-star | 2-4 pax | 600-1,000 (est.) | 800-1,400 (est.) | Near lifts | Popular option. |
+
+**Supermarket**: Very small village shops only. Stock up in Brunico/Belluno/Bressanone with a car.
+**Ski bus**: Limited -- village is compact/walkable. Bus connections to Corvara via Passo Campolongo.
+**Ski areas accessible on skis**: Arabba-Marmolada (63 km), full Sella Ronda circuit.
+**Tourist tax**: Only EUR 1/person/night (max 10 nights) -- cheapest in the Dolomites (Veneto region).
+
+### 6f. Weekly Price Summary (Studio/1-Bed for 1-2 Persons)
+
+| Area | January (Low) | February (High) | Notes |
+|------|--------------|----------------|-------|
+| **Selva (Val Gardena)** | 700-1,200 | 1,000-1,800 | Most expensive Sella Ronda village. Best lift access. |
+| **Ortisei (Val Gardena)** | 500-900 | 700-1,400 | 10-20% cheaper than Selva. Not directly on Sella Ronda. |
+| **Corvara (Alta Badia)** | 600-1,100 | 900-1,600 | Direct Sella Ronda. Refined. |
+| **La Villa (Alta Badia)** | 550-1,000 | 800-1,500 | Slightly cheaper than Corvara. |
+| **Canazei (Val di Fassa)** | 400-800 | 600-1,200 | Cheapest Sella Ronda village. Lower tourist tax. |
+| **Campitello di Fassa** | 350-700 | 500-1,000 | Budget alternative. Near Col Rodella. |
+| **Arabba** | 500-900 | 700-1,200 | Small, authentic. Limited groceries. |
+| **San Vigilio (Kronplatz)** | 500-900 | 800-1,400 | Not on Sella Ronda. Quiet. |
+| **Bruneck (Kronplatz)** | 450-800 | 700-1,200 | Real town. Not on Sella Ronda. |
+
+**Timing notes:**
+- **Low season** = Jan 11 - Jan 31 (and similar for 2027)
+- **High season** = Feb 1 - Mar 21
+- **Peak** (Christmas/NY/Epiphany, Dec 21 - Jan 10) = 30-50% more than above
+- Mid-January (after Epiphany Jan 7) is consistently cheapest and quietest
+- 2-week bookings may get 10-15% discount on some platforms
+
+### 6g. Tourist Tax by Region
+
+| Region | Rate (2026) | Cap | Exempt |
+|--------|------------|-----|--------|
+| **South Tyrol** (Val Gardena, Alta Badia, Kronplatz) | EUR 2.50-4.00/p/night (EUR 4.00 from Jan 1, 2026) | Varies | Under 14 |
+| **Trentino** (Val di Fassa/Canazei) | EUR 1.00-3.00/p/night | Max 10 nights | Under 14 |
+| **Veneto** (Arabba) | EUR 1.00/p/night | Max 10 nights | Under 12 |
+
+For a 14-night stay (1 person): South Tyrol ~EUR 56, Trentino ~EUR 20, Arabba ~EUR 10.
+
+### 6h. Best Base Analysis
+
+**Best base WITHOUT a car: Selva di Val Gardena**
+- Direct lift access to Sella Ronda (Ciampinoi + Dantercepies from village)
+- Ski to Alta Badia, Arabba, Val di Fassa and back in a day
+- 175 km local + ~490 km lift-connected terrain
+- Free ski bus every 10-20 min
+- Despar supermarket in village, restaurants, shops
+- Mobilcard for free regional public transport
+- Runner-up: Corvara (also direct Sella Ronda, slightly less variety in dining/shops)
+
+**Best base WITH a car: Selva di Val Gardena (still)**
+- All on-snow advantages above, PLUS can drive to Kronplatz (~45 min), Cortina (~1.5 hr), 3 Zinnen (~1.5 hr)
+- Alternative: Bruneck/Brunico for town life (medieval center, big supermarkets, culture), with Kronplatz on doorstep and 30 min drive to Alta Badia. Downside: must drive every time for Sella Ronda.
+
+**Best VALUE base for 2-week self-catering: Canazei / Val di Fassa**
+- 10-20% cheaper accommodation than Val Gardena
+- Lower tourist tax (Trentino: EUR 1-3/night, capped 10 nights)
+- Trentino Guest Card = free public transport
+- Sella Ronda access via Belvedere
+- Less polished but authentic Italian mountain feel
+
+### 6i. Key Booking Platforms
+
+| Platform | Best For | URL |
+|----------|---------|-----|
+| val-gardena.com | Val Gardena direct booking, best-price guarantee | val-gardena.com |
+| valgardena.it | Val Gardena official | valgardena.it |
+| alta-badia.net | Alta Badia official | alta-badia.net |
+| altabadia.org | Alta Badia tourism | altabadia.org |
+| visitfassa.com | Val di Fassa (gives Trentino Guest Card) | visitfassa.com |
+| canazei.com | Canazei apartments | canazei.com |
+| arabba.it | Arabba official | arabba.it |
+| sanvigilio.com | San Vigilio/Kronplatz | sanvigilio.com |
+| kronplatz.com | Kronplatz official | kronplatz.com |
+| yesalps.com | Pan-Dolomites apartment listings | yesalps.com |
+| Booking.com | Widest selection, reviews | booking.com |
+| Airbnb | Private apartments, longer-stay discounts | airbnb.com |
+| Interhome | Quality-checked holiday homes | interhome.com |
+| dolomitisuperski.com | Lift passes + accommodation search | dolomitisuperski.com |
+
+### Estimated 2-Week Accommodation Cost (Solo, Budget)
+
+- Budget studio in Canazei or Ortisei: ~EUR 800-1,400 for 2 weeks (January)
+- Budget studio in Canazei or Ortisei: ~EUR 1,000-2,000 for 2 weeks (February)
+- Mid-range apartment (Selva/Corvara): ~EUR 1,400-2,800 for 2 weeks
+
+---
+
+## 7. Getting There -- Airport Transfers
+
+### Airport Distances and Drive Times
+
+| Airport | Code | Distance to Val Gardena | Drive Time | Best For |
+|---------|------|------------------------|------------|----------|
+| Bolzano | BZO | 40 km | 30-45 min | Closest, but limited flights |
+| Innsbruck | INN | 130 km | 1h 30min | Fast northern entry via Brenner Pass |
+| Verona | VRN | 230 km | 2h 15min | Good for western Dolomites |
+| Venice Marco Polo | VCE | 310 km | 3h 20min | Best for Cortina/eastern areas |
+| Munich | MUC | 350 km | 4h | Most international connections |
+
+### Transfer Options by Airport
+
+**From Innsbruck (INN) -- 1h 30min**
+- Train: Innsbruck -> Bolzano (1h 45min by EC train), then SAD bus to Val Gardena (~1h)
+- Car rental: Straightforward drive via Brenner motorway (A13 -> A22)
+- Shuttle: Various private transfer companies
+
+**From Verona (VRN) -- 2h 15min**
+- AltoAdigeBus: Direct bus service to Val Gardena
+- Train: Verona Porta Nuova -> Bolzano (~1h 45min), then SAD bus
+- Car rental: A22 Brennero motorway north
+
+**From Venice (VCE) -- 3h 20min**
+- Cortina Express: Direct bus to Cortina d'Ampezzo (~2h)
+- FlixBus / ATVO bus: To Cortina or Bolzano
+- For Val Gardena: AltoAdigeBus or FlixBus to Bolzano, then SAD bus
+- Private transfer: Recommended for groups of 3+
+
+**From Munich (MUC) -- 4h**
+- Train: Munich -> Innsbruck -> Bolzano -> Val Gardena (4.5-5h total)
+- FlixBus: Direct routes to South Tyrol
+- Car rental: Munich -> Innsbruck -> Brenner -> Bolzano -> Val Gardena
+
+### Key Transport Tips
+
+- Bolzano is the main transport hub for the western/central Dolomites
+- Train services: Trenitalia, OBB (Austrian), Deutsche Bahn
+- A22 Brennero motorway is a toll road
+- Austrian motorway vignette required if driving through Austria (EUR ~10 for 10-day)
+- Italian motorway tolls: ~EUR 15-25 depending on route
+
+---
+
+## 8. Public Transport Within the Dolomites
+
+### Free Guest Pass System
+
+**Val Gardena Guest Pass** (included with most accommodations):
+- Free unlimited use of all public buses in Val Gardena
+- Free use of nearly all public transport in South Tyrol
+- Valid from arrival day to departure day
+- NOT valid for: Nightbus, Monte Pana/Saltria bus, Alpe di Siusi buses
+
+**If not staying at participating accommodation:**
+- Val Gardena Mobil Card available for purchase:
+  - 1 day: EUR 20 adult / EUR 10 child (6-13)
+  - 3 days: EUR 30 / EUR 15
+  - 7 days: EUR 45 / EUR 22.50
+
+### Ski Bus Network
+
+**Val Gardena ski buses** (winter 2025-2026: Dec 6 - Apr 6):
+- Multiple routes connecting Ortisei, Santa Cristina, Selva to all lift stations
+- Ski Bus 1: Ortisei - St. Giacomo
+- Ski Bus 2: Ortisei - Bulla
+- Ski Bus 4: Ortisei - Rodra - Costamula
+- Ski Bus 5: Ortisei - Lip - Cademia
+- Ski Bus 11: S. Cristina - Church - Mayr - Saslong
+- Ski Bus 22/23: Selva - Nives - Dantercepies - Daunei
+- Line 357: Additional Selva connections
+
+**Inter-valley connections:**
+- Line 473: Val Gardena - Gardena Pass - Val Badia (Corvara/Colfosco)
+- "Connecting Skiers" free bus: Alta Badia <-> Kronplatz (every 20 min)
+- Cortina Express: Alta Badia <-> Cortina d'Ampezzo
+- SAD bus network: Bolzano <-> Val Gardena (regular service)
+
+### General Notes
+
+- South Tyrol has excellent, reliable, punctual public transport (Austrian influence)
+- The lift network itself connects the Sella Ronda areas -- you rarely need buses during ski days
+- Night bus available on Saturday evenings (special ticket required)
+- Bus timetables: www.sii.bz.it or www.suedtirolmobil.info
+
+---
+
+## 9. Car Rental Considerations
+
+### Do You Need a Car?
+
+**For a skiing-focused 2-week trip in one base village: NO, a car is not necessary.**
+- Free guest pass covers local buses
+- Ski buses connect to all lifts
+- The Sella Ronda lift network connects the four central zones
+- Most apartments are near bus stops or within walking distance of lifts
+
+**A car IS useful if:**
+- Flying into a distant airport (Venice, Munich) and want flexibility
+- Planning to explore multiple non-connected zones (e.g., Kronplatz + Cortina + Val Gardena)
+- Accommodation is outside the main village
+- Want to visit other towns/areas on rest days
+
+### If You Do Rent
+
+**Legal requirements (winter):**
+- Winter tires OR snow chains in the vehicle (mandatory mid-Nov to mid-Apr)
+- Reflective safety vest (mandatory since 2004)
+- Headlights on at all times on motorways and dual carriageways
+
+**Road conditions:**
+- Open roads are well-maintained even in heavy snow
+- Mountain passes may close temporarily in severe weather
+- Check pass status signs in valleys or online
+
+**Parking:**
+- Most ski area parking is paid
+- Typical rate: ~EUR 0.70/30min, max ~EUR 10/day
+- Free parking available at some accommodation
+- For a 2-week stay, parking adds up -- consider if you actually need the car daily
+
+**Rental tips:**
+- Rent from Bolzano or Verona for best prices (avoid airport surcharges where possible)
+- Get the smallest car you'll be comfortable with -- narrow mountain roads
+- Manual transmission is cheaper and more common
+- Check all dents/scratches are documented at pickup
+- Budget: ~EUR 300-600 for 2 weeks (compact car, winter)
+
+**Tolls:**
+- Italian motorway (A22): ~EUR 15-25 per journey
+- Austrian vignette: ~EUR 10 (10-day) if driving via Innsbruck/Brenner
+- Brenner Pass toll: additional fee
+
+---
+
+## 10. Mountain Restaurant (Rifugio) Prices
+
+### On-Mountain Lunch Prices (EUR)
+
+| Item | Price Range |
+|------|------------|
+| Simple lunch (gnocchi, grilled cheese, sausage, pizza) | EUR 10-15 |
+| Pasta / polenta dishes | EUR 15-22 |
+| Soup / sandwich | EUR 8-12 |
+| Packed lunch (from rifugio) | ~EUR 15 |
+| Coffee | EUR 3-5 |
+| Beer (pint) | EUR 5-8 |
+| Aperol Spritz | EUR 2.50-5 |
+| Wine (0.5L) | EUR 10-20 |
+
+### Valley Restaurant Prices
+
+| Type | Price per Person |
+|------|-----------------|
+| Budget self-catered dinner | EUR 10-15 |
+| Traditional restaurant dinner (multi-course + wine) | EUR 25-35 |
+| Mid-range restaurant | EUR 35-55 |
+| Fine dining / Michelin | EUR 80-200 |
+
+### Daily Food Budget Estimates
+
+| Style | Per Day (EUR) |
+|-------|--------------|
+| Full self-catering | EUR 15-25 |
+| Self-catered + mountain lunch | EUR 30-40 |
+| Eating out for all meals | EUR 50-80 |
+
+### Tips
+
+- Rifugios serve large portions -- consider sharing
+- Most rifugios accept cards, but bring EUR cash as backup
+- Supermarket prices are standard Italian rates -- not inflated resort prices
+- South Tyrolean cuisine mixes Italian and Austrian: speck, canederli (dumplings), strudel, polenta
+
+---
+
+## Summary: Total Budget Estimates for 2-Week Trip (Solo)
+
+### Budget Option (Ortisei/Canazei, Self-Catered, January)
+
+| Item | Low | High |
+|------|-----|------|
+| Flights (budget airline) | 100 | 300 |
+| Airport transfer (bus/train) | 40 | 80 |
+| Accommodation (2 weeks, budget studio) | 700 | 1,200 |
+| Lift pass (2x 6-day, shoulder season, online -5%) | 745 | 828 |
+| Ski rental (14 days, mid-range) | 290 | 440 |
+| Food (self-catered + occasional mountain lunch) | 350 | 500 |
+| Local transport | 0 | 50 |
+| Extras (apres-ski, rest day activities) | 50 | 150 |
+| **TOTAL** | **EUR 2,275** | **EUR 3,548** |
+
+### Notes on 2026-2027 Season
+
+- 2026-2027 prices not yet announced; expect ~3% increase over 2025-2026
+- Season dates likely similar: late Nov 2026 - early/mid Apr 2027
+- January 2027: weeks straddling Jan 11 - Jan 31 likely to be shoulder/low season
+- Book accommodation and flights as early as possible for best rates
+- Check Olympic/event impacts on Cortina area (2026 Olympics may cause lingering closures or improvements)
+
+---
+
+## Sources
+
+### Lift Passes & Ski Areas
+- https://www.dolomitisuperski.com/en/plan-and-book/skipassandprices
+- https://www.skicorvara.com/skipasses.php
+- https://www.skivalgardena.com/skipasses.php
+- https://www.skicortinadampezzo.com/skipasses.php
+- https://www.skicanazei.com/skipasses.php
+- https://cortinaprosport.com/en/ski/rental-pricelist.html
+- https://www.dolomitisuperski.com/en/areas
+- https://en.wikipedia.org/wiki/Dolomiti_Superski
+- https://snowstash.com/news/2025/04/dolomiti-superski-2024-25-success-2025-26-pricing
+
+### Accommodation -- Val Gardena
+- https://www.val-gardena.com/en/apartments-selva-val-gardena-italy/
+- https://www.valgardena.it/en/holidays-dolomites/apartments-val-gardena/
+- https://www.apartments-clivia.com/en/prices-vacation-rental-val-gardena.html
+- https://www.crespeina.com/en/pricelist-selva.asp
+- https://www.garni-petra.com/en/apartments-selva-val-gardena-wolkenstein.html
+- https://www.gardenacenter.com/en/ (Despar supermarket)
+- https://www.residence-ciastel.com/en/apartments.asp
+
+### Accommodation -- Alta Badia
+- https://www.alta-badia.net/en/
+- https://www.altabadia.org/en/villages/corvara-alta-badia/accommodations
+- https://www.lisura.it/en/
+- https://www.booking.com/apartments/city/it/corvara-in-badia.html
+
+### Accommodation -- Val di Fassa / Canazei
+- https://www.visitfassa.com/en/canazei/
+- https://www.canazei.com/en/r/apartments/canazei
+- https://apartmentscanazei.com/?lang=en
+- https://www.yesalps.com/en/apartments/val-di-fassa/riz-43e97fad1e.html
+
+### Accommodation -- Kronplatz
+- https://www.sanvigilio.com/en/planning-booking/accommodation-search
+- https://www.kronplatz.com/en/the-kronplatz
+- https://www.plandecorones.bz/en/apartments-san-vigilio-di-marebbe
+- https://us.j2ski.com/ski_hotels/Italy/Bruneck_Kronplatz/A_Lunis.html
+
+### Accommodation -- Arabba
+- https://www.arabba.it/en/holiday-apartments-arabba/52-0.html
+- https://www.appartamentidolomites.com/en/
+- https://www.appartmarisa.it/en/
+- https://www.skiarabba.com/hotels.php
+
+### Transport & General
+- https://www.powderhounds.com/Europe/Italy/Dolomites/Accommodation.aspx
+- https://www.valgardena.it/en/winter-holidays-dolomites/mobility/
+- https://www.val-gardena.com/en/winter/mobility/
+- https://www.holidays-info.com/italy/school-holidays/2027/
+- https://www.moonhoneytravel.com/dolomites-skiing/
+- https://www.moonhoneytravel.com/how-to-get-to-the-dolomites/
+- https://loveyouritaly.com/are-the-dolomites-expensive/
+- https://www.machupicchu.org/dolomites-budget-guide-2026-complete-cost-breakdown.htm
+- https://www.nationalgeographic.com/travel/article/paid-content-choose-the-best-dolomites-ski-resort
+
+### Tourist Tax
+- https://www.south-tirol.com/useful-information/local-tax
+- https://www.visittrentino.info/en/booking/visitor-s-tax
+
+### Forum Discussions
+- https://snowheads.com/ski-forum/viewtopic.php?t=171144 (Sellaronda 2025-2026 accommodation advice)
+- https://www.snowheads.com/ski-forum/viewtopic.php?t=93933 (Budget Dolomites apartments)

--- a/research/dolomiti-superski-transport.md
+++ b/research/dolomiti-superski-transport.md
@@ -1,0 +1,441 @@
+# Dolomiti Superski Transport Research
+
+## Getting There from Manila
+
+### Gateway Airports
+
+The Dolomites sit at the intersection of three Italian regions (South Tyrol, Trentino, Veneto) and are accessible from multiple airports. No airport is "right next door" -- all require 1.5 to 4+ hours of ground transfer.
+
+| Airport | Code | Distance to Val Gardena (Ortisei) | Distance to Cortina | Drive Time (Val Gardena) | Drive Time (Cortina) |
+|---------|------|-----------------------------------|---------------------|--------------------------|----------------------|
+| **Innsbruck** | INN | ~120 km | ~163 km | ~1.5-2 hrs | ~2.5 hrs |
+| **Verona** | VRN | ~210 km | ~300 km | ~2.5 hrs | ~3.5 hrs |
+| **Venice Marco Polo** | VCE | ~190 km (via passes) | ~150 km | ~3-3.5 hrs | ~2-2.5 hrs |
+| **Munich** | MUC | ~310 km | ~400 km | ~3.5-4 hrs | ~5 hrs |
+| **Bolzano** | BZO | ~40 km | ~130 km | ~45 min | ~2 hrs |
+
+**Bolzano (BZO)** is the closest but has very limited flights -- mainly SkyAlps to a handful of European cities (Berlin, London, Vienna). Not viable from Manila.
+
+### Flights from Manila
+
+There are no direct Manila-Europe flights to any of these airports. The routing is always Manila --> Hub --> Gateway Airport.
+
+**Typical routing options:**
+- Manila --> Singapore/Dubai/Doha/Istanbul --> Venice/Munich/Verona
+- Manila --> Middle East hub --> major European hub --> Innsbruck/Verona (budget connection)
+
+**Estimated return flight costs (Manila to gateway airports, Jan/Feb):**
+
+| Route | Typical Cost | Cheapest Airlines | Notes |
+|-------|-------------|-------------------|-------|
+| MNL --> MUC return | €550-800 | Gulf Air, China Southern, Saudia | Best long-haul connections, many options |
+| MNL --> VCE return | €600-900 | Turkish, Emirates + connection | Often requires 2 stops from Manila |
+| MNL --> VRN return | €650-950 | Budget carriers + connection | Fewer direct options, usually via Rome/Milan |
+| MNL --> INN return | €700-1,000 | Via Munich/Vienna + short hop | Smallest airport, fewest connections |
+
+**Best value strategy:** Fly Manila --> Munich (best long-haul options, €550-700 with Gulf Air/Saudia/China Southern) and either rent a car or take FlixBus/train south. Alternatively, fly Manila --> Venice if heading to Cortina.
+
+**Average round-trip:** ~€600-800 booking 2-3 months ahead for Jan/Feb travel.
+
+---
+
+## Airport Transfer Options (to the Dolomites)
+
+### From Venice Marco Polo (VCE)
+
+| Mode | Destination | Duration | Cost | Notes |
+|------|-------------|----------|------|-------|
+| **Cortina Express bus** | Cortina d'Ampezzo | ~2.5 hrs | €15-30 one-way | 5x daily in winter (Dec 20 - Apr 5). Book ahead -- sells out |
+| **Private transfer** | Cortina | ~2.5 hrs | €180-280 per vehicle | Up to 8 passengers, door-to-door |
+| **FlySki Shuttle** | Val di Fassa | ~3-4 hrs | €50 one-way | Weekends only (Dec-Apr), bookable to hotel |
+| **Train** | Bolzano (via Verona) | ~3-3.5 hrs | €20-35 | Trenitalia regional. Change at Verona |
+| **FlixBus** | Bolzano | ~4.5 hrs | €15-28 | 3x daily, departs Tronchetto |
+| **Rental car** | Val Gardena | ~3.5 hrs | See car rental section | Via A4 + A22 motorways |
+| **Rental car** | Cortina | ~2.5 hrs | See car rental section | Via A27 + SS51 |
+
+### From Innsbruck (INN)
+
+| Mode | Destination | Duration | Cost | Notes |
+|------|-------------|----------|------|-------|
+| **Train** | Bolzano | ~2 hrs | €15-25 | OBB/Trenitalia via Brenner Pass. Frequent service |
+| **Private transfer** | Val Gardena | ~2 hrs | €160-240 per vehicle | Auto Dul, Taxi Raimund |
+| **Rental car** | Val Gardena | ~1.5-2 hrs | See car rental section | Shortest drive. Via A13 Brenner + A22 |
+| **FlixBus** | Bolzano | ~1.5-2 hrs | €10-18 | 10x daily |
+
+### From Munich (MUC)
+
+| Mode | Destination | Duration | Cost | Notes |
+|------|-------------|----------|------|-------|
+| **Train** | Bolzano | ~3.5-4 hrs | €30-50 | DB/OBB via Brenner. Scenic route |
+| **FlixBus** | Bolzano | ~3.5-4 hrs | €18-40 | 10x daily. Cheapest month: December |
+| **Rental car** | Val Gardena | ~3.5-4 hrs | See car rental section | Via A13 Brenner, needs Austrian vignette |
+| **Private transfer** | Val Gardena | ~3.5 hrs | €300-450 per vehicle | Expensive but convenient for groups |
+
+### From Verona (VRN)
+
+| Mode | Destination | Duration | Cost | Notes |
+|------|-------------|----------|------|-------|
+| **Train** | Bolzano | ~1.5 hrs | €10-20 | Trenitalia direct. Very convenient |
+| **FlySki Shuttle** | Val di Fassa | ~2.5 hrs | €46 one-way | Weekends Dec-Apr |
+| **Rental car** | Val Gardena | ~2.5 hrs | See car rental section | Via A22 Autostrada del Brennero |
+| **FlixBus** | Bolzano | ~2 hrs | €10-15 | Multiple daily |
+
+### Bolzano: The Hub
+
+Once in Bolzano, you still need to reach the ski valleys. The "last mile" options:
+
+| To | Mode | Duration | Cost |
+|----|------|----------|------|
+| Val Gardena (Ortisei) | SAD Bus (line 350) | ~50 min | Free with Guest Pass |
+| Alta Badia (Corvara) | Bus via Brunico | ~2 hrs | Free with Guest Pass |
+| Cortina | Bus 445 via Dobbiaco | ~3+ hrs | €10-15 |
+| Val di Fassa (Canazei) | Bus via Passo Sella | ~1.5-2 hrs | €5-10 |
+
+---
+
+## Car Rental
+
+### 14-Day Economy Rental Costs by Airport
+
+Prices for a basic economy/compact car, manual transmission, 14 days in January:
+
+| Airport | Budget Range (14 days) | Average (14 days) | Notes |
+|---------|------------------------|--------------------|-------|
+| **Verona (VRN)** | €130-350 | ~€250 | Cheapest option. High competition from budget carriers |
+| **Venice (VCE)** | €200-560 | ~€350 | Mid-range. Good availability |
+| **Munich (MUC)** | €300-600 | ~€450 | More expensive. German market rates |
+| **Innsbruck (INN)** | €350-700 | ~€500 | Most expensive. Smaller airport, less competition |
+
+**Add-ons to budget for:**
+- Automatic transmission: +€10-15/day (~€140-210 for 14 days)
+- Full insurance/CDW excess waiver: +€15-25/day (~€210-350 for 14 days)
+- Cross-border fee (if picking up in Austria/Germany and driving to Italy): €0-50 depending on company
+
+**Best value:** Rent from Verona or Venice. January is the cheapest month for rentals across all airports.
+
+### Motorway Tolls
+
+Italy uses a distance-based toll system on the autostrada network. The average rate is ~€0.07/km for a passenger car.
+
+**Key route toll estimates (one-way):**
+
+| Route | Distance | Estimated Toll |
+|-------|----------|----------------|
+| Venice (VCE) --> Bolzano (via A4 + A22) | ~250 km | €18-22 |
+| Venice (VCE) --> Belluno exit (toward Cortina) | ~100 km | €8-10 |
+| Verona (VRN) --> Bolzano (via A22) | ~155 km | €10-14 |
+| Bolzano --> Cortina (via passes) | Mountain roads | Toll-free |
+
+**For a 14-day trip (round trip from Venice):** ~€35-45 in tolls total.
+
+**Note:** The A22 Autostrada del Brennero (Brenner motorway) is the main north-south artery. Toll rates on A22 have not increased since 2021, though a 1.46% adjustment took effect Jan 1, 2026.
+
+**Payment:** Cash, credit card, or Telepass transponder (available from rental agencies).
+
+### Austrian Tolls (if arriving via Innsbruck/Munich)
+
+If your route passes through Austria, you need:
+
+1. **Austrian Vignette (2026 prices, cars up to 3.5t):**
+   - 1-day: €9.60
+   - 10-day: €12.80
+   - 2-month: €32.10
+   - Annual: €106.80
+
+2. **Brenner Pass Section Toll (A13):** €12.50 per single journey (2026). This is charged IN ADDITION to the vignette. The entire A13 is subject to this special toll regardless of having a vignette.
+
+**Total Austria transit cost (e.g., Munich --> Bolzano):** ~€12.80 (10-day vignette) + €12.50 (Brenner section toll) = **~€25.30 one-way, ~€50.60 return.**
+
+### Fuel Costs
+
+**Current Italy fuel prices (Feb 2026):**
+- Petrol (Benzina/Euro 95): ~€1.65/litre
+- Diesel (Gasolio): ~€1.69/litre
+
+**Tip:** Self-service ("self") pumps are €0.10-0.20 cheaper per litre than full-service ("servito").
+
+**14-day fuel estimate:**
+- Airport transfer round trip: ~400-500 km = ~€45-55
+- Daily driving between valleys/villages: ~20-30 km/day x 10 driving days = ~€25-35
+- **Total fuel estimate: ~€70-90 for 14 days**
+
+### Parking in Dolomite Ski Villages
+
+| Location | Cost | Notes |
+|----------|------|-------|
+| **Ortisei (Val Gardena)** | ~€10/day | Parking Isgla: €0.70/30 min, max €10/day. Most parking is paid |
+| **Selva di Val Gardena** | €5-10/day | Can be tight at gondola stations |
+| **Corvara (Alta Badia)** | €5-10/day | Free in some outer areas |
+| **Cortina d'Ampezzo** | €5-15/day | Central parking is expensive. Outer lots cheaper |
+| **Canazei (Val di Fassa)** | €5-10/day | Lift base lots available |
+
+**14-day parking estimate:** If parking daily, ~€70-140. If relying on ski buses most days and only driving occasionally, ~€30-50.
+
+**Tip:** Many hotels/apartments include parking (sometimes garage parking). Prioritize accommodation with included parking to save €70-140.
+
+### Winter Driving Requirements
+
+**Mandatory (Nov 15 - Apr 15):**
+- Winter tires (M+S or 3PMSF marked, min 1.6mm tread) OR snow chains carried in the vehicle
+- Even with winter tires, chains may be required on certain mountain roads (indicated by blue chain sign)
+- Rental companies typically provide chains or winter tires at no extra cost -- VERIFY when booking
+
+**Vehicle recommendations:**
+- Compact SUV or AWD is ideal but not essential
+- Manual transmission gives better engine braking on descents
+- Any modern car with winter tires handles main roads fine
+- The Autostrada del Brennero (A22) is flat motorway; valley roads are well-maintained
+- High passes (Pordoi, Falzarego, Sella) can be challenging in heavy snow -- possible closures
+
+**Driving difficulty: MODERATE**
+- Main roads and motorways: Easy. Well-maintained and cleared regularly
+- Valley roads (Val Gardena, Alta Badia): Moderate. Winding but well-cleared
+- High mountain passes: Can be difficult in heavy snowfall. Pordoi and Falzarego can close
+- Overall: "Not that hard -- roads are cleaned very well even when snowing" (common traveler feedback)
+
+### Advantages of Having a Car
+
+1. **Multi-valley freedom:** Drive between Val Gardena, Alta Badia, Val di Fassa, Cortina, and Kronplatz without bus timetables
+2. **Early starts / late finishes:** Not dependent on bus schedules
+3. **Grocery runs:** Access to larger supermarkets in Bolzano, Bressanone, Brunico
+4. **Rest day exploration:** Visit towns, lakes, museums without transport constraints
+5. **Gear transport:** Ski/snowboard equipment, boots, bags -- no lugging on buses
+6. **Airport transfer savings:** Round-trip transfer would cost €300-500+ per person; driving yourself is much cheaper for 1-2 people
+7. **Inter-valley flexibility:** The thing that makes the Dolomites special is exploring multiple valleys; a car makes this dramatically easier
+
+---
+
+## Public Transport (No Car)
+
+### Free Ski Bus Systems
+
+Each valley operates its own ski bus network during winter season (roughly Dec - early Apr):
+
+| Valley/Area | Ski Bus | Frequency | Free? | Coverage |
+|-------------|---------|-----------|-------|----------|
+| **Val Gardena** | Val Gardena Ski Bus | Every 10-20 min | Yes (with Guest Pass/Mobil Card) | Ortisei, Santa Cristina, Selva + all lift bases |
+| **Alta Badia** | Alta Badia Ski Bus | Every 15-20 min | Yes (with Guest Pass) | Corvara, Colfosco, La Villa, San Cassiano, Badia |
+| **Val di Fassa** | Ski Bus Val di Fassa | Regular service | Free/discounted with ski pass | Canazei, Campitello, Vigo, Moena, Pozza |
+| **Cortina d'Ampezzo** | Cortina Ski Bus | Regular service | Free with ski pass | Central Cortina + lift bases |
+| **Kronplatz/Plan de Corones** | Local bus | Regular | Yes (with Guest Pass) | Brunico + surrounding villages |
+| **3 Zinnen/Tre Cime** | Ski shuttle | Regular | Yes (with Guest Pass) | San Candido, Sesto, Dobbiaco |
+
+**Key point:** Within any single valley, ski buses are frequent, free (with Guest Pass), and eliminate the need for a car entirely.
+
+### The Sudtirol Guest Pass
+
+**What it is:** A free digital transport pass issued by participating accommodations in South Tyrol (Alto Adige). Covers your entire stay.
+
+**What it covers:**
+- All regional buses (SAD)
+- City buses
+- Ski buses
+- Regional trains (R, RV, RE) including Bolzano-Merano and Fortezza-Brunico-San Candido lines
+- Selected cable cars (Renon/Ritten, Colle/Kohlern, etc.)
+- Mendola funicular, Renon light railway
+
+**What it does NOT cover:**
+- Long-distance trains (EC, Railjet, Frecciarossa, Italo)
+- Cross-border routes (Brenner-Innsbruck, San Candido-Lienz)
+- Nightliners
+- Some seasonal shuttle services
+
+**How to get it:** Automatically issued by participating hotels/apartments at check-in. Digital pass sent via email. Valid from 00:00 arrival day to 23:59 departure day. Personalized and non-transferable.
+
+**Important:** Applies only to South Tyrol (Alto Adige) accommodations. If staying in Cortina (Veneto) or Val di Fassa (Trentino), different regional passes apply.
+
+**Alternative:** If your accommodation does not participate, buy a South Tyrol Mobilcard: 1-day, 3-day, or 7-day unlimited transport throughout South Tyrol.
+
+### Train Connections
+
+| Route | Frequency | Duration | Notes |
+|-------|-----------|----------|-------|
+| Bolzano --> Merano | Frequent (every 30 min) | ~40 min | Val Venosta line |
+| Bolzano --> Fortezza (Franzensfeste) | Frequent | ~30 min | Main Brenner line |
+| Fortezza --> Brunico (Bruneck) | Every 30-60 min | ~45 min | Val Pusteria line. Currently bus replacement on some sections |
+| Fortezza --> San Candido | Hourly | ~1.5 hrs | Via Brunico |
+| Bolzano --> Bressanone (Brixen) | Frequent | ~25 min | Main line |
+| Bolzano --> Trento | Frequent | ~40 min | Southbound mainline |
+| Verona --> Bolzano | Multiple daily | ~1.5 hrs | Trenitalia direct |
+| Innsbruck --> Bolzano | Multiple daily | ~2 hrs | Via Brenner Pass |
+
+**Key station for the Dolomites:** Fortezza/Franzensfeste is where the mainline (Innsbruck-Bolzano) meets the Val Pusteria branch line (to Brunico, San Candido, and on to Lienz in Austria).
+
+### SAD Bus Services (South Tyrol)
+
+SAD Mobilita operates the public bus network across South Tyrol with 100+ routes.
+
+**Key routes for skiers:**
+- **Line 350:** Bolzano --> Ortisei (Val Gardena), ~50 min
+- **Line 360:** Selva --> Sella Pass connections
+- **Line 460:** Brunico --> Corvara (Alta Badia), ~1 hr
+- **Line 473:** Val Gardena --> Colfosco/Corvara (Alta Badia), via Plan de Gralba. Key inter-valley connection
+- **Line 445:** Cortina --> Dobbiaco (connecting to trains)
+
+**Note on inter-valley travel:** In winter, there are NO direct buses connecting Val Gardena with Alta Badia via the main road. You must either:
+- Take Bus 473 via Plan de Gralba (when running)
+- Or transit through Bressanone and Brunico (trains and buses), which takes 2+ hours
+
+### Inter-Valley Connectivity (The Critical Question)
+
+**How well connected are the different valleys by public transport?**
+
+| Connection | Feasibility | Method | Time |
+|------------|-------------|--------|------|
+| Within Val Gardena | Excellent | Free ski bus every 10-20 min | 10-30 min |
+| Within Alta Badia | Excellent | Free ski bus | 10-20 min |
+| Val Gardena <--> Alta Badia | Possible | Bus 473 (or ski over via Sella Ronda lifts) | ~1 hr by bus |
+| Val Gardena <--> Bolzano | Good | SAD Bus 350 | 50 min |
+| Bolzano <--> Cortina | Difficult | Bus to Dobbiaco + bus to Cortina | 3+ hrs, multiple changes |
+| Val Gardena <--> Cortina | Very Difficult | No direct connection. Via Bolzano/Bressanone/Brunico/Dobbiaco | 4+ hrs |
+| Val Gardena <--> Val di Fassa | Possible in ski season | Via Sella Pass road (seasonal bus) or ski lifts (Sella Ronda) | Varies |
+| Kronplatz <--> Alta Badia | Good | Ski bus connection | ~30-45 min |
+
+**The hard truth:** Getting between the South Tyrol valleys (Val Gardena, Alta Badia) and Cortina (in Veneto) by public transport is a slog -- 4+ hours with multiple transfers. These are served by completely different regional transport authorities (SAD in South Tyrol vs. Dolomiti Bus in Veneto).
+
+### Can You Explore the Whole Dolomiti Superski Area Without a Car?
+
+**Short answer: Not realistically.**
+
+The 12 ski areas of Dolomiti Superski span ~29 x 28 miles. Without a car:
+- You can thoroughly enjoy 2-3 adjacent valleys (e.g., Val Gardena + Alta Badia + Arabba via Sella Ronda lifts)
+- Getting to outlying areas like Cortina, Kronplatz, 3 Zinnen, or Alpe di Siusi requires long bus/train journeys
+- Changing valleys for a day trip (e.g., Val Gardena --> Cortina) would consume 8+ hours in transit alone
+
+**What you CAN do without a car:**
+- Ski the entire Sella Ronda circuit (Val Gardena + Alta Badia + Val di Fassa + Arabba-Marmolada) -- these are LIFT-LINKED
+- Explore your home valley thoroughly using free ski buses
+- Take occasional day trips to adjacent areas (e.g., Val Gardena to Kronplatz via bus/train -- doable but takes ~2 hrs each way)
+
+**Best base without a car:** Val Gardena (Ortisei or Selva). Free Mobil Card covers all local transport, central location on Sella Ronda, SAD bus to Bolzano in 50 min.
+
+### Shuttle Services from Airports
+
+| Service | Route | Schedule | Cost | Book |
+|---------|-------|----------|------|------|
+| **Cortina Express** | Venice VCE --> Cortina | 5x daily (Dec-Apr) | €15-30 one-way | cortinaexpress.it |
+| **FlySki Shuttle** | Verona/Venice/Bergamo/Milan --> Val di Fassa | Weekends (Dec-Apr) | €46-50 one-way | flyskishuttle.com |
+| **Auto Dul** | Innsbruck --> Val Gardena | On request | Quote-based | autodul.com |
+| **Taxi Raimund** | Venice/Innsbruck/Munich --> Alta Badia/Val Gardena | On request | €160-280+ per vehicle | taxiraimund.it |
+| **Alps2Alps** | Various airports --> Dolomites resorts | On request | Quote-based | alps2alps.com |
+
+**FlySki Shuttle discounts:**
+- 20% off if you book accommodation on fassa.com, visittrentino.it, or dolomitisuperski.com
+- 10% repeater discount if you used FlySki in the last 2 years
+- Must book by Thursday midday before travel weekend
+
+### FlixBus
+
+| Route | Frequency | Duration | Cost |
+|-------|-----------|----------|------|
+| Munich --> Bolzano | 10x daily | 3.5-4 hrs | €18-40 |
+| Venice --> Bolzano | 3x daily | 4-4.5 hrs | €15-28 |
+| Milan --> Bolzano | Multiple | 4-5 hrs | €10-25 |
+| Verona --> Bolzano | Multiple | ~2 hrs | €10-15 |
+
+FlixBus is the budget champion but only gets you to Bolzano. From there you still need SAD bus/train to reach the ski valleys (covered by Guest Pass if staying in South Tyrol).
+
+---
+
+## Cost Comparison: Car vs No Car (14-Day Trip)
+
+### Option A: With Rental Car (Venice Airport)
+
+| Item | Cost (EUR) | Notes |
+|------|-----------|-------|
+| Car rental -- 14 days, economy | €250-400 | Venice airport, manual, January rates |
+| Full insurance/CDW waiver | €210-350 | Recommended for mountain driving |
+| Motorway tolls (round trip) | €35-45 | A4 + A22 Venice-Bolzano return |
+| Fuel | €70-90 | ~600-800 km total |
+| Parking (14 days) | €30-140 | €0 if hotel has free parking; up to €10/day otherwise |
+| **Total transport** | **€595-1,025** | |
+
+### Option B: No Car, Public Transport (Venice Airport)
+
+| Item | Cost (EUR) | Notes |
+|------|-----------|-------|
+| Cortina Express OR FlixBus to Bolzano (return) | €30-60 | Budget bus options |
+| SAD bus / train Bolzano to valley (return) | €0-20 | Free with Guest Pass if staying in South Tyrol |
+| Sudtirol Guest Pass | €0 | Free from participating accommodation |
+| Local ski buses | €0 | Free with Guest Pass / ski pass |
+| Occasional taxi / inter-valley day trip | €50-100 | For trips beyond local bus network |
+| **Total transport** | **€80-180** | |
+
+### Option C: No Car, Premium Shuttle (Venice Airport)
+
+| Item | Cost (EUR) | Notes |
+|------|-----------|-------|
+| FlySki Shuttle or Cortina Express (return) | €60-100 | Direct to resort |
+| Local transport | €0 | Guest Pass |
+| Occasional taxi/private transfer for day trips | €100-200 | E.g., Val Gardena to Cortina for a day |
+| **Total transport** | **€160-300** | |
+
+### Comparison Summary
+
+| | Car | Public Transport | Premium Shuttle |
+|--|-----|-------------------|-----------------|
+| **Cost** | €595-1,025 | €80-180 | €160-300 |
+| **Flexibility** | Maximum | Limited to schedules | Moderate |
+| **Multi-valley access** | Easy | Difficult beyond home valley | Moderate |
+| **Stress** | Winter driving, parking, tolls | Timetable dependency | Low |
+| **Gear transport** | Easy | Challenging | Easy (on shuttle) |
+
+**The car adds ~€400-850 compared to public transport.** Much larger premium than Les Trois Vallees (which was only ~€540 more for the car option) because the insurance costs are higher for mountain driving and distances are greater.
+
+---
+
+## Key Question: Is a Car MORE Necessary in the Dolomites Than in Les Trois Vallees?
+
+**Yes, significantly.**
+
+| Factor | Les Trois Vallees | Dolomites |
+|--------|-------------------|-----------|
+| **Ski area structure** | 3 valleys, ALL lift-linked into one seamless domain (600 km) | 12 ski areas across ~29 x 28 miles. Only the Sella Ronda core (Val Gardena + Alta Badia + Val di Fassa + Arabba) is lift-linked |
+| **Getting to slopes from base** | Single gondola (e.g., Olympe from Brides) accesses entire domain | Ski bus to nearest lift, but you're limited to your valley's lifts unless you ski the Sella Ronda or drive |
+| **Exploring the full pass area** | Possible on skis alone. Traverse all 3 valleys in one day | Impossible without a car. Outlying areas (Cortina, Kronplatz, 3 Zinnen, Civetta) require long bus/train journeys |
+| **Free local transport** | Free shuttles within each resort village | Free ski buses within each valley (Guest Pass). Inter-valley is the problem |
+| **Inter-valley travel** | Ski over the ridgeline. No bus needed | Bus Line 473, or 2-4+ hour bus/train combos |
+| **Airport transfer (no car)** | Ben's Bus: Geneva to Brides, €55 one-way, direct | FlixBus/Cortina Express to Bolzano/Cortina, then local bus to valley -- 2-3 stages |
+| **Grocery/town access** | Brides has small shops; Moutiers 10 min by car/bus | Similar -- small village shops. Bolzano/Bressanone for big shops are 30-60 min away |
+
+### The Core Difference
+
+In Les Trois Vallees, once you are in ANY village (Brides, Meribel, Val Thorens, Courchevel, Les Menuires), you can ski the ENTIRE 600 km domain on lifts alone. A car adds convenience but is genuinely optional.
+
+In the Dolomites, the Dolomiti Superski pass covers 1,200 km of piste across 12 separate ski areas, but you can only ski ~450 km of it (the Sella Ronda core) without ground transport. To access the remaining ~750 km (Cortina, Kronplatz, 3 Zinnen, Civetta, San Pellegrino, etc.), you need a car or lengthy bus journeys.
+
+**Verdict:**
+- **If you plan to stay in one valley and ski the Sella Ronda:** A car is nice-to-have but not necessary. Public transport works fine.
+- **If you want to explore the full Dolomiti Superski area across multiple valleys over 14 days:** A car is strongly recommended. It transforms the trip from "ski one area with occasional frustrating bus excursions" to "ski safari across the most beautiful mountains in the world."
+
+### Recommendation for a 14-Day Trip
+
+For a 2-week trip, a car is highly worth the extra ~€500-800 because:
+1. You have enough time to explore 5-6 different valleys
+2. The per-day cost of the car becomes very reasonable (~€40-55/day all-in)
+3. You avoid the 4+ hour bus journeys that would eat into valuable ski days
+4. Rest days become opportunities for exploring towns, not being stuck in one village
+5. The Dolomites' magic is in the VARIETY across valleys -- a car unlocks this
+
+**Optimal setup:** Fly into Venice or Verona. Rent an economy car. Base yourself in Val Gardena or Alta Badia (central location). Drive to Cortina, Kronplatz, 3 Zinnen, etc. on different days. Use free ski buses on days you're staying in your home valley.
+
+---
+
+## Sources
+
+- [Dolomiti Superski -- Getting Here](https://www.dolomitisuperski.com/en/experience-the-dolomites/journey)
+- [Powderhounds -- Dolomites Getting There](https://www.powderhounds.com/Europe/Italy/Dolomites/Getting-There.aspx)
+- [Cortina Express](https://www.cortinaexpress.it/en/)
+- [FlySki Shuttle](https://www.flyskishuttle.com/en/)
+- [Sudtirolmobil -- Public Transport](https://www.suedtirolmobil.info/en/)
+- [Sudtirol Guest Pass](https://www.suedtirol.info/en/en/information/suedtirol-guest-pass)
+- [Val Gardena Mobility](https://www.val-gardena.com/en/winter/mobility/)
+- [Val di Fassa Ski Bus](https://www.fassa.com/en/ski-bus-service)
+- [Austria Vignette 2026 Prices](https://www.tolls.eu/austria)
+- [Autobrennero Tolls](https://www.autobrennero.it/en/on-the-road/toll/)
+- [Italy Fuel Prices](https://www.fuel-prices.eu/Italy(IT)/)
+- [FlixBus Munich-Bolzano](https://www.omio.com/buses/munich/bolzano)
+- [Mom In Italy -- Dolomites Without a Car](https://mominitaly.com/visiting-the-dolomites-without-a-car/)
+- [Moon Honey Travel -- Dolomites Skiing](https://www.moonhoneytravel.com/dolomites-skiing/)
+- [SnowHeads -- Dolomite Superski vs 3 Valleys](https://snowheads.com/ski-forum/viewtopic.php?t=160306)
+- [Les 3 Vallees -- Without a Car](https://www.les3vallees.com/en/guide/in-resort-without-a-car)


### PR DESCRIPTION
## Summary

This PR adds extensive research and planning documentation for a potential 2-week ski trip to Dolomiti Superski in the Italian Alps, including detailed cost analysis, accommodation research, transport options, and a head-to-head comparison with the Trois Vallées alternative.

## Changes

- **research/dolomiti-superski-research.md** (675 lines): Comprehensive ski trip research covering:
  - Lift pass pricing and discount strategies for the 2025-2026 season
  - Complete ski area overview with 12 zones, statistics, and the Sella Ronda circuit
  - Detailed accommodation pricing by village (Val Gardena, Alta Badia, Val di Fassa, Kronplatz, Arabba)
  - Italian school holiday dates (Settimana Bianca) and impact on trip timing
  - Ski rental pricing and seasonal deals
  - Tourist tax breakdown by region
  - Best base village analysis with pros/cons

- **research/dolomiti-superski-transport.md** (441 lines): Transport and logistics research including:
  - Gateway airport comparison (Innsbruck, Verona, Venice, Munich, Bolzano)
  - Flight routing options from Manila with estimated costs
  - Airport transfer options and costs by origin
  - Car rental pricing, motorway tolls, fuel costs, and parking
  - Winter driving requirements and difficulty assessment
  - Public transport alternatives (ski buses, trains, FlixBus)
  - Südtirol Guest Pass and regional transport coverage

- **entities/trips/2027-01-dolomiti-superski.md** (436 lines): Trip planning document with:
  - Overview and key research links
  - Head-to-head comparison with Trois Vallées (ski area size, terrain, vibe, structure)
  - Three budget scenarios with detailed cost breakdowns (with car, without car, season pass)
  - Full price comparison vs Trois Vallées for both car and no-car options
  - Accommodation recommendations by village with specific properties and pricing
  - Analysis of car vs public transport trade-offs
  - Ski zone accessibility matrix

## Notable Details

- Research is based on 2025-2026 season data (2026-2027 pricing not yet available)
- Accommodation pricing verified across multiple sources with estimates clearly marked
- Budget analysis includes all major cost categories: flights, transport, lodging, lift passes, equipment, food, taxes
- Identifies Canazei (Val di Fassa) as optimal budget base due to 20-30% lower costs and lower tourist tax
- Quantifies the trade-off: Dolomiti Superski is only €306 more expensive than Trois Vallées with a car, but offers 2x the piste km
- Highlights that without a car, Dolomiti access is limited to ~490 km (Sella Ronda) vs full 1,246 km pass coverage

https://claude.ai/code/session_012snQdB9Jm7TZZ3x8s4eDuV