### PR TITLE
Add comprehensive NJ trip question brainstorm document

### DIFF
--- a/research/podplay-nj-trip-question-brainstorm.md
+++ b/research/podplay-nj-trip-question-brainstorm.md
@@ -1,0 +1,248 @@
+---
+date: 2026-02-19
+related: [[Pod Play]], [[Pod Play SEA]], [[Magpie]], [[Digital Wallet]], [[2026-03 NJ PodPlay Training]]
+tags: [podplay, brainstorm, questions, training-prep, pre-trip]
+---
+
+# Pod Play NJ Trip — Complete Question Brainstorm
+
+Everything we need to know before, during, and after the NJ training trip (March 2–10). Organized by category. The goal: walk in with zero ambiguity, leave with zero open questions.
+
+---
+
+## Current Understanding (What We Know)
+
+### Revenue & Business
+- 70/30 upcharge split (us/Pod Play) above $50 base price
+- 17% Philippines withholding tax
+- SEA distribution rights confirmed
+- Franchise model: $100K country fee, $28K per store
+
+### Payment
+- Magpie handles GCash + credit card in Philippines (working, test booking done)
+- US uses Stripe — won't work in Asia
+- Magpie developing digital wallet for free (sees the platform potential)
+- Money flow: ~10–15 pesos to Pod Play per 100-peso reservation, ~85 to court owner
+- Settlement: manual withdrawal or auto-frequency to merchant bank account
+- Credit system active per venue partner request; architecture supports direct booking too
+- Wallet-to-wallet ~1.5% vs direct card ~3.5% per transaction
+
+### Technical Architecture
+- Hybrid: cloud backend (booking, accounts, payments) + on-premises per venue (replay stack)
+- On-premises: Unifi network stack → Mac Mini (Node.js replay service) → cameras → iPads → Apple TVs
+- Communication: Mac Mini ↔ PodPlay servers via port 4000 over internet
+- DDNS via FreeDNS (podplaydns.com), cron job updates every 5 min
+- Replay is local (Mac Mini → Apple TV on same VLAN) — no latency concern for playback
+- Config guide v1 exists (Stan Wu, Sept 2024)
+
+### What's In Progress
+- Marcelo has payment instance, testing as "Cosmos" (merchant role)
+- 3rd iteration of Stripe Payment Elements UI
+- Tela Park (Las Piñas) identified as first venue — needs site survey
+- Cross-venue vs venue-locked credits: unresolved, need Kim's input
+
+---
+
+## What's NOT Clear — The Gaps
+
+### A. Venue Discovery & the "Spotlight" Question
+
+This is the biggest UX gap. We've seen the backend and payment side, but how does the **user-facing experience** actually work?
+
+1. **How do venues appear in the Pod Play app?** Is there a map view? A list? Search by location?
+2. **What is "Spotlight"?** Is this a feature name? A promotional placement? A way venues get featured?
+3. **Region locking**: If I'm in the Philippines, do I see US venues in the app? Or is it filtered by region/country?
+4. **Venue visibility controls**: Can a venue be hidden, private, invite-only, or soft-launched before going public?
+5. **How does a brand-new venue appear to users?** Automatically after setup? After some approval process? After a certain configuration threshold?
+6. **Venue metadata**: What information does a venue listing show? (Photos, hours, pricing, court types, amenities, ratings?)
+7. **Multi-sport**: The app started with ping pong (Ping Pod). Now padel is in the picture. How does the app handle different sports at different venues? Is there sport-specific filtering?
+8. **Venue search radius**: How does the app determine which venues to show? GPS-based? City-based? Country-based?
+9. **Can venue owners control their listing?** Edit description, photos, hours, pricing? Or is that all admin-controlled?
+10. **Is there a venue approval workflow?** Who decides a venue goes live? Pod Play HQ? The distributor (us)?
+
+### B. Payment Integration (Technical Deep Dive)
+
+We know Magpie works for payments, but we don't know how deep Stripe is wired into Pod Play's codebase.
+
+11. **Is Stripe hardcoded throughout the codebase, or is there a payment provider abstraction layer?**
+12. **What specific Stripe APIs does Pod Play call?** (Charges, Payment Intents, Customers, Subscriptions, Refunds?)
+13. **What Stripe webhook events does Pod Play listen for?** (payment_intent.succeeded, charge.refunded, etc.)
+14. **Can the admin dashboard's "Stripe Account ID" field be repurposed for a different provider per venue?**
+15. **Is payment configuration per-venue or per-region?** Can Venue A use Stripe while Venue B uses Magpie?
+16. **What's the payment data model?** What gets stored in the database when a payment happens? How does it tie to bookings?
+17. **Does the Pod Play app handle payment UI, or does it redirect to Stripe's hosted checkout?** (We know Marcelo is using Stripe Payment Elements — is that the standard or custom?)
+18. **What happens when a payment fails?** Retry logic? User notification? Booking held or released?
+19. **Refund flow**: What does Pod Play expect from the payment provider for refunds? (Magpie has the one-way e-wallet limitation)
+20. **Does the credit/wallet system bypass the payment gateway for subsequent transactions?** Or does every credit spend still hit Stripe/Magpie?
+21. **What would it actually take to add a second payment provider?** Days? Weeks? Months? Is there precedent?
+
+### C. Merchant / Venue Owner Experience
+
+We understand the player/user side somewhat, but the merchant side is vague.
+
+22. **What does merchant onboarding look like end-to-end?** From signing up to first booking — what are all the steps?
+23. **What does the merchant dashboard show?** Revenue, bookings, utilization, customer data?
+24. **Can merchants set their own pricing?** Or is pricing controlled by the admin/distributor?
+25. **Can merchants set their own hours of operation?** Blackout dates? Holiday schedules?
+26. **Can merchants add their own products?** (Coaching, merch, food — per the digital wallet vision)
+27. **How does a merchant get paid?** What's the payout report look like? How do they reconcile?
+28. **Merchant permissions**: What can a merchant do vs. what can only a distributor/admin do?
+29. **Multi-location merchants**: Can one merchant own multiple venues under one account?
+30. **Merchant branding**: Can each venue have its own branding in the app, or is it all Pod Play branded?
+31. **Merchant notifications**: Do merchants get notified of new bookings, cancellations, issues?
+32. **Staff accounts**: Can a venue have multiple staff logins with different permission levels?
+
+### D. Setup & Configuration — Philippines vs US Differences
+
+The config guide is US-specific. What changes for Philippines?
+
+33. **PAL vs NTSC**: Does changing the camera video standard from NTSC to PAL break the replay pipeline? Does frame rate change from 30fps to 25fps? Does the Mac Mini's Node.js replay service care?
+34. **Camera region setting**: The config guide says "Region: United States" during camera setup. What happens if we select Philippines? Different firmware? Different encoding defaults?
+35. **Camera model**: What exact camera model is used? Is it available in the Philippines? Region-locked firmware?
+36. **ISP configuration for Philippines providers**: PLDT, Globe, Converge, Sky Fiber — the DMZ/port forwarding procedures will be different. Any tips from Pod Play on non-US ISPs?
+37. **Power standards**: US is 120V/60Hz, Philippines is 220V/60Hz. Do the Unifi equipment, Mac Mini, cameras, POE chargers all support 220V? Or do we need transformers?
+38. **Apple Business Manager**: Does the "Managed by Pingpod Inc" enrollment work in the Philippines? Or do we need our own Apple Business account for Asia?
+39. **Mosyle MDM**: Shared instance with US or separate instance for Asia? Who creates device groups for PH clients?
+40. **FreeDNS / DDNS**: Same podplaydns.com domain for Asian venues? Or separate DNS?
+41. **Deployment server**: The Jersey City server — can we access it remotely from the Philippines for `deploy.py`? Or do we need our own?
+42. **What does `deploy.py setup <AREA_NAME>` actually generate?** A macOS installer package? A config bundle? Can we inspect it?
+43. **Can we run our own deployment server in Asia?** Is deploy.py open-source or proprietary?
+44. **App binary**: Is the Pod Play iOS/tvOS app the same binary worldwide? Or are there regional builds?
+45. **App distribution**: Through App Store, TestFlight, or Mosyle? How does the customer ID in the Mosyle config route to the correct backend/venue?
+46. **Time zone handling**: Does the system handle Philippine time (UTC+8) correctly for bookings, schedules, and replay timestamps?
+47. **Currency**: How does the system handle Philippine pesos? Is currency configurable per venue? What about the admin dashboard — does it show pesos or always USD?
+48. **Language**: Is the app English-only? Any localization for Filipino/Tagalog? Does the merchant dashboard support other languages?
+
+### E. Deployment & Ongoing Operations
+
+After initial setup, how do we run this day-to-day?
+
+49. **Remote Mac Mini access**: After deployment, can we SSH or screen-share into the Mac Mini remotely for support?
+50. **App updates**: How do app updates get pushed? Via Mosyle MDM, App Store, or manually?
+51. **Firmware updates**: Cameras, Unifi equipment, Mac Mini OS updates — who manages these? Automatic or manual?
+52. **Monitoring & alerting**: Is there a health monitoring dashboard? Does Pod Play get notified if a venue's Mac Mini goes offline?
+53. **The health check endpoint** (`/health` on port 4000) — is there a central dashboard that shows all venues' health status? Or do we have to check each one?
+54. **Replay clip storage**: How long are clips kept? Auto-deleted? How much SSD space per court per day?
+55. **Backup & recovery**: If the Mac Mini dies, what's the recovery process? Re-run deploy.py? Or full reinstall?
+56. **Scaling**: If a venue adds more courts later, what's the process? New cameras + update config? Or full re-deployment?
+57. **Escalation path**: When something breaks, who do we contact? Stan? Chad? Is there a support SLA?
+58. **Software licensing**: What's the licensing model for Asia? Per-venue? Per-court? Flat fee?
+
+### F. User Experience & Booking Flow
+
+Understanding the end-to-end user journey.
+
+59. **User registration**: How does a new user sign up? Email, phone, social login?
+60. **Booking flow**: Step by step, what does a user do to book a court? (Open app → find venue → pick time → pay → confirm?)
+61. **Cancellation policy**: How are cancellations handled? Refund to credit? Full refund? Configurable per venue?
+62. **Waitlist**: Is there a waitlist feature for popular time slots?
+63. **Recurring bookings**: Can users book recurring weekly slots?
+64. **Group bookings**: Can a user book for a group? Split payments?
+65. **Replay sharing**: How do users share their instant replays? Social media integration? Direct link?
+66. **User profiles**: What data does a user profile contain? Booking history, replays, credits?
+67. **Push notifications**: Does the app send notifications? Booking reminders, replay ready, promotions?
+68. **Ratings/reviews**: Can users rate venues or leave reviews?
+
+### G. Cross-Venue Credits & Digital Wallet
+
+The wallet vision is big but the details are unresolved.
+
+69. **Cross-venue credits**: If user loads credits at Venue A, can they spend at Venue B? How does settlement work across different venue owners?
+70. **Credit expiration**: Do credits expire? Configurable per venue or platform-wide?
+71. **Credit transfer**: Can users transfer credits to other users?
+72. **Minimum load amount**: Is there a minimum credit purchase?
+73. **Refund to credits**: When a booking is cancelled, do credits go back to wallet automatically?
+74. **Credit visibility**: Can users see their credit balance in the app? Transaction history?
+75. **Multi-currency credits**: If a user loads pesos, can they use those credits at a Singapore venue (SGD)?
+76. **Merchant payout on credits**: When a user spends cross-venue credits, how does the merchant (court owner) get paid? Does Magpie handle the splitting?
+
+### H. Legal & Compliance
+
+77. **Data privacy**: Where is user data stored? GDPR/Philippine Data Privacy Act compliance?
+78. **Terms of service**: Does Pod Play have standard ToS for the app? Do we need Philippines-specific terms?
+79. **Payment compliance**: PCI-DSS handled by Magpie? Or do we have obligations?
+80. **Liability**: If equipment malfunctions (camera, replay, booking error), who's liable? Pod Play or distributor?
+81. **Insurance**: Is there venue insurance required? What does Pod Play recommend?
+
+### I. Hardware Specifics (Need Exact Answers)
+
+82. **Camera exact model and part number** — need to source in Philippines
+83. **Mac Mini exact specs** (year, chip, RAM, storage) — need to source locally
+84. **Samsung SSD exact model and capacity** — need to source locally
+85. **POE charger exact brand/model** — need to source locally
+86. **All Unifi gear exact models** (UDM variant, switch model, PDU model)
+87. **Kisi controller/reader model** — if applicable
+88. **Brother label maker model** — minor but for completeness
+89. **Bill of Materials (BOM) template** — get a sample for an actual past deployment
+90. **Cables and connectors** — full list of what's needed (ethernet, HDMI, SFP, power)
+
+### J. Port 4000 — What Actually Flows?
+
+This is architecturally critical for understanding latency and reliability.
+
+91. **What data flows over port 4000 between Mac Mini and Pod Play servers?**
+92. **Is it synchronous (real-time) or asynchronous (queue-based)?**
+93. **Is it just health checks and clip uploads? Or is there real-time booking data?**
+94. **What happens if the connection drops?** Does the venue still function? Can users still book? Can replays still play?
+95. **Bandwidth requirements**: How much upload bandwidth does a venue need? Per court?
+96. **Is there a fallback if port 4000 is blocked by ISP?** VPN tunnel? Alternative port?
+
+---
+
+## Questions to Send Pod Play BEFORE the Trip
+
+### Email 1: Venue & App Questions (Send Immediately)
+- Questions 1–10 (Venue discovery, Spotlight, region locking)
+- Questions 59–68 (User experience and booking flow)
+- These help us understand the product from the user/venue perspective
+
+### Email 2: Payment & Merchant Technical Questions (Send This Week)
+- Questions 11–21 (Payment abstraction, Stripe integration depth)
+- Questions 22–32 (Merchant experience)
+- Questions 69–76 (Cross-venue credits)
+- These need engineering input — give them time to prepare
+
+### Email 3: Infrastructure & Setup Questions (Send 1 Week Before Trip)
+- Questions 33–48 (Philippines vs US setup differences)
+- Questions 82–90 (Exact hardware specs)
+- Questions 91–96 (Port 4000 details)
+- These are the hands-on training questions — they should prepare materials
+
+### Things We Need to Resolve Internally (Before Trip)
+- Cross-venue vs venue-locked credits → get answer from Kim and padel partners
+- Tela Park site survey → send someone before the trip
+- Magpie term sheet → structure this so we can discuss intelligently during training
+- Pitch deck → have a draft ready showing payment capabilities
+
+---
+
+## What "Complete Picture" Looks Like
+
+When all these questions are answered, we should be able to:
+
+1. **Set up a venue from scratch in the Philippines** without any US support
+2. **Onboard a new merchant** end-to-end (sign up → configure → go live)
+3. **Process payments** through Magpie with the same reliability as Stripe in the US
+4. **Explain to any venue owner** exactly how the system works, what they get, and what it costs
+5. **Handle support issues** remotely without calling Stan or Chad
+6. **Source all hardware locally** with exact part numbers
+7. **Deploy the digital wallet** when ready, knowing exactly how credits flow through the system
+8. **Scale to multiple venues** across Philippines and eventually other SEA markets
+9. **Present to investors/partners** with a complete understanding of the technology stack
+
+---
+
+## Priority Matrix
+
+| Priority | Category | Questions | Why |
+|----------|----------|-----------|-----|
+| **CRITICAL** | Payment abstraction | 11–21 | Blocks Magpie integration — the #1 technical risk |
+| **CRITICAL** | PAL/NTSC + hardware | 33–36, 82–90 | Blocks first venue deployment |
+| **CRITICAL** | Port 4000 | 91–96 | Determines if PH latency is a problem |
+| **HIGH** | Venue discovery | 1–10 | Need to explain the product to venue partners |
+| **HIGH** | Merchant experience | 22–32 | Need to onboard Tela Park |
+| **HIGH** | Accounts & access | 38–45 | Need before first deployment |
+| **MEDIUM** | User experience | 59–68 | Important but can figure out once app is live |
+| **MEDIUM** | Digital wallet | 69–76 | Important for strategy but not day-1 blocker |
+| **MEDIUM** | Operations | 49–58 | Important but can learn during/after training |
+| **LOW** | Legal/compliance | 77–81 | Important but separate workstream |


### PR DESCRIPTION
## Summary
Add a detailed pre-trip research document for the Pod Play NJ training visit (March 2–10, 2026). This brainstorm captures all outstanding questions and knowledge gaps across product, technical, and operational domains to ensure the team walks in prepared and leaves with zero ambiguity.

## Key Changes
- **New document**: `research/podplay-nj-trip-question-brainstorm.md`
  - Comprehensive inventory of current understanding (revenue, payments, technical architecture, in-progress work)
  - 96 specific questions organized into 10 categories (venue discovery, payment integration, merchant experience, Philippines-specific setup, deployment/operations, user experience, digital wallet, legal/compliance, hardware specs, port 4000 architecture)
  - Prioritized email schedule for sending questions to Pod Play before the trip
  - Internal action items to resolve before departure
  - Priority matrix ranking questions by criticality and impact

## Notable Details
- Questions are structured to support three distinct communication phases with Pod Play (immediate, this week, 1 week before trip)
- Includes a "complete picture" checklist defining success criteria for the training
- Covers critical technical risks (payment abstraction layer, PAL/NTSC video standards, port 4000 reliability) alongside operational concerns (hardware sourcing, merchant onboarding, cross-venue credits)
- Frontmatter includes related wiki links and tags for knowledge management

https://claude.ai/code/session_018kn3ZgG1LpVHXBTEueRQTi