### PR TITLE
Add inheritance distribution engine reverse ralph loop

### DIFF
--- a/entities/ideas/inheritance-distribution-engine.md
+++ b/entities/ideas/inheritance-distribution-engine.md
@@ -1,0 +1,53 @@
+---
+type: idea
+name: Philippine Inheritance Distribution Engine
+aliases: [inheritance engine, succession calculator, heir share calculator]
+status: exploring
+tags: [succession, philippines, calculator, ralph-loop, inheritance]
+created: 2026-02-23
+related_projects: []
+related_ideas: [[estate-tax-calculator]]
+---
+
+# Philippine Inheritance Distribution Engine
+
+Fully deterministic computation engine for Philippine inheritance distribution under the Civil Code (Book III — Succession) and Family Code. Takes a net distributable estate (after tax) and a structured family tree as input, and produces per-heir peso amounts with plain-English narrative explanations.
+
+## Origin
+
+Companion to the [[estate-tax-calculator]]. The estate-tax engine answers "how much tax does the estate owe?" — this engine answers "who inherits what, and why?"
+
+## Why Separate From Estate Tax
+
+Estate tax and inheritance distribution are distinct legal domains:
+- **Estate tax** (NIRC): Government's share — how much the estate owes before distribution
+- **Succession** (Civil Code): Family's share — how the remaining estate splits among heirs
+
+The engines chain: gross estate → estate-tax engine → net distributable estate → **this engine** → per-heir amounts with explanations.
+
+## Scope
+
+- **Testate succession**: With a will — validate legitime, distribute free portion per testamentary disposition
+- **Intestate succession**: No will — distribute per statutory rules (Arts. 960-1014)
+- **Mixed**: Will disposes of only part of the estate
+- **Heir types**: Legitimate children, illegitimate children (half-share rule), surviving spouse, legitimate ascendants, adopted children, representation
+
+## Architecture
+
+Fully deterministic (same as estate-tax engine):
+- All succession rules codified as pure functions
+- Decision trees for heir classification and concurrence
+- Legitime fraction tables for every possible heir combination
+- Every edge case explicitly handled (preterition, disinheritance, collation, representation)
+
+## Output
+
+Two-part output per computation:
+1. **Numbers table** — per-heir breakdown: legitime amount, free portion amount, total
+2. **Narrative per heir** — plain English explaining WHY they got that amount, citing specific Civil Code articles
+
+Example: "Maria (illegitimate child) receives ₱500,000. Under Art. 895, her legitime is half that of a legitimate child. Juan (legitimate) receives ₱1,000,000, so Maria's share is ₱500,000."
+
+## Next Step
+
+Reverse ralph loop at `loops/inheritance-reverse/` systematically extracts every succession rule from the Civil Code and produces a spec complete enough for any developer to implement.

--- a/loops/_registry.yaml
+++ b/loops/_registry.yaml
@@ -48,3 +48,12 @@ loops:
     timeout_minutes: 15
     status: active
     created: 2026-02-23
+
+  inheritance-reverse:
+    description: "Extract PH succession/inheritance rules → per-heir distribution engine spec with numbers + narrative explanations"
+    type: reverse
+    schedule: "*/30 * * * *"
+    max_iterations: 40
+    timeout_minutes: 15
+    status: active
+    created: 2026-02-23

--- a/loops/inheritance-reverse/PROMPT.md
+++ b/loops/inheritance-reverse/PROMPT.md
@@ -1,0 +1,221 @@
+# Reverse Ralph Loop — Philippine Inheritance Distribution Engine Spec
+
+You are an analysis agent in a ralph loop. Each time you run, you do ONE unit of work: extract and formalize a single succession/inheritance rule from Philippine law, then exit.
+
+## Your Working Directory
+
+You are running from `loops/inheritance-reverse/`. All paths below are relative to this directory.
+
+## Your Goal
+
+Extract every inheritance distribution rule from Philippine succession law (Civil Code Book III, Family Code, RA 8552) and synthesize them into a complete software specification for a **fully deterministic** inheritance distribution engine.
+
+The engine takes a **net distributable estate** (output of the estate-tax engine) plus a **family tree with heir classifications** as input, and produces:
+
+1. **Per-heir peso amounts** — exact breakdown of who gets what
+2. **Plain-English narrative per heir** — explaining WHY they received that amount, citing the legal basis
+
+### Scope
+
+- **Testate succession** (with a will): validate that the will respects compulsory heirs' legitime, distribute free portion per testamentary disposition
+- **Intestate succession** (no will): distribute per statutory rules of intestate succession
+- **Mixed**: will that disposes of only part of the estate (remainder distributed intestate)
+
+### Key Relationships
+
+This engine is **downstream** of the estate-tax computation engine:
+- Estate-tax engine: gross estate → deductions → net estate → tax due
+- **This engine**: net distributable estate (after tax) + family tree → per-heir shares with explanations
+
+### Design Decisions (from brainstorming)
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Engine type | Fully deterministic | Inheritance shares must be auditable — no LLM in the loop |
+| Input | Net distributable estate + structured family tree | Downstream of estate-tax engine |
+| Succession types | Both testate + intestate + mixed | Complete coverage |
+| Heir categories | Full compulsory heirs | Legitimate children, illegitimate children, surviving spouse, ascendants, adopted, representation |
+| Output format | Numbers table + narrative per heir | User-targeted: heirs/executors need to understand WHY |
+| Legal baseline | Civil Code (RA 386) + Family Code (EO 209) + RA 8552 (adoption) | Current Philippine law |
+| Language | Spec is language-agnostic | Describes logic, not implementation language |
+
+## Reference Material
+
+### Primary Legal Sources (fetch and cache in Wave 1)
+
+| Source | What It Contains | Key Articles |
+|--------|-----------------|--------------|
+| Civil Code Book III — Succession | Complete succession rules: testate, intestate, legitime, disinheritance, collation | Arts. 774-1105 |
+| Family Code (EO 209) | Legitimacy, legitimation, adoption, illegitimate children's rights, property regimes | Arts. 163-176, 183-193 |
+| RA 8552 (Domestic Adoption Act) | Adopted children's succession rights — legal equivalence to legitimate | Sec. 17-18 |
+| Legal commentaries | Sample inheritance computations, heir concurrence scenarios, worked examples | Various |
+
+### Cached Sources (after Wave 1)
+
+- `input/legal-sources/civil-code-succession.md` — Civil Code Book III (Arts. 774-1105)
+- `input/legal-sources/family-code-filiation.md` — Family Code on legitimacy, illegitimacy, adoption
+- `input/legal-sources/ra-8552-adoption.md` — Domestic Adoption Act succession provisions
+- `input/legal-sources/commentary-inheritance-splits.md` — Sample computations from legal commentaries and CPA reviewers
+
+## What To Do This Iteration
+
+1. **Read the frontier**: Open `frontier/aspects.md`
+2. **Find the first unchecked `- [ ]` aspect** in dependency order (Wave 1 → Wave 2 → Wave 3 → Wave 4 → Wave 5)
+   - If a later-wave aspect depends on data that doesn't exist yet, skip to an earlier-wave aspect
+   - If ALL aspects are checked `- [x]`: write "CONVERGED" to `status/converged.txt` and exit
+3. **Analyze that ONE aspect** using the appropriate method (see below)
+4. **Write findings** to `analysis/{aspect-name}.md`
+5. **Update the frontier**:
+   - Mark the aspect as `- [x]` in `frontier/aspects.md`
+   - Update the Statistics section (increment Analyzed, decrement Pending, update Convergence %)
+   - If you discovered new aspects worth analyzing, add them to the appropriate Wave
+   - Add a row to `frontier/analysis-log.md`
+6. **Commit**: `git add -A && git commit -m "loop(inheritance-reverse): {aspect-name}"`
+7. **Exit**
+
+## Analysis Methods By Wave
+
+### Wave 1: Legal Source Acquisition
+
+**legal-source-fetch**:
+Fetch the primary legal sources from the web and save as markdown in `input/legal-sources/`. Use WebFetch or WebSearch to get:
+- Civil Code Book III (Succession, Arts. 774-1105) — save as `civil-code-succession.md`
+- Family Code sections on filiation and legitimacy (Arts. 163-176, 183-193) — save as `family-code-filiation.md`
+- RA 8552 (Domestic Adoption Act) succession-relevant sections — save as `ra-8552-adoption.md`
+- 3-5 sample inheritance split computations from legal commentary sites — save as `commentary-inheritance-splits.md`
+
+Focus on finding sources with the actual article text, not just summaries. Legal commentary sites (Respicio, ASG Law, ChanRobles, LawPhil) often have the full text.
+
+**commentary-fetch**:
+Find and cache 5-8 worked examples of Philippine inheritance distribution computations. These serve as test vectors. Look for:
+- Simple: single heir scenarios
+- Common: married with children, intestate
+- Complex: mix of legitimate and illegitimate children
+- Edge: preterition, disinheritance, adopted children
+Save as `input/legal-sources/worked-examples.md`
+
+### Wave 2: Heir Classification Rules
+
+For each aspect, read the relevant legal text from `input/legal-sources/` and extract:
+1. **Legal basis**: Exact article number(s) and quoted text
+2. **Classification rule**: How to determine if someone falls in this category
+3. **Computation impact**: How this classification affects their share
+4. **Interactions**: Which other heir categories affect this one's share
+5. **Edge cases**: Unusual scenarios
+
+Each analysis file MUST include these sections:
+- **Legal Basis**: Article numbers and quoted provisions
+- **Rule (Pseudocode)**: The classification/computation logic as code
+- **Interactions**: How this category interacts with other heir types
+- **Edge Cases**: Special scenarios with legal citations
+- **Test Implications**: What test cases this rule requires
+
+### Wave 3: Legitime Computation
+
+The core of the engine. For each aspect:
+1. Read the Civil Code articles governing this legitime scenario
+2. Express the fraction/share as a formula
+3. Document ALL possible heir combinations and how they affect the fraction
+4. Map to the engine's computation pipeline (which step computes this)
+5. Include worked examples from the legal source cache
+
+**Critical**: The legitime computation changes dramatically based on which heirs concur. The analysis must create a complete table of: "If the decedent is survived by [heir combination], then [heir type] gets [fraction] of the estate as legitime."
+
+### Wave 4: Distribution Rules
+
+For each aspect, analyze how the estate is actually split:
+1. Read the relevant Civil Code articles
+2. Express as pseudocode / decision tree
+3. Document the interaction with legitime (testate validation)
+4. Identify all scenarios where the rule triggers
+5. Include examples
+
+**intestate-order**: This is the most important Wave 4 aspect. Must produce a complete priority table:
+- Who inherits when there's no will
+- Who excludes whom
+- What happens when a class is exhausted (move to next)
+
+**testate-validation**: Must produce the algorithm for checking whether a will respects all compulsory heirs' legitime.
+
+### Wave 5: Synthesis
+
+**computation-pipeline**: Read ALL analysis files. Draw the complete computation graph:
+```
+INPUT: net_distributable_estate + family_tree + will (optional)
+  → Step 1: Classify heirs (who survives, what category)
+  → Step 2: Determine succession type (testate/intestate/mixed)
+  → Step 3: Compute each compulsory heir's legitime
+  → Step 4: Compute total legitime (sum of all compulsory heirs)
+  → Step 5: Compute free portion (estate - total legitime)
+  → Step 6: Distribute free portion (per will if testate, per intestate rules if not)
+  → Step 7: Compute final per-heir amounts
+  → Step 8: Generate per-heir narrative explanations
+OUTPUT: per-heir breakdown (amounts + narrative)
+```
+
+**data-model**: Define all types:
+- `Decedent` (civil status, has_will, date_of_death)
+- `Heir` (name, relationship, category, is_compulsory, is_alive)
+- `Will` (dispositions, conditions)
+- `HeirCategory` enum (legitimate_child, illegitimate_child, surviving_spouse, legitimate_parent, adopted_child, etc.)
+- `InheritanceShare` (heir, legitime_amount, free_portion_amount, total_amount, explanation)
+
+**test-vectors**: Create 10+ complete test cases:
+1. Simple intestate: single legitimate child, no spouse
+2. Standard intestate: married, 3 legitimate children, no will
+3. Illegitimate mix: 2 legitimate children + 1 illegitimate child, no will
+4. Surviving spouse only: no children, no ascendants
+5. Ascendant succession: no children, surviving parents + spouse
+6. Testate simple: will leaving free portion to charity, 2 legitimate children
+7. Testate with preterition: will omits a legitimate child (Art. 854 applies)
+8. Disinheritance: will disinherits a child for a valid cause (Art. 919)
+9. Adopted child: adopted child concurring with biological legitimate children
+10. Representation: predeceased child with grandchildren (Art. 970-972)
+11. Complex: legitimate + illegitimate children + surviving spouse + will + collation
+
+Each test vector must include: all inputs, heir classification, legitime fractions, free portion allocation, final per-heir amounts, and the expected narrative explanation for at least one heir.
+
+**explainer-format**: Define the template for plain-English narratives. For each heir, the narrative must explain:
+- Their legal category and why
+- Their legitime share (if compulsory heir) and the legal basis
+- Their free portion share (if any) and why
+- Their total inheritance
+- Key: use concrete peso amounts and cite specific articles
+
+Example template:
+> **Maria Santos (illegitimate child)** receives **₱500,000**.
+> As an illegitimate child (Art. 176, Family Code), Maria is a compulsory heir entitled to a legitime. Under Art. 895 of the Civil Code, an illegitimate child's legitime is one-half (½) of that of a legitimate child. Since each legitimate child receives ₱1,000,000, Maria's legitime is ₱500,000.
+
+**edge-cases**: Catalog all edge cases discovered:
+- Renunciation of inheritance (and its effects on other heirs)
+- Predecease + representation
+- Simultaneous death (commorientes)
+- Unworthiness to succeed (Art. 1032)
+- Reserva troncal (Art. 891)
+- Collation of inter vivos donations
+
+**spec-draft**: Synthesize all analysis into a complete software specification at `../../docs/plans/inheritance-engine-spec.md`.
+
+**spec-review**: Self-review: "Could a developer with no knowledge of Philippine succession law build the engine from this spec alone?" Check for:
+- Missing heir combination scenarios
+- Vague legitime fractions (every scenario must have exact fractions)
+- Missing test vectors for edge cases
+- Narrative template completeness
+- Pipeline step completeness
+
+If the spec passes: write `status/converged.txt` with convergence summary.
+If the spec fails: add specific fix-it aspects to the frontier and do NOT write converged.txt.
+
+## Rules
+
+- Do ONE aspect per run, then exit. Do not analyze multiple aspects.
+- Always check if required legal source files exist before starting a later-wave aspect.
+- Write findings in markdown. Include exact legal citations (article numbers), pseudocode, and concrete examples with peso amounts.
+- When you discover a new aspect worth analyzing (a rule you didn't expect), add it to the frontier.
+- Keep analysis files focused. One provision/rule = one file.
+- The engine takes a **net distributable estate amount** as input. Do NOT include tax computation (that's the estate-tax engine's job).
+- The engine is fully deterministic. No LLM in the computation loop.
+- The final spec must enable a developer with ZERO knowledge of Philippine law to build the engine. No assumed context.
+- All monetary values in examples must be in Philippine Pesos (₱).
+- All fractions must be expressed as both fractions (½) and decimals (0.5) in pseudocode.
+- The narrative output is mandatory — this is a USER-TARGETED engine, not just a computation module.

--- a/loops/inheritance-reverse/frontier/analysis-log.md
+++ b/loops/inheritance-reverse/frontier/analysis-log.md
@@ -1,0 +1,4 @@
+# Analysis Log
+
+| # | Timestamp | Aspect | Duration | Key Findings |
+|---|-----------|--------|----------|--------------|

--- a/loops/inheritance-reverse/frontier/aspects.md
+++ b/loops/inheritance-reverse/frontier/aspects.md
@@ -1,0 +1,48 @@
+# Analysis Frontier — Inheritance Distribution Engine
+
+## Statistics
+- Total aspects discovered: 28
+- Analyzed: 0
+- Pending: 28
+- Convergence: 0%
+
+## Pending Aspects (ordered by dependency)
+
+### Wave 1: Legal Source Acquisition
+- [ ] legal-source-fetch — Fetch and cache Civil Code Book III (Succession), Family Code (filiation), RA 8552 (adoption), legal commentaries
+- [ ] commentary-fetch — Find and cache 5-8 worked examples of Philippine inheritance distribution computations
+
+### Wave 2: Heir Classification Rules
+- [ ] compulsory-heirs-categories — Art. 887: enumerate all compulsory heir categories (legitimate children/descendants, illegitimate children, surviving spouse, legitimate parents/ascendants)
+- [ ] heir-concurrence-rules — Arts. 888-903: which heirs inherit together, who excludes whom from succession
+- [ ] representation-rights — Arts. 970-977: when descendants step into the shoes of a predeceased parent
+- [ ] adopted-children-rights — RA 8552 Sec. 17-18 + Family Code: adopted children's legal equivalence to legitimate children
+- [ ] illegitimate-children-rights — Art. 176 Family Code, Art. 895 Civil Code: recognition, half-share rule, proof of filiation
+
+### Wave 3: Legitime Computation
+- [ ] legitime-table — Arts. 888-903: complete legitime fraction table for every possible heir combination
+- [ ] legitime-with-illegitimate — half-share computation when legitimate and illegitimate children concur (Art. 895)
+- [ ] legitime-surviving-spouse — Arts. 892, 893, 896-900: spouse's legitime varying by who they concur with (children, parents, alone)
+- [ ] legitime-ascendants — Arts. 889-891: parents/ascendants' legitime when there are no descendants
+- [ ] free-portion-rules — computation of disposable free portion: total estate minus total legitime of all compulsory heirs
+
+### Wave 4: Distribution Rules
+- [ ] intestate-order — Arts. 960-1014: complete priority order for intestate succession (descendants → ascendants → spouse → collaterals → state)
+- [ ] testate-institution — Arts. 840-856: institution of heirs in a will, conditions, modal institutions
+- [ ] testate-validation — algorithm for checking if a will respects all compulsory heirs' legitime (inofficious disposition reduction)
+- [ ] disinheritance-rules — Arts. 915-923: valid grounds for disinheritance, effect on disinherited heir's descendants
+- [ ] preterition — Art. 854: effect of totally omitting a compulsory heir from a will (annuls institution, preserves legacies/devises if within free portion)
+- [ ] accretion-rules — Arts. 1015-1023: how a vacant share distributes to co-heirs
+- [ ] collation — Arts. 1061-1077: accounting for inter vivos donations/advances when computing legitime and free portion
+
+### Wave 5: Synthesis
+- [ ] computation-pipeline — end-to-end computation flow: inputs → heir classification → legitime → free portion → distribution → per-heir amounts → narrative
+- [ ] data-model — complete type definitions (Decedent, Heir, Will, HeirCategory, InheritanceShare, etc.)
+- [ ] test-vectors — 10+ complete test cases across intestate, testate, mixed, with illegitimate children, adopted children, representation, preterition
+- [ ] explainer-format — template for per-heir plain-English narrative explanations with peso amounts and article citations
+- [ ] edge-cases — catalog of all edge cases: renunciation, commorientes, unworthiness, reserva troncal, collation
+- [ ] spec-draft — synthesize all analysis into complete software spec at `../../docs/plans/inheritance-engine-spec.md`
+- [ ] spec-review — self-review: can a developer with no Philippine law knowledge build the engine from this spec?
+
+## Recently Analyzed
+(Empty — loop hasn't started yet)

--- a/loops/inheritance-reverse/reverse-ralph.sh
+++ b/loops/inheritance-reverse/reverse-ralph.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Ralph Loop — Inheritance Distribution Engine (Reverse)
+# Analyzes Philippine succession law → inheritance distribution engine spec.
+# Runs Claude Code repeatedly until convergence.
+#
+# Usage: cd loops/inheritance-reverse && ./reverse-ralph.sh [max_iterations]
+
+set -uo pipefail
+
+# Allow nested Claude Code sessions
+unset CLAUDECODE 2>/dev/null || true
+
+WORK_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_NAME="$(basename "$WORK_DIR")"
+PROMPT_FILE="$WORK_DIR/PROMPT.md"
+CONVERGED_FILE="$WORK_DIR/status/converged.txt"
+PAUSED_FILE="$WORK_DIR/status/paused.txt"
+MAX_ITERATIONS=${1:-40}
+SLEEP_BETWEEN=5
+
+cd "$WORK_DIR"
+
+if [ ! -f "$PROMPT_FILE" ]; then
+    echo "ERROR: PROMPT.md not found at $PROMPT_FILE"
+    exit 1
+fi
+
+if [ -f "$PAUSED_FILE" ]; then
+    echo "Loop '$LOOP_NAME' is paused. Remove status/paused.txt to resume."
+    exit 0
+fi
+
+if [ -f "$CONVERGED_FILE" ]; then
+    echo "Loop '$LOOP_NAME' already converged."
+    exit 0
+fi
+
+mkdir -p status
+
+iteration=0
+failures=0
+
+echo "=== Ralph Loop Starting: $LOOP_NAME ==="
+echo "Working directory: $WORK_DIR"
+echo "Max iterations: $MAX_ITERATIONS"
+echo ""
+
+while [ ! -f "$CONVERGED_FILE" ] && [ "$iteration" -lt "$MAX_ITERATIONS" ]; do
+    iteration=$((iteration + 1))
+    echo "--- Iteration $iteration / $MAX_ITERATIONS ---"
+    echo "$(date '+%Y-%m-%d %H:%M:%S')"
+
+    iter_log="/tmp/ralph-${LOOP_NAME}-iter-${iteration}.log"
+    if timeout 1800 bash -c 'unset CLAUDECODE; cat "$1" | stdbuf -oL claude --print --dangerously-skip-permissions' _ "$PROMPT_FILE" 2>&1 | stdbuf -oL tee "$iter_log"; then
+        echo ""
+        echo "Iteration $iteration completed successfully."
+        failures=0
+    else
+        iter_exit=$?
+        if [ "$iter_exit" -eq 124 ]; then
+            echo "WARNING: Iteration $iteration timed out after 1800s"
+        else
+            echo "WARNING: Iteration $iteration exited with code $iter_exit"
+        fi
+        failures=$((failures + 1))
+        if [ "$failures" -ge 3 ]; then
+            echo "ERROR: 3 consecutive failures. Stopping loop."
+            break
+        fi
+    fi
+
+    echo "Sleeping ${SLEEP_BETWEEN}s..."
+    sleep "$SLEEP_BETWEEN"
+done
+
+echo ""
+echo "=== Loop Summary: $LOOP_NAME ==="
+echo "Iterations run: $iteration"
+echo "Failures: $failures"
+
+if [ -f "$CONVERGED_FILE" ]; then
+    echo "Status: CONVERGED"
+    cat "$CONVERGED_FILE"
+elif [ "$iteration" -ge "$MAX_ITERATIONS" ]; then
+    echo "Status: STOPPED (max iterations reached)"
+    echo "Check frontier/ for remaining work."
+else
+    echo "Status: STOPPED (failures)"
+    echo "Check /tmp/ralph-${LOOP_NAME}-iter-*.log for details."
+fi


### PR DESCRIPTION
## Summary

Establishes a reverse ralph loop to systematically extract Philippine succession law rules and synthesize them into a complete software specification for a deterministic inheritance distribution engine.

## Key Changes

- **New reverse ralph loop** (`loops/inheritance-reverse/`): A 5-wave analysis framework that extracts every inheritance distribution rule from the Philippine Civil Code (Book III), Family Code, and RA 8552, then synthesizes them into an executable specification
  - `PROMPT.md`: Comprehensive 221-line specification defining the loop's goal, working methods, analysis techniques by wave, and rules for convergence
  - `reverse-ralph.sh`: Bash harness that runs Claude Code iteratively until the loop converges (max 40 iterations, 30-minute sleep between runs)
  - `frontier/aspects.md`: Frontier tracking 28 pending analysis aspects organized by dependency wave (legal source acquisition → heir classification → legitime computation → distribution rules → synthesis)
  - `frontier/analysis-log.md`: Timestamped log of completed analyses

- **New idea entity** (`entities/ideas/inheritance-distribution-engine.md`): Documents the inheritance distribution engine as a companion to the estate-tax calculator, explaining scope (testate/intestate/mixed succession), architecture (fully deterministic), and output format (per-heir amounts + narrative explanations)

- **Loop registry entry** (`loops/_registry.yaml`): Registers the new loop with 40 max iterations, 15-minute timeout, active status

## Implementation Details

The loop is designed to produce a specification that enables any developer—regardless of Philippine law knowledge—to implement the engine. Each iteration analyzes one aspect (extraction of a single succession rule), writes findings to `analysis/{aspect-name}.md`, updates the frontier, and commits. The five waves progress from legal source acquisition through heir classification, legitime computation, distribution rules, and final synthesis into a complete spec at `docs/plans/inheritance-engine-spec.md`.

The engine takes a net distributable estate (output of the estate-tax engine) and a structured family tree as input, and produces per-heir peso amounts with plain-English narratives citing specific Civil Code articles—making it user-targeted for heirs and executors, not just a computation module.

https://claude.ai/code/session_01B8h9qkVZdhDLQcFgqkS4vL