### PR TITLE
loop: inheritance-rust-forward

### DIFF
--- a/loops/_registry.yaml
+++ b/loops/_registry.yaml
@@ -54,3 +54,11 @@ loops:
     status: converged
     created: 2026-02-23
     converged_at: "2026-02-23"
+  inheritance-rust-forward:
+    description: "Build PH inheritance distribution engine in Rust from spec, 12-stage TDD pipeline"
+    type: forward
+    schedule: "*/30 * * * *"
+    max_iterations: 50
+    timeout_minutes: 30
+    status: active
+    created: 2026-02-24

--- a/loops/inheritance-rust-forward/PROMPT.md
+++ b/loops/inheritance-rust-forward/PROMPT.md
@@ -1,0 +1,150 @@
+# Forward Ralph Loop — Inheritance Distribution Engine (Rust)
+
+You are a development agent in a forward ralph loop. Each time you run, you do ONE unit of work: write tests, implement code, or fix failures for a single pipeline stage, then commit and exit.
+
+## Your Working Directories
+
+- **Loop + Engine dir**: `loops/inheritance-rust-forward/` (both loop frontier AND Rust crate)
+- **Spec**: `docs/plans/inheritance-engine-spec.md` (your source of truth for ALL types, algorithms, and parameters)
+
+## What To Do This Iteration
+
+1. **Read the frontier**: Open `frontier/current-stage.md`
+2. **Identify your work priority** (pick the FIRST that applies):
+
+   **Priority 1 — SCAFFOLD** (if `Cargo.toml` doesn't exist):
+   - Create the Rust project skeleton:
+     - `Cargo.toml` with dependencies: `num-rational`, `num-bigint`, `num-traits`, `serde`, `serde_json`, `thiserror`
+     - `src/lib.rs` — crate root, module declarations
+     - `src/main.rs` — CLI entry point (placeholder)
+     - `src/types.rs` — ALL data model types from Spec §3 (Fraction, Money, EngineInput, Decedent, Person, Heir, Will, Donation, EngineOutput, etc.)
+     - `src/fraction.rs` — Exact rational arithmetic wrapper around `num_rational::BigRational` with helpers: `frac(n, d)`, `money_to_frac()`, `frac_to_centavos()`, GCD reduction
+   - Write tests for fraction operations (add, sub, mul, div, comparison, GCD reduction, centavo conversion)
+   - Ensure `cargo build` and `cargo test` pass
+   - Commit: `forward: stage 0 - scaffold project, types, and fraction lib`
+   - Exit
+
+   **Priority 2 — WRITE TESTS** (if `src/step{N}_{name}.rs` doesn't exist or its `#[cfg(test)] mod tests` has < 5 test functions):
+   - Read the spec sections listed in the stage table below
+   - Write comprehensive tests covering: happy path, edge cases, and any test vectors from Spec §14 that exercise this step
+   - Use `BigRational` fractions for all assertions — never floating-point
+   - Tests must compile and run (they will fail since implementation doesn't exist yet — that's expected)
+   - Create stub functions that return `todo!()` or `unimplemented!()` so tests compile
+   - Commit: `forward: stage {N} - write tests`
+   - Exit
+
+   **Priority 3 — IMPLEMENT** (if tests exist but the step module is mostly stubs/`todo!()`):
+   - Read the spec sections carefully — use exact algorithms, fractions, and rules
+   - Implement the step's public functions
+   - Focus on making as many tests pass as possible in one iteration
+   - Every parameter and threshold comes from the spec — never invent values
+   - Commit: `forward: stage {N} - implement {description}`
+   - Exit
+
+   **Priority 4 — FIX FAILURES** (if tests exist and some are failing):
+   - Read the test output in `frontier/current-stage.md`
+   - Identify the root cause of 1-3 related failures
+   - Fix the implementation code (NOT the tests, unless a test contradicts the spec)
+   - Commit: `forward: stage {N} - fix {description}`
+   - Exit
+
+   **Priority 5 — DONE** (if ALL tests in `cargo test step{N}` pass):
+   - This shouldn't happen (the loop detects convergence externally)
+   - But if you see it: write `status/stage-{N}-complete.txt`
+   - Exit
+
+3. **Commit your work** before exiting. Always. Even partial progress.
+
+## Stage Table
+
+| Stage | Name | Module | Spec Sections | Pipeline Step |
+|-------|------|--------|---------------|---------------|
+| 0 | Scaffold + Types + Fractions | `types.rs`, `fraction.rs` | §3, §15 | — |
+| 1 | Classify Heirs | `step1_classify.rs` | §4 (Heir Classification) | Step 1 |
+| 2 | Build Lines | `step2_lines.rs` | §5 (Representation) | Step 2 |
+| 3 | Determine Succession Type + Scenario | `step3_scenario.rs` | §3.7, §2.4 | Step 3 |
+| 4 | Compute Estate Base (Collation Add) | `step4_estate_base.rs` | §8.1-8.3 (which donations are collatable) | Step 4 |
+| 5 | Compute Legitimes + Free Portion | `step5_legitimes.rs` | §6, §2.3 (FP pipeline) | Step 5 |
+| 6 | Testate Validation | `step6_validation.rs` | §9 (preterition, disinheritance, underprovision, inofficiousness) | Step 6 |
+| 7 | Distribute Estate | `step7_distribute.rs` | §7 (intestate), §7.5 (mixed), testate distribution | Step 7 |
+| 8 | Collation Adjustment | `step8_collation.rs` | §8.4-8.7 (impute donations against shares) | Step 8 |
+| 9 | Vacancy Resolution | `step9_vacancy.rs` | §10 (substitution, representation, accretion, intestate fallback) | Step 9 |
+| 10 | Finalize + Narrate | `step10_finalize.rs` | §11 (narrative templates), §12 (rounding) | Step 10 |
+| 11 | Integration (End-to-End) | `tests/integration.rs` | §14 (23 test vectors), §14.2 (10 invariants) | All |
+
+## Key Spec References
+
+### Data Model (§3) — Types You Must Define
+
+```
+Fraction (BigRational wrapper)     Money (centavos: BigInt)
+EngineInput                        EngineOutput
+Decedent                           Person
+Heir                               HeirCategory / EffectiveCategory
+Will                               InstitutionOfHeir / Legacy / Devise
+Donation                           Disinheritance
+InheritanceShare                   HeirNarrative
+ScenarioCode (T1-T15, I1-I15)     SuccessionType
+```
+
+### Fraction Arithmetic (§15.2)
+
+- ALL intermediate computations use exact `BigRational`
+- Convert to `Money` (centavos) ONLY in Step 10
+- Rounding: banker's rounding, remainder distributed to largest-share heir (§12)
+
+### Test Vectors (§14)
+
+23 test vectors cover 17 scenarios. The integration stage (11) must run all of them end-to-end. Individual stages should test the subset of vectors relevant to their step.
+
+Key vectors per stage:
+- Stage 1: TV-17 (filiation gate), TV-09 (adopted = legitimate)
+- Stage 2: TV-10 (representation per stirpes), TV-08 (disinheritance + representation)
+- Stage 3: TV-06/TV-07 (testate vs preterition), TV-14 (mixed detection)
+- Stage 4: TV-11 (collation), TV-22 (representation collation)
+- Stage 5: TV-13 (cap rule), TV-16 (articulo mortis)
+- Stage 6: TV-07 (preterition annuls), TV-08 (valid disinheritance), TV-12 (inofficious legacy)
+- Stage 7: TV-02/TV-03 (intestate formulas), TV-14 (mixed 3-phase)
+- Stage 8: TV-22 (donation imputation)
+- Stage 9: TV-19 (total renunciation restart)
+- Stage 10: All vectors (narrative + rounding verification)
+- Stage 11: ALL 23 vectors end-to-end + 10 invariants
+
+### Invariants (§14.2)
+
+Every test case must satisfy:
+1. **Sum**: total distributed from estate = net_distributable_estate
+2. **Legitime floor**: compulsory heirs receive >= legitime (except valid disinheritance)
+3. **Art. 895 ratio**: IC_share <= 1/2 * LC_share (testate only)
+4. **Cap**: total IC legitimes <= FP_remaining_after_spouse (testate only)
+5. **Representation**: sum of representatives = line ancestor's share
+6. **Adoption**: adopted_child.share == legitimate_child.share
+7. **Preterition**: if detected -> ALL institutions annulled
+8. **Disinheritance**: if valid -> heir gets 0 but descendants may represent
+9. **Collation**: estate_base = net_estate + collatable_donations; from_estate_sum = net_estate
+10. **Scenario consistency**: scenario code matches surviving heir combination
+
+## Rules
+
+- Do ONE unit of work, then exit. Do not do multiple priorities in one iteration.
+- Always read the spec before writing code. The spec is the source of truth.
+- Every algorithm, fraction, threshold, and rule comes from the spec — never invent values.
+- Use `BigRational` for ALL intermediate arithmetic. Zero tolerance for floating-point in computation paths.
+- Never modify a passing test to keep it passing after a code change.
+- If a test contradicts the spec, fix the test AND note it in your commit message.
+- Keep modules focused: one pipeline step per file.
+- Public API for each step: `pub fn step{N}_{name}(input: &StepNInput) -> StepNOutput`
+- Re-export all step functions from `lib.rs` for integration use.
+
+## Commit Convention
+
+```
+forward: stage {N} - {description}
+```
+
+Examples:
+- `forward: stage 0 - scaffold project, types, and fraction lib`
+- `forward: stage 1 - write heir classification tests`
+- `forward: stage 1 - implement classify_heirs`
+- `forward: stage 5 - fix cap rule spouse priority`
+- `forward: stage 11 - integration test vectors TV-01 through TV-10`

--- a/loops/inheritance-rust-forward/forward-ralph.sh
+++ b/loops/inheritance-rust-forward/forward-ralph.sh
@@ -1,0 +1,294 @@
+#!/bin/bash
+# Forward Ralph Loop — Inheritance Distribution Engine (Rust)
+# Runs Claude Code repeatedly to build one pipeline stage at a time.
+#
+# Usage:
+#   ./forward-ralph.sh [stage_number]   # Build a specific stage (0-11)
+#   ./forward-ralph.sh                  # Auto-detect lowest incomplete stage
+#   ./forward-ralph.sh all              # Build all stages sequentially
+
+set -uo pipefail
+
+unset CLAUDECODE 2>/dev/null || true
+
+WORK_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROMPT_FILE="$WORK_DIR/PROMPT.md"
+STAGE_PLAN="$WORK_DIR/frontier/stage-plan.md"
+CURRENT_STAGE_FILE="$WORK_DIR/frontier/current-stage.md"
+MAX_ITERATIONS=${2:-40}
+SLEEP_BETWEEN=5
+
+# Dev order (sequential pipeline)
+DEV_ORDER=(0 1 2 3 4 5 6 7 8 9 10 11)
+
+# Stage names for display
+declare -A STAGE_NAMES=(
+    [0]="Scaffold + Types + Fractions"
+    [1]="Classify Heirs"
+    [2]="Build Lines"
+    [3]="Succession Type + Scenario"
+    [4]="Compute Estate Base"
+    [5]="Compute Legitimes + FP"
+    [6]="Testate Validation"
+    [7]="Distribute Estate"
+    [8]="Collation Adjustment"
+    [9]="Vacancy Resolution"
+    [10]="Finalize + Narrate"
+    [11]="Integration (End-to-End)"
+)
+
+# Stage dependencies (space-separated upstream stage numbers)
+declare -A STAGE_DEPS=(
+    [0]=""
+    [1]="0"
+    [2]="1"
+    [3]="1"
+    [4]="0"
+    [5]="3"
+    [6]="5"
+    [7]="2 5 6"
+    [8]="4 7"
+    [9]="7"
+    [10]="7 8 9"
+    [11]="0 1 2 3 4 5 6 7 8 9 10"
+)
+
+# Test filter patterns for cargo test
+declare -A STAGE_TEST_FILTERS=(
+    [0]="fraction"
+    [1]="step1"
+    [2]="step2"
+    [3]="step3"
+    [4]="step4"
+    [5]="step5"
+    [6]="step6"
+    [7]="step7"
+    [8]="step8"
+    [9]="step9"
+    [10]="step10"
+    [11]="integration"
+)
+
+cd "$WORK_DIR"
+
+if [ ! -f "$PROMPT_FILE" ]; then
+    echo "ERROR: PROMPT.md not found at $PROMPT_FILE"
+    exit 1
+fi
+
+# --- Helper functions ---
+
+stage_complete() {
+    [ -f "$WORK_DIR/status/stage-${1}-complete.txt" ]
+}
+
+check_dependencies() {
+    local stage=$1
+    local deps="${STAGE_DEPS[$stage]}"
+    for dep in $deps; do
+        if ! stage_complete "$dep"; then
+            echo "ERROR: Stage $stage depends on Stage $dep, which is not complete."
+            echo "Run: ./forward-ralph.sh $dep"
+            return 1
+        fi
+    done
+    return 0
+}
+
+auto_detect_stage() {
+    for s in "${DEV_ORDER[@]}"; do
+        if ! stage_complete "$s"; then
+            echo "$s"
+            return
+        fi
+    done
+    echo "-1"  # All complete
+}
+
+run_tests() {
+    local stage=$1
+    local filter="${STAGE_TEST_FILTERS[$stage]}"
+
+    # No Cargo.toml = no tests possible (stage 0 hasn't run yet)
+    if [ ! -f "$WORK_DIR/Cargo.toml" ]; then
+        echo "NO_TESTS"
+        return
+    fi
+
+    local output
+    if [ "$stage" -eq 11 ]; then
+        # Integration tests are in tests/ directory
+        output=$(cd "$WORK_DIR" && cargo test --test integration 2>&1) || true
+    else
+        output=$(cd "$WORK_DIR" && cargo test "$filter" 2>&1) || true
+    fi
+    echo "$output"
+}
+
+tests_pass() {
+    local test_output="$1"
+    echo "$test_output" | grep -qE "^error" && return 1
+    echo "$test_output" | grep -q "FAILED" && return 1
+    echo "$test_output" | grep -q "test result: ok" && return 0
+    return 1  # No "ok" found
+}
+
+update_frontier() {
+    local stage=$1
+    local test_output="$2"
+    local iteration=$3
+
+    # Preserve existing work log
+    local existing_log
+    existing_log=$(grep "^- iter" "$CURRENT_STAGE_FILE" 2>/dev/null || echo "(no iterations yet)")
+
+    local spec_sections=""
+    case $stage in
+        0)  spec_sections="- Data Model: §3 (all types)\n- Implementation Notes: §15 (language-agnostic, BigInt fractions, determinism)" ;;
+        1)  spec_sections="- Heir Classification: §4\n- Eligibility Gate: §4.3\n- Filiation Proof: §4.4" ;;
+        2)  spec_sections="- Representation: §5\n- Build Lines Algorithm: §5.3" ;;
+        3)  spec_sections="- Scenario Codes: §3.7\n- Mixed Succession Detection: §2.4" ;;
+        4)  spec_sections="- Collation: §8.1-8.3 (which donations are collatable)" ;;
+        5)  spec_sections="- Legitime Fraction Table: §6\n- FP Pipeline: §2.3\n- Cap Rule: §6.6" ;;
+        6)  spec_sections="- Testate Validation: §9 (preterition, disinheritance, underprovision, inofficiousness)" ;;
+        7)  spec_sections="- Intestate Distribution: §7\n- Mixed Succession: §7.5" ;;
+        8)  spec_sections="- Collation Adjustment: §8.4-8.7 (impute donations against shares)" ;;
+        9)  spec_sections="- Vacancy Resolution: §10 (substitution, representation, accretion, intestate fallback)" ;;
+        10) spec_sections="- Narrative Templates: §11\n- Rounding: §12" ;;
+        11) spec_sections="- Test Vectors: §14 (23 vectors)\n- Invariants: §14.2 (10 invariants)\n- Edge Cases: §13" ;;
+    esac
+
+    cat > "$CURRENT_STAGE_FILE" << FRONTIER_EOF
+# Current Stage: $stage (${STAGE_NAMES[$stage]})
+
+## Spec Sections
+$(echo -e "$spec_sections")
+
+## Test Results (updated by loop — iteration $iteration)
+\`\`\`
+$test_output
+\`\`\`
+
+## Work Log
+$existing_log
+FRONTIER_EOF
+}
+
+write_completion() {
+    local stage=$1
+    local test_output="$2"
+    local iteration=$3
+
+    local test_count
+    test_count=$(echo "$test_output" | grep -oE "[0-9]+ passed" | head -1 || echo "unknown")
+
+    cat > "$WORK_DIR/status/stage-${stage}-complete.txt" << COMPLETE_EOF
+COMPLETE
+Stage: $stage (${STAGE_NAMES[$stage]})
+Tests: $test_count
+Iterations: $iteration
+Timestamp: $(date -Iseconds)
+COMPLETE_EOF
+
+    echo "=== Stage $stage COMPLETE ==="
+    cat "$WORK_DIR/status/stage-${stage}-complete.txt"
+}
+
+# --- Main logic ---
+
+run_stage() {
+    local stage=$1
+
+    echo "=== Forward Ralph: Stage $stage (${STAGE_NAMES[$stage]}) ==="
+
+    # Check dependencies
+    if ! check_dependencies "$stage"; then
+        exit 1
+    fi
+
+    # Already complete?
+    if stage_complete "$stage"; then
+        echo "Stage $stage is already complete."
+        cat "$WORK_DIR/status/stage-${stage}-complete.txt"
+        return 0
+    fi
+
+    local iteration=0
+    local failures=0
+
+    while [ "$iteration" -lt "$MAX_ITERATIONS" ]; do
+        iteration=$((iteration + 1))
+        echo ""
+        echo "--- Stage $stage, Iteration $iteration / $MAX_ITERATIONS ---"
+        echo "$(date '+%Y-%m-%d %H:%M:%S')"
+
+        # Run tests and update frontier
+        local test_output
+        test_output=$(run_tests "$stage")
+
+        update_frontier "$stage" "$test_output" "$iteration"
+
+        # Check convergence
+        if [ "$test_output" != "NO_TESTS" ] && tests_pass "$test_output"; then
+            write_completion "$stage" "$test_output" "$iteration"
+            return 0
+        fi
+
+        # Run Claude
+        local iter_log="/tmp/forward-ralph-inheritance-stage-${stage}-iter-${iteration}.log"
+        if timeout 1800 bash -c \
+            'unset CLAUDECODE; cat "$1" | stdbuf -oL claude --print --dangerously-skip-permissions' \
+            _ "$PROMPT_FILE" 2>&1 | stdbuf -oL tee "$iter_log"; then
+            echo ""
+            echo "Iteration $iteration completed successfully."
+            failures=0
+        else
+            local iter_exit=$?
+            if [ "$iter_exit" -eq 124 ]; then
+                echo "WARNING: Iteration $iteration timed out after 1800s"
+            else
+                echo "WARNING: Iteration $iteration exited with code $iter_exit"
+            fi
+            failures=$((failures + 1))
+            if [ "$failures" -ge 3 ]; then
+                echo "ERROR: 3 consecutive failures. Stopping."
+                return 1
+            fi
+        fi
+
+        echo "Sleeping ${SLEEP_BETWEEN}s..."
+        sleep "$SLEEP_BETWEEN"
+    done
+
+    echo "ERROR: Stage $stage did not converge in $MAX_ITERATIONS iterations."
+    return 1
+}
+
+# --- Entry point ---
+
+MODE="${1:-auto}"
+
+if [ "$MODE" = "all" ]; then
+    for s in "${DEV_ORDER[@]}"; do
+        if ! stage_complete "$s"; then
+            run_stage "$s" || exit 1
+        fi
+    done
+    echo ""
+    echo "=== All stages complete ==="
+elif [ "$MODE" = "auto" ]; then
+    STAGE=$(auto_detect_stage)
+    if [ "$STAGE" = "-1" ]; then
+        echo "All stages are already complete."
+        exit 0
+    fi
+    echo "Auto-detected: Stage $STAGE (${STAGE_NAMES[$STAGE]})"
+    run_stage "$STAGE"
+else
+    STAGE="$MODE"
+    if [ -z "${STAGE_NAMES[$STAGE]+x}" ]; then
+        echo "ERROR: Unknown stage '$STAGE'. Valid: 0 1 2 3 4 5 6 7 8 9 10 11 all"
+        exit 1
+    fi
+    run_stage "$STAGE"
+fi

--- a/loops/inheritance-rust-forward/frontier/current-stage.md
+++ b/loops/inheritance-rust-forward/frontier/current-stage.md
@@ -1,0 +1,18 @@
+# Current Stage: 0 (Scaffold + Types + Fractions)
+
+## Spec Sections
+- Data Model: §3 (all types)
+- Implementation Notes: §15 (language-agnostic, BigInt fractions, determinism)
+
+## Test Results (updated by loop)
+```
+(no tests yet — scaffold not created)
+```
+
+## Validation Results (updated by loop)
+```
+(not yet run)
+```
+
+## Work Log
+(no iterations yet)

--- a/loops/inheritance-rust-forward/frontier/stage-plan.md
+++ b/loops/inheritance-rust-forward/frontier/stage-plan.md
@@ -1,0 +1,20 @@
+# Forward Ralph — Stage Plan
+
+Dev order: 0 → 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9 → 10 → 11
+
+| Stage | Name                          | Spec Sections    | Depends On | Status  |
+|-------|-------------------------------|------------------|------------|---------|
+| 0     | Scaffold + Types + Fractions  | §3, §15          | —          | pending |
+| 1     | Classify Heirs                | §4               | 0          | blocked |
+| 2     | Build Lines                   | §5               | 1          | blocked |
+| 3     | Succession Type + Scenario    | §3.7, §2.4       | 1          | blocked |
+| 4     | Compute Estate Base           | §8.1-8.3         | 0          | blocked |
+| 5     | Compute Legitimes + FP        | §6, §2.3         | 3          | blocked |
+| 6     | Testate Validation            | §9               | 5          | blocked |
+| 7     | Distribute Estate             | §7, §7.5         | 2, 5, 6    | blocked |
+| 8     | Collation Adjustment          | §8.4-8.7         | 4, 7       | blocked |
+| 9     | Vacancy Resolution            | §10              | 7          | blocked |
+| 10    | Finalize + Narrate            | §11, §12         | 7, 8, 9    | blocked |
+| 11    | Integration (End-to-End)      | §14              | 0-10       | blocked |
+
+Status values: blocked | pending | active | complete


### PR DESCRIPTION
## Summary
- Scaffolds a 12-stage forward ralph loop to build the PH inheritance distribution engine in Rust
- Stages map 1:1 to the spec's 10-step pipeline (classify heirs → build lines → scenario → estate base → legitimes → testate validation → distribute → collation adjustment → vacancy resolution → finalize/narrate) plus scaffold and integration
- TDD approach: each stage writes tests first from spec, then implements until `cargo test` passes
- Uses `num-rational` BigRational for exact fraction arithmetic — zero floating-point in computation paths
- Spec source: `docs/plans/inheritance-engine-spec.md` (converged from inheritance-reverse loop)

## Test plan
- [ ] `./forward-ralph.sh 0` scaffolds Rust project with types + fraction tests passing
- [ ] Subsequent stages build incrementally with `cargo test step{N}` convergence
- [ ] Stage 11 runs all 23 test vectors end-to-end and verifies 10 invariants

🤖 Generated with [Claude Code](https://claude.com/claude-code)