### PR TITLE
Document game state model and decision types for EV engine

### DIFF
--- a/docs/plans/2026-02-21-bazaar-ev-engine-design.md
+++ b/docs/plans/2026-02-21-bazaar-ev-engine-design.md
@@ -159,7 +159,15 @@ projects/bazaar-coach/data/
 
 ## Layer 2: Game State Model
 
-Structured representation populated from screenshot analysis.
+> **Canonical spec**: See `projects/bazaar-coach/mechanics/game-state-model.md` for the full schema, decision types, day structure, and board layout rules.
+
+Structured representation populated from screenshot analysis. The model must capture four distinct decision types (event choice, PvE choice, shop, level-up) — not just the shop phase.
+
+### Day Structure
+
+Each day follows: **PvP → Hour 1 (pick 1 of 3 events) → Hour 2 (pick 1 of 3 events) → Hour 3 (pick 1 of 3 PvE encounters) → Hour 4 (pick 1 of 3 events) → Hour 5 (pick 1 of 3 events) → PvP**. Shops are one event type among many (free items, skill trainers, enchantment stations, gold/XP rewards, special encounters). One option per hour is typically economic (free stuff).
+
+### Example: Shop Decision Point
 
 ```json
 {
@@ -173,48 +181,113 @@ Structured representation populated from screenshot analysis.
     "health": 200,
     "max_health": 200,
     "level": 7,
+    "xp": 3,
     "wins": 2,
     "losses": 1
   },
-  "board": [
-    {
-      "item_id": "pufferfish",
-      "tier": "silver",
-      "enchantment": "toxic",
-      "position": 0,
-      "ammo": null
-    },
-    {
-      "item_id": "jellyfish",
-      "tier": "bronze",
-      "enchantment": null,
-      "position": 1,
-      "ammo": null
-    },
-    {
-      "item_id": "beach_ball",
-      "tier": "bronze",
-      "enchantment": null,
-      "position": 2,
-      "ammo": null
-    }
+  "board": {
+    "slots_total": 10,
+    "slots_used": 5,
+    "items": [
+      {
+        "name": "Pufferfish",
+        "size": "M",
+        "tier": "silver",
+        "enchantment": "toxic",
+        "position": 0,
+        "types": ["aquatic", "friend", "haste", "poison"],
+        "ammo": null
+      },
+      {
+        "name": "Jellyfish",
+        "size": "S",
+        "tier": "bronze",
+        "enchantment": null,
+        "position": 2,
+        "types": ["aquatic", "poison"],
+        "ammo": null
+      },
+      {
+        "name": "Beach Ball",
+        "size": "M",
+        "tier": "bronze",
+        "enchantment": null,
+        "position": 3,
+        "types": ["aquatic", "haste"],
+        "ammo": null
+      }
+    ]
+  },
+  "stash": {
+    "slots_total": 10,
+    "slots_used": 0,
+    "items": []
+  },
+  "skills": [
+    { "name": "Final Dose", "tier": "bronze", "effect": "+3 Poison on first Poison application each fight" },
+    { "name": "Strength", "tier": "silver", "effect": "+5 Damage to all Weapons" }
   ],
-  "stash": [],
-  "shop": {
-    "merchant": "jay_jay",
+  "decision": {
+    "type": "shop",
+    "merchant": "Jay Jay",
     "merchant_tier": "silver",
     "items": [
-      { "item_id": "catfish", "tier": "bronze", "price": 8, "enchantment": null },
-      { "item_id": "bayonet", "tier": "bronze", "price": 5, "enchantment": null },
-      { "item_id": "handaxe", "tier": "bronze", "price": 4, "enchantment": null }
+      { "name": "Catfish", "tier": "bronze", "price": 8, "enchantment": null, "size": "S" },
+      { "name": "Bayonet", "tier": "bronze", "price": 5, "enchantment": null, "size": "S" },
+      { "name": "Handaxe", "tier": "bronze", "price": 4, "enchantment": null, "size": "S" }
     ],
     "reroll_cost": 4
   },
   "history": {
-    "items_seen": ["pufferfish", "jellyfish", "beach_ball", "lighter", "bayonet"],
-    "items_purchased": ["pufferfish", "jellyfish", "beach_ball"],
-    "merchants_seen": ["jay_jay", "aila", "kina", "jay_jay"],
-    "rerolls_this_shop": 0
+    "items_seen": ["Pufferfish", "Jellyfish", "Beach Ball", "Lighter", "Bayonet"],
+    "items_purchased": ["Pufferfish", "Jellyfish", "Beach Ball"],
+    "merchants_seen": [
+      { "name": "Jay Jay", "tier": "bronze", "day": 1 },
+      { "name": "Aila", "tier": "bronze", "day": 2 },
+      { "name": "Jay Jay", "tier": "silver", "day": 5 }
+    ],
+    "events_encountered": [],
+    "pve_results": [],
+    "skills_acquired": [
+      { "name": "Final Dose", "tier": "bronze", "day": 2, "source": "level_up" },
+      { "name": "Strength", "tier": "silver", "day": 4, "source": "event" }
+    ],
+    "pvp_results": [
+      { "day": 1, "result": "win" },
+      { "day": 2, "result": "win" },
+      { "day": 3, "result": "loss", "prestige_cost": 3 },
+      { "day": 4, "result": "win" }
+    ]
+  }
+}
+```
+
+### Example: Event Choice Decision Point
+
+```json
+{
+  "decision": {
+    "type": "event_choice",
+    "options": [
+      { "event_type": "shop", "description": "Jay Jay (Silver merchant)" },
+      { "event_type": "free_item", "description": "Treasure Chest — free item" },
+      { "event_type": "gold_reward", "description": "Borrow — lose 1 income, gain 7 gold" }
+    ]
+  }
+}
+```
+
+### Example: PvE Choice Decision Point
+
+```json
+{
+  "decision": {
+    "type": "pve_choice",
+    "encounters": [
+      { "monster": "Flame Juggler", "tier": "gold", "rewards": { "gold": 4, "xp": 3 }, "notes": "54 fight-start Burn" },
+      { "monster": "Trashtown Mayor", "tier": "diamond", "rewards": { "gold": 5, "xp": 4, "drop": "Augmented Weaponry skill" }, "notes": "Hard but amazing drop" },
+      { "monster": "Crab", "tier": "bronze", "rewards": { "gold": 2, "xp": 3 }, "notes": "Free win" }
+    ]
   }
 }
 ```
@@ -224,9 +297,12 @@ Structured representation populated from screenshot analysis.
 The engine should maintain cumulative state across multiple screenshots/queries within a run. Key fields to track:
 
 - **items_seen**: Every item offered in every shop. Informs probability calculations.
-- **merchants_seen**: Every merchant encountered. Informs merchant distribution model.
+- **merchants_seen**: Every merchant encountered with day/tier. Informs merchant distribution model.
+- **events_encountered**: Events seen and choices made. Informs event probability model.
+- **skills_acquired**: Skills gained, when, and from where. Skills are permanent and build-defining.
+- **pve_results**: PvE encounters fought, outcomes, drops. No Prestige risk but affects gold/XP/items.
+- **pvp_results**: Win/loss record with Prestige changes. Critical for run trajectory assessment.
 - **decisions_made**: What was bought/sold/skipped and why. Enables retrospective analysis.
-- **combat_results**: Win/loss and approximate board power of opponents faced. Calibrates opponent model.
 
 ## Layer 3: Probability Engine
 

--- a/projects/bazaar-coach/CLAUDE.md
+++ b/projects/bazaar-coach/CLAUDE.md
@@ -29,12 +29,23 @@ If The Bazaar isn't open (capture fails), fall back to asking the user for a scr
 
 ### Step 1: Parse Game State (Structured)
 
-Extract into a structured model — not prose:
-- **Hero**, **Day**, **Hour**, **Gold**, **Income**, **Prestige**, **Health/Max Health**, **Level**
-- **Board items**: name, tier, enchantment, position, size, types (for each item)
-- **Stash items**: same fields
-- **Shop**: merchant name, merchant tier, each item (name, tier, price, enchantment)
-- **Run history** (maintain across the conversation): items seen, merchants seen, items purchased
+Extract into the structured model defined in `mechanics/game-state-model.md` — not prose. Identify which **decision type** you're looking at (event choice, PvE choice, shop, or level-up).
+
+**Run state**: Hero, Day, Hour, Gold, Income, Prestige (run HP — 0 = near elimination), Health/Max Health, Level, XP, Wins/Losses
+
+**Board**: Items in their exact positions (left-to-right order matters — adjacency effects are real). For each: name, size (S=1/M=2/L=3 slots), tier, enchantment, types, ammo. Board has 4→10 slots (maxes at Level 4).
+
+**Stash**: Off-board items (10 size-units capacity, inactive in combat). Same fields minus position.
+
+**Skills**: All acquired skills with name, tier, and effect. Skills are permanent, ~10 slots, acquired from level-ups and events. Often build-defining.
+
+**Current decision**:
+- If **event choice**: the 3 options available this hour (shops are one event type among many — free items, skill trainers, enchantments, gold/XP rewards, etc.)
+- If **PvE choice**: the 3 monster encounters with visible info and rewards (no Prestige risk)
+- If **shop**: merchant name/tier, items (name, tier, price, enchantment, size), reroll cost. Can buy multiple.
+- If **level-up**: options offered (skill picks, upgrade targets, items, enchantments)
+
+**Run history** (maintain across the conversation): items seen, merchants seen (with day/tier), events encountered, skills acquired, PvE results, PvP results with Prestige changes
 
 ### Step 2: Compute Board Power
 
@@ -61,7 +72,14 @@ For the current board, estimate effective combat power:
 
 ### Step 3: Evaluate Every Action
 
-For **each possible action** (buy item A, buy item B, sell item X, reroll, skip), compute:
+The actions to evaluate depend on the **decision type**:
+
+- **Event choice**: Compare the EV of each of the 3 options (e.g., shop visit vs free item vs skill trainer). A shop is only valuable if it likely contains items you want to buy.
+- **PvE choice**: Compare reward value vs risk. PvE has no Prestige risk, so pick the highest-reward encounter you can beat. If a monster drops a build-defining item (e.g., Augmented Weaponry from Trashtown Mayor), that outweighs gold differences.
+- **Shop**: Evaluate buy/sell/reroll/skip (detailed below).
+- **Level-up**: Compute exact power delta for each option (which skill, which upgrade target, which item).
+
+**For shop decisions**, evaluate each possible action:
 
 **Buy Item X (cost N gold):**
 ```

--- a/projects/bazaar-coach/mechanics/game-state-model.md
+++ b/projects/bazaar-coach/mechanics/game-state-model.md
@@ -1,0 +1,213 @@
+# Game State Model
+
+The complete state of a Bazaar run at any discrete decision point. This is what the EV engine needs to parse from a screenshot or reconstruct from conversation history.
+
+## Decision Points
+
+There are **four types** of decision points. Every hour except PvP presents **3 options** — the player picks one.
+
+| Decision Type | When It Happens | What You Choose |
+|---------------|-----------------|-----------------|
+| **Event choice** | Hours 1, 2, 4, 5 (non-PvE, non-PvP) | Pick 1 of 3 events. Events include: shops (merchants), free items, skill trainers, enchantment stations, gold/XP rewards, special encounters |
+| **PvE choice** | Hour 3 | Pick 1 of 3 PvE monster encounters. You see monster info and rewards before choosing. No Prestige risk — PvE losses are free |
+| **Shop** | When you pick a merchant event | Buy/sell/reroll within that merchant's shop. ~3 items shown, can buy multiple if you can afford them |
+| **Level-up / Upgrade** | On XP threshold | Pick from offered rewards (skill choice, item upgrade target, enchantment, etc.) |
+
+### Day Structure
+
+Each day follows this sequence:
+
+```
+PvP Fight (auto, results from previous day's board)
+  │
+  ├─ Hour 1: Pick 1 of 3 events
+  ├─ Hour 2: Pick 1 of 3 events
+  ├─ Hour 3: Pick 1 of 3 PvE encounters
+  ├─ Hour 4: Pick 1 of 3 events
+  ├─ Hour 5: Pick 1 of 3 events
+  │
+PvP Fight (next day boundary)
+```
+
+One of the 3 options each hour is typically an economic/free option (free item, gold, XP). Shops (merchants) are one possible event type — they are not guaranteed every hour.
+
+## State Schema
+
+### Run State
+
+Top-level stats visible on the game screen.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `hero` | string | Which hero (Vanessa, Dooley, Pygmalien, Mak, Stelle, Jules) |
+| `day` | int | Current day number (1+) |
+| `hour` | int | Current hour within the day (1-5) |
+| `gold` | int | Current gold available to spend |
+| `income` | int | Gold gained at start of each day |
+| `prestige` | int | Run HP. Starts at 20. Lost on PvP losses (cost = day number). Reaches 0 → Fate's Crossroads → next loss ends run. Essentially unrecoverable. |
+| `health` | int | Per-fight combat HP |
+| `max_health` | int | Maximum combat HP |
+| `level` | int | Current level (determines board slots, unlock thresholds) |
+| `xp` | int | Current XP toward next level (8 XP per level). Sources: 1/hour auto, PvE performance, events |
+| `wins` | int | Total PvP wins this run |
+| `losses` | int | Total PvP losses this run |
+
+### Board
+
+Single horizontal row. **Position matters** — adjacency effects, left/right targeting, and "leftmost/rightmost" item triggers are real mechanics.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `slots_total` | int | Total board size in slot-units. Starts at 4, maxes at 10 by Level 4 |
+| `slots_used` | int | Currently occupied slots |
+| `items` | array | Ordered list of items left-to-right |
+
+Each board item:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Item name |
+| `size` | S/M/L | Small = 1 slot, Medium = 2 slots, Large = 3 slots |
+| `tier` | string | bronze / silver / gold / diamond / legendary |
+| `enchantment` | string? | Enchantment applied (fiery, toxic, turbo, etc.) or null |
+| `position` | int | Slot index (0 = leftmost). Determines adjacency. |
+| `types` | array | Item types (weapon, aquatic, friend, tech, etc.) |
+| `ammo` | int? | Current ammo if applicable, null otherwise |
+
+### Stash
+
+Off-board storage. Items here are **inactive** — they don't participate in combat.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `slots_total` | int | Always 10 size-units |
+| `slots_used` | int | Currently occupied |
+| `items` | array | Same fields as board items (minus position) |
+
+### Skills
+
+Passive abilities that persist for the entire run. Always visible on the game screen.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `skills` | array | All skills currently held |
+
+Each skill:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Skill name |
+| `tier` | string | bronze / silver / gold / diamond / legendary |
+| `source` | string? | Where acquired (level-up trainer, event, PvE drop) |
+| `effect` | string | What the skill does (passive buff, trigger condition, etc.) |
+
+Skills are:
+- **Permanent** once acquired (cannot be lost or sold)
+- **Tiered** like items (bronze through legendary)
+- Acquired from **level-up skill trainers** (levels 2, 5, 7, 8, 11, 14, 17, 19, 23) and **random events**
+- Capacity is ~10 skills over a full run
+- Often build-defining (e.g., Final Dose for Poison, Augmented Weaponry for Weapons)
+
+### Current Decision
+
+What the player is looking at right now.
+
+**If event choice (most hours):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | "event_choice" | |
+| `options` | array[3] | Three events to choose between |
+
+Each option:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `event_type` | string | shop, free_item, skill_trainer, enchantment, gold_reward, xp_reward, special_event |
+| `description` | string | What's visible about this option |
+| `merchant` | object? | If shop: merchant name, tier, visible items |
+
+**If PvE choice (hour 3):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | "pve_choice" | |
+| `encounters` | array[3] | Three monster encounters to choose between |
+
+Each encounter:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `monster` | string | Monster name |
+| `tier` | string | Difficulty tier |
+| `rewards` | object | Expected gold, XP, possible drops |
+| `can_win` | bool? | Engine's assessment of whether current board beats this |
+
+**If shop (inside a merchant event):**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | "shop" | |
+| `merchant` | string | Merchant name (Jay Jay, Aila, Nautica, etc.) |
+| `merchant_tier` | string | bronze / silver / gold / diamond |
+| `items` | array | Items available for purchase |
+| `reroll_cost` | int | Gold cost to reroll this shop |
+
+Each shop item:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `name` | string | Item name |
+| `tier` | string | bronze / silver / gold / diamond |
+| `price` | int | Gold cost |
+| `enchantment` | string? | Pre-applied enchantment or null |
+| `size` | S/M/L | Item size |
+
+**If level-up / upgrade:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | "level_up" | |
+| `level` | int | Level being reached |
+| `options` | array | Choices offered (skill picks, upgrade targets, items, enchantments) |
+
+### Run History
+
+Cumulative state maintained across the entire run. Critical for probability calculations.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `items_seen` | array | Every item offered in every shop (feeds item pool probability) |
+| `items_purchased` | array | Items bought (with day/gold cost) |
+| `items_sold` | array | Items sold and when |
+| `merchants_seen` | array | Every merchant encountered (name + tier + day) |
+| `events_encountered` | array | Events seen and choices made |
+| `pve_results` | array | PvE encounters fought, outcomes, drops |
+| `skills_acquired` | array | Skills gained and when |
+| `pvp_results` | array | Win/loss record with Prestige changes |
+
+## What's NOT in Game State (Opponent Info)
+
+PvP opponents are **blind** — you cannot see their board before a fight. This means:
+- Opponent modeling is purely **predictive** (archetype distributions by day/meta)
+- No reactive positioning against specific opponent items
+- Win probability estimates are against expected opponent distributions, not known boards
+
+## Board Layout Rules
+
+- Single horizontal row of slots
+- Small items occupy 1 slot, Medium 2, Large 3
+- Board starts at 4 slots (Level 1), grows to 10 slots (Level 4)
+- Player manually places items — **positioning is a real decision**
+- Adjacency effects apply to items in neighboring slots
+- "Leftmost" and "rightmost" item effects depend on actual position
+- Board can be rearranged freely during non-combat phases
+
+## Prestige Rules
+
+- Start: 20 Prestige
+- Loss cost: equal to current day number (Day 1 loss = -1, Day 10 loss = -10)
+- Recovery: essentially none (Arken's Ring is extremely rare edge case)
+- At 0: Fate's Crossroads event (one-time reprieve with 3 options)
+- After Fate's Crossroads: next PvP loss ends the run
+- **Implication**: Early losses are cheap, late losses are devastating. The engine must factor Prestige into EV — a risky play that might lose you a Day 8 fight costs 8 Prestige, which could end the run.


### PR DESCRIPTION
## Summary

Adds comprehensive documentation of the Bazaar game state model and decision framework to support the EV engine implementation. This establishes the canonical schema for representing game state from screenshots and conversation history, covering all four decision types (event choice, PvE choice, shop, level-up) and the complete day structure.

## Key Changes

- **New file**: `projects/bazaar-coach/mechanics/game-state-model.md`
  - Complete schema specification for run state (hero, day, hour, gold, income, prestige, health, level, XP, wins/losses)
  - Board representation with position-aware item layout (slots, sizes, adjacency rules)
  - Stash (off-board storage) and skills (permanent, build-defining abilities)
  - Four distinct decision types with detailed examples for each
  - Run history tracking (items seen, merchants, events, PvE results, PvP results with prestige costs)
  - Board layout rules and prestige mechanics

- **Updated**: `docs/plans/2026-02-21-bazaar-ev-engine-design.md`
  - Added reference to canonical game state model spec
  - Expanded Layer 2 (Game State Model) section with day structure explanation
  - Replaced single shop example with three decision type examples (shop, event choice, PvE choice)
  - Enhanced run history tracking guidance with merchant tier/day, events, skills, and PvP results
  - Clarified that shops are one event type among many (not the only decision point)

- **Updated**: `projects/bazaar-coach/CLAUDE.md`
  - Revised Step 1 (Parse Game State) to reference the game state model spec
  - Expanded guidance on extracting all decision types, not just shops
  - Added explicit instructions for board position tracking and skill handling
  - Clarified decision type identification and run history maintenance
  - Enhanced Step 3 (Evaluate Every Action) with decision-type-specific evaluation strategies

## Notable Details

- **Position matters**: Board is a single horizontal row where adjacency effects and left/right targeting are real mechanics
- **Four decision types**: Event choice (most hours), PvE choice (hour 3), shop (within merchant events), level-up (on XP threshold)
- **Prestige as run HP**: Starts at 20, lost on PvP losses (cost = day number), essentially unrecoverable. Critical for EV calculations.
- **Skills are permanent**: Acquired from level-ups and events, ~10 capacity, often build-defining (e.g., Final Dose for poison builds)
- **Blind PvP**: Opponent boards are unknown; opponent modeling is purely predictive against expected distributions

https://claude.ai/code/session_01K1YnBHcJRkcPJ17H9Zsby4