### PR TITLE
Document payment instance setup and Digital Wallet architecture

### DIFF
--- a/entities/meetings/2026-02-19-payment-instance-setup.md
+++ b/entities/meetings/2026-02-19-payment-instance-setup.md
@@ -1,0 +1,105 @@
+---
+type: meeting
+date: 2026-02-19
+attendees: [[Carlos]]
+projects: [[Digital Wallet]], [[Pod Play SEA]]
+businesses: [[Pod Play]], [[Magpie]]
+tags: [payment, stripe, credits, settlement, strategy]
+---
+
+# Payment Instance Setup & Digital Wallet Architecture
+
+Discussion covering the payment instance given to [[Marcelo]], Stripe integration details, money flow and settlement design, and the credits vs direct booking architecture.
+
+## Key Topics Discussed
+
+### 1. Payment Instance for Marcelo
+
+- [[Marcelo]] was given an instance of the payment platform to start documenting
+- Marcelo is currently acting as "Cosmos" (the merchant/platform role) in the payment flow
+- There were complaints about the initial payment UI — went through iterations
+- Currently on the **3rd iteration** of customization
+- Using **Stripe Payment Elements** (what Stripe calls "Payment Element") — not the standard checkout, a custom-built experience
+- Assessment: the customization is a perfectly fine experience
+
+### 2. Money Flow & Settlement
+
+- Most of the money belongs to the **court owners** — e.g., on a 100-peso reservation, Pod Play takes ~10–15 pesos, court owner gets ~85
+- Settlement options being offered to merchants:
+  - **View balance**: Merchants can see what's settled in their account
+  - **Manual withdrawal**: "Give me a bank account, we settle it"
+  - **Auto-frequency**: Set up recurring settlement (e.g., daily) to merchant's bank account
+- Reconciliation must complete before funds are available
+- [[Kim]] is the key person on settlement flow design
+
+### 3. Credits vs Direct Booking Debate
+
+- Current instruction from the venue partners: **use the credit system** (users buy credits, then book with credits)
+- Alternative: direct booking (credit card → booking, no intermediate credit step)
+- The venue partners themselves created confusion by going back and forth on this
+- Team's position: **agnostic** — told them "tell us what Skype does, we'll copy it and give you the exact same"
+- Architecture is clean and flexible enough to support either model
+- Current state: credit system active, but could switch to direct booking easily
+
+### 4. What Credits Enable (Future Vision)
+
+Credits aren't just for court bookings — the system can handle:
+- **Court bookings** (current)
+- **Coaching sessions** (expected to be the #1 requested add-on — every venue needs coaches)
+- **Merchandise purchases**
+- **Food & beverage**
+- **Any product the merchant wants to add**
+
+This is the path to the full [[Digital Wallet]] vision — Pod Play becomes a payment platform.
+
+### 5. Cost Advantage of Owning the Wallet
+
+- Direct credit card processing: ~3.5% per transaction
+- Wallet-to-wallet (credits already loaded): ~1.5% per transaction
+- **If credits are pre-loaded**, subsequent purchases cost less to process
+- Strategic value: owning the wallet means not giving a split to external payment partners for every transaction
+- Counter-argument: you still have acquisition cost on the initial credit load
+
+### 6. Cross-Venue vs Venue-Locked Credits
+
+- Open question: are credits locked to one venue or usable across any Pod Play facility?
+- The team wants **cross-venue credits** (the [[Digital Wallet]] vision)
+- If credits are venue-locked, you must credit first before visiting a new venue
+- Need to confirm with venue partners how they want this to work
+- **Action**: Ask [[Kim]] and the padel partners for a definitive answer
+
+### 7. Merchant Dashboard & Branding
+
+- Discussion about branding at three levels: **merchant**, **user**, and **Cosmos** (platform)
+- Primary user interface belongs to the venue/players
+- Merchants (court owners) may have their own permission-based dashboard
+- The Cosmos dashboard feeds information into the merchant view
+- Question: how does the Pod Play guide coexist with the credit/score system? Answer: it's a convergence — they're complementary, not competing
+
+### 8. Market Considerations
+
+- Singapore and Malaysia: small markets
+- Indonesia: they don't have to deal with us (separate arrangement)
+- Venue partners want to show investors and listing prospects strong numbers — "give us billions of dollars"
+- Need to document capabilities in a **pitch deck** showing what the system can do
+
+### 9. NJ Trip & Remaining Questions
+
+- The [[2026-03 NJ PodPlay Training]] trip should resolve almost all remaining questions
+- Need to send all open questions ahead of time so the trip is productive
+
+## Action Items
+
+- [ ] Confirm with [[Kim]] and padel partners: venue-locked vs cross-venue credits
+- [ ] Document all open payment/architecture questions and send before NJ trip
+- [ ] Create a small deck showing payment capabilities for investor conversations
+- [ ] Define what merchants can add as products beyond court bookings (coaching, merch, food)
+- [ ] Decide on settlement frequency defaults for merchant onboarding
+- [ ] Clarify the Cosmos role/branding — is it a separate entity or just a layer?
+
+## Open Questions
+
+- How do cross-venue credits work with settlement to individual court owners?
+- What is the exact split structure with [[Magpie]] for wallet transactions?
+- How does the credit/booking system integrate with the venue's existing operations?
+- Should we build the merchant product catalog now or wait for demand?

--- a/entities/people/kim.md
+++ b/entities/people/kim.md
@@ -1,0 +1,16 @@
+---
+type: person
+name: Kim
+related: [[Digital Wallet]], [[Pod Play SEA]]
+tags: [payment, operations, padel]
+---
+
+# Kim
+
+Involved in payment and settlement discussions for [[Pod Play SEA]] and the [[Digital Wallet]] project.
+
+## Role
+
+- Working on settlement and money flow design — how court owners get paid
+- Coordinating with the padel venue operators on payment requirements
+- Key stakeholder in deciding credit system vs direct booking approach

--- a/entities/people/marcelo.md
+++ b/entities/people/marcelo.md
@@ -1,0 +1,18 @@
+---
+type: person
+name: Marcelo
+businesses: [[Magpie]]
+locations: [[Philippines]]
+related: [[Digital Wallet]], [[Pod Play SEA]]
+tags: [payment, technical, magpie]
+---
+
+# Marcelo
+
+Technical contact at [[Magpie]], working on the payment instance setup for [[Pod Play SEA]].
+
+## Role
+
+- Given a payment instance to document and configure
+- Currently acting as "Cosmos" (the merchant/platform role) in the payment flow for testing and development
+- Key point of contact for payment integration work alongside [[Kim]]

--- a/entities/projects/digital-wallet.md
+++ b/entities/projects/digital-wallet.md
@@ -2,7 +2,7 @@
 type: project
 name: Digital Wallet
 status: active
-people: [[Dominic]]
+people: [[Dominic]], [[Marcelo]], [[Kim]]
 places: [[Philippines]]
 related: [[Pod Play]], [[Magpie]], [[Pod Play SEA]]
 tags: [fintech, wallet, payment, strategy]
@@ -32,8 +32,30 @@ Digital wallet / stored-value platform built on top of [[Pod Play]]'s booking sy
 - Negotiation strategy: push for 80/20 split, expect to settle at ~50/50
 - Need to structure term sheet for wallet partnership
 
+## Payment Implementation (as of 2026-02-19)
+
+- [[Marcelo]] given a payment instance, currently acting as "Cosmos" (merchant/platform role) for testing
+- Using **Stripe Payment Elements** — 3rd iteration after UI feedback, custom-built experience
+- Money flow: on a 100-peso reservation, ~10–15 pesos to Pod Play, ~85 to court owner
+- Settlement options for merchants: manual withdrawal, or auto-daily settlement to bank account
+- Reconciliation required before funds become available
+
+### Credits vs Direct Booking
+
+- Architecture supports both models — currently running credit system per venue partner request
+- Credits enable: court bookings, coaching sessions, merchandise, food & beverage, any merchant product
+- Cost advantage: wallet-to-wallet ~1.5% vs direct credit card ~3.5% per transaction
+- Open question: venue-locked vs cross-venue credits — need confirmation from [[Kim]] and padel partners
+
+### Merchant Product Catalog (Future)
+
+- Coaching sessions expected to be the #1 requested add-on
+- Merchants should be able to add their own products beyond court bookings
+- Path to full payment platform — Pod Play handles all money movement for the venue ecosystem
+
 ## Expansion
 
 - Magpie's license is Philippines-only
 - For other Asian markets, Magpie can provide technology while local partners handle regulation
 - Singapore EDB engagement may support regional wallet infrastructure
+- Singapore and Malaysia are small markets; Indonesia has separate arrangements


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation of the payment instance setup for Pod Play SEA and updates the Digital Wallet project with implementation details from a February 19, 2026 meeting with Carlos.

## Key Changes

- **New meeting notes** (`entities/meetings/2026-02-19-payment-instance-setup.md`): Detailed discussion covering:
  - Payment instance given to Marcelo for testing and documentation
  - Stripe Payment Elements integration (3rd iteration of UI customization)
  - Money flow and settlement design (court owners receive ~85% of booking value)
  - Credits vs direct booking architecture debate and current stance
  - Cross-venue vs venue-locked credits as an open question
  - Merchant dashboard and branding considerations
  - Action items and open questions for the upcoming NJ training trip

- **Updated Digital Wallet project** (`entities/projects/digital-wallet.md`):
  - Added Marcelo and Kim to project team
  - New "Payment Implementation" section documenting current state as of Feb 19
  - Details on Stripe integration, settlement options, and cost advantages of wallet-to-wallet transactions (~1.5% vs ~3.5% for direct card)
  - Clarified credits enable beyond court bookings (coaching, merchandise, food & beverage)
  - Added market expansion notes for Singapore, Malaysia, and Indonesia

- **New person entities**:
  - `entities/people/marcelo.md`: Technical contact at Magpie, acting as "Cosmos" (merchant/platform role) for payment testing
  - `entities/people/kim.md`: Settlement and money flow design lead, coordinating with venue operators

## Notable Details

- Architecture is flexible enough to support both credit-based and direct booking models
- Key strategic advantage: owning the wallet reduces per-transaction costs and eliminates external payment partner splits
- Several action items identified for pre-NJ trip preparation, including confirmation on credit scope (venue-locked vs cross-venue)

https://claude.ai/code/session_0131NuZ1ZgQkC3j3DMjKV9nb