### PR TITLE
Enable WhatsApp channel in OpenClaw gateway

### DIFF
--- a/automations/openclaw/docs/channel-setup.md
+++ b/automations/openclaw/docs/channel-setup.md
@@ -27,12 +27,46 @@ The bot runs on Fly.io and is always listening on Telegram. You can message it a
 
 Everything you tell the bot gets persisted as entities in the monorepo.
 
-## WhatsApp (People Comms — Planned)
+## WhatsApp (People Comms — Always-On Conversation)
 
-1. Run `openclaw onboard` and select WhatsApp
-2. Scan QR code from terminal
-3. Once linked, messages route through OpenClaw
-4. **Security**: Limit who can message the bot
+WhatsApp runs via Baileys (WhatsApp Web protocol). It connects your phone number to the bot so you can message it from WhatsApp just like Telegram. OpenClaw recommends using a separate/dedicated phone number.
+
+### Pair Your Phone
+
+1. SSH into your Fly.io instance or run locally:
+   ```bash
+   fly ssh console
+   openclaw channels login --channel whatsapp
+   ```
+2. Scan the QR code from your WhatsApp app (Settings → Linked Devices → Link a Device)
+3. Credentials are stored in the persistent volume at `/app/monorepo/.openclaw/credentials/whatsapp/`
+
+### Access Control
+
+By default `dmPolicy` is set to `pairing` — unknown senders get a pairing code challenge before they can chat with the bot. To lock it down to specific numbers:
+
+```yaml
+# In gateway.yaml
+channels:
+  whatsapp:
+    dmPolicy: allowlist
+    allowFrom:
+      - "+1XXXXXXXXXX"
+```
+
+### Manage Pairing
+
+```bash
+# List pending pairing requests
+openclaw pairing list whatsapp
+
+# Approve a specific request
+openclaw pairing approve whatsapp <CODE>
+```
+
+### Use It
+
+Same as Telegram — message the bot to give updates, dump transcripts, ask questions, or log decisions. Everything gets persisted as entities in the monorepo.
 
 ## Outlook (Email Ingestion — Twice Daily)
 
@@ -85,4 +119,7 @@ fly secrets set GIT_REPO_URL=https://x-access-token:<PAT>@github.com/<user>/mono
 # When enabling Outlook
 fly secrets set OUTLOOK_EMAIL=<your-email>
 fly secrets set OUTLOOK_APP_PASSWORD=<app-password>
+
+# WhatsApp — no secrets needed, pair via QR code:
+# fly ssh console → openclaw channels login --channel whatsapp
 ```

--- a/automations/openclaw/gateway.yaml
+++ b/automations/openclaw/gateway.yaml
@@ -1,5 +1,5 @@
 # OpenClaw Gateway Configuration
-# Hosted on Fly.io — always-on Telegram bot
+# Hosted on Fly.io — always-on Telegram + WhatsApp bot
 # Docs: https://openclaw.ai/docs/gateway
 
 gateway:
@@ -38,8 +38,20 @@ channels:
     # to give updates, ask questions, or dump information
 
   whatsapp:
-    enabled: false
+    enabled: true
     type: whatsapp-web
+    # Pair via: openclaw channels login --channel whatsapp
+    # Uses Baileys (WhatsApp Web protocol) — QR code pairing
+    # Recommended: use a separate/dedicated phone number
+    dmPolicy: pairing # pairing | allowlist | open | disabled
+    groupPolicy: disabled
+    sendReadReceipts: true
+    ackReaction:
+      emoji: "👀"
+      direct: true
+      group: never
+    historyLimit: 50
+    mode: conversational
 
   outlook:
     enabled: true


### PR DESCRIPTION
## Summary
- Enables WhatsApp as a second always-on conversational channel alongside Telegram
- Configures Baileys (WhatsApp Web protocol) with QR pairing and DM pairing policy
- Expands channel-setup docs with full pairing, access control, and usage instructions

## Setup after merge
1. Deploy to Fly.io: `fly deploy`
2. SSH in and pair: `fly ssh console` → `openclaw channels login --channel whatsapp`
3. Scan QR code from WhatsApp → Linked Devices

No new secrets needed — WhatsApp authenticates via QR, not API keys.

## Test plan
- [ ] Deploy to Fly.io and verify gateway starts with WhatsApp enabled
- [ ] Complete QR pairing from `fly ssh console`
- [ ] Send a test message via WhatsApp and confirm bot responds
- [ ] Verify entities are written to the monorepo on WhatsApp input

🤖 Generated with [Claude Code](https://claude.com/claude-code)