### PR TITLE
loop: inheritance-frontend-forward

### DIFF
--- a/loops/_registry.yaml
+++ b/loops/_registry.yaml
@@ -79,6 +79,14 @@ loops:
     timeout_minutes: 30
     status: active
     created: 2026-02-24
+  inheritance-frontend-forward:
+    description: "Build PH inheritance wizard frontend (React + TypeScript) from spec, 12-stage TDD pipeline"
+    type: forward
+    schedule: "*/30 * * * *"
+    max_iterations: 50
+    timeout_minutes: 30
+    status: active
+    created: 2026-02-25
   cheerful-reverse:
     description: "Distill Cheerful codebase → ultra-comprehensive modular rebuild spec with full user stories"
     type: reverse

--- a/loops/inheritance-frontend-forward/PROMPT.md
+++ b/loops/inheritance-frontend-forward/PROMPT.md
@@ -1,0 +1,449 @@
+# Forward Ralph Loop — Inheritance Frontend (React + TypeScript)
+
+You are a development agent in a forward ralph loop. Each time you run, you do ONE unit of work: write tests, implement code, or fix failures for a single stage, then commit and exit.
+
+## Your Working Directories
+
+- **Loop dir**: `loops/inheritance-frontend-forward/` (frontier, status, loop script)
+- **App dir**: `loops/inheritance-frontend-forward/app/` (the Vite + React project)
+- **Spec dir**: `loops/inheritance-frontend-reverse/analysis/synthesis/` (your source of truth)
+- **Cross-cutting specs**: `loops/inheritance-frontend-reverse/analysis/` (conditional-visibility.md, invalid-combinations.md, shared-components.md, scenario-field-mapping.md)
+
+## Tech Stack
+
+- **Framework**: Vite + React 18 + TypeScript (strict mode)
+- **Styling**: Tailwind CSS 4
+- **Forms**: React Hook Form + @hookform/resolvers/zod
+- **Validation**: Zod
+- **Charts**: Recharts
+- **Testing**: Vitest + @testing-library/react + @testing-library/jest-dom
+- **WASM**: Mocked initially (Stage 4), real integration in Stage 12
+
+## What To Do This Iteration
+
+1. **Read the frontier**: Open `frontier/current-stage.md`
+2. **Identify your work priority** (pick the FIRST that applies):
+
+   **Priority 1 — SCAFFOLD** (if `app/package.json` doesn't exist):
+   - Create Vite + React + TypeScript project in `app/`:
+     ```
+     app/
+     ├── package.json
+     ├── vite.config.ts
+     ├── tsconfig.json
+     ├── tailwind.config.ts (or CSS-only Tailwind v4 setup)
+     ├── vitest.config.ts (or vitest.workspace.ts)
+     ├── index.html
+     ├── src/
+     │   ├── main.tsx
+     │   ├── App.tsx
+     │   ├── index.css (Tailwind directives)
+     │   ├── types/           # Stage 2
+     │   ├── schemas/         # Stage 3
+     │   ├── wasm/            # Stage 4
+     │   ├── components/      # Stage 5+
+     │   │   ├── shared/      # Shared form components
+     │   │   ├── wizard/      # Wizard step components
+     │   │   └── results/     # Results view components
+     │   ├── hooks/           # Custom hooks
+     │   └── utils/           # Utility functions
+     └── tests/               # or __tests__/ colocated
+     ```
+   - Install dependencies:
+     ```
+     react react-dom react-hook-form @hookform/resolvers zod recharts
+     @types/react @types/react-dom typescript @vitejs/plugin-react
+     tailwindcss vite vitest @testing-library/react @testing-library/jest-dom
+     jsdom
+     ```
+   - Configure Vitest with jsdom environment
+   - Write a smoke test that imports React and renders a placeholder component
+   - Ensure `npm run dev` and `npx vitest run` both work
+   - Commit: `forward: stage 1 - scaffold vite + react + tailwind project`
+   - Exit
+
+   **Priority 2 — WRITE TESTS** (if the stage's test file has < 5 test functions):
+   - Read the spec files listed in the stage table below
+   - Write comprehensive tests covering: happy path, edge cases, validation rules
+   - For component tests: use `@testing-library/react` to render, fill fields, and assert
+   - For type/schema tests: test valid inputs, invalid inputs, boundary values, serialization
+   - Tests MUST compile and run (they may fail if implementation doesn't exist yet)
+   - Create stub exports so tests can import (empty functions, placeholder components)
+   - Commit: `forward: stage {N} - write tests`
+   - Exit
+
+   **Priority 3 — IMPLEMENT** (if tests exist but the module is mostly stubs):
+   - Read the spec files carefully — use exact types, field names, enums, and validation rules
+   - Implement the module/component to pass as many tests as possible
+   - Every type name, enum variant, field name, and validation rule comes from the spec — never invent
+   - Focus on one cohesive piece per iteration (don't try to implement everything)
+   - Commit: `forward: stage {N} - implement {description}`
+   - Exit
+
+   **Priority 4 — FIX FAILURES** (if tests exist and some are failing):
+   - Read the test output in `frontier/current-stage.md`
+   - Identify the root cause of 1-3 related failures
+   - Fix the implementation code (NOT the tests, unless a test contradicts the spec)
+   - Commit: `forward: stage {N} - fix {description}`
+   - Exit
+
+   **Priority 5 — DONE** (if ALL tests pass):
+   - This shouldn't happen (the loop detects convergence externally)
+   - If you see it: write `status/stage-{N}-complete.txt` and exit
+
+3. **Commit your work** before exiting. Always. Even partial progress.
+
+## Stage Table
+
+| Stage | Name | Test Filter | Spec Files | Depends On |
+|-------|------|-------------|-----------|-----------|
+| 1 | Project Scaffold | `smoke` | — | — |
+| 2 | Types & Enums | `types` | `synthesis/types.ts` | 1 |
+| 3 | Zod Schemas | `schemas` | `synthesis/schemas.ts` | 2 |
+| 4 | WASM Bridge Mock | `wasm` | `engine-output.md`, `scenario-field-mapping.md` | 2 |
+| 5 | Shared Components | `shared` | `shared-components.md` | 1 |
+| 6 | Wizard Steps 1-2 | `wizard-step1\|wizard-step2\|estate\|decedent` | `synthesis/wizard-steps.md` §1-2 | 3, 5 |
+| 7 | Wizard Step 3 | `wizard-step3\|family-tree\|person` | `synthesis/wizard-steps.md` §3 | 3, 5 |
+| 8 | Wizard Step 4 | `wizard-step4\|will\|institution\|legacy\|devise\|disinheritance` | `synthesis/wizard-steps.md` §4 | 7 |
+| 9 | Wizard Steps 5-6 | `wizard-step5\|wizard-step6\|donation\|review` | `synthesis/wizard-steps.md` §5-6 | 7 |
+| 10 | Results View | `results` | `synthesis/results-view.md` | 4 |
+| 11 | Validation Layer 3 | `validation\|warning` | `invalid-combinations.md`, `conditional-visibility.md` | 6, 7, 8, 9 |
+| 12 | Integration & Polish | `integration\|e2e` | `synthesis/spec-summary.md` | all |
+
+## Stage Details
+
+### Stage 1 — Project Scaffold
+
+Create the Vite project. Bare minimum to get `npx vitest run` passing with one smoke test.
+
+### Stage 2 — Types & Enums
+
+**Read**: `../inheritance-frontend-reverse/analysis/synthesis/types.ts`
+
+Produce `src/types/index.ts` containing:
+- All 17 TypeScript interfaces (EngineInput, EngineOutput, Decedent, Person, Will, etc.)
+- All 12 enums (Relationship, FiliationProof, DisinheritanceCause, ScenarioCode, etc.)
+- Utility functions: `pesosToCentavos()`, `centavosToPesos()`, `formatPeso()`, `serializeCentavos()`, `fracToString()`, `stringToFrac()`
+
+**Tests** (`src/types/__tests__/types.test.ts`):
+- Each enum has the correct number of variants with exact PascalCase strings
+- `pesosToCentavos(500)` === 50000
+- `centavosToPesos(50025)` === 500.25
+- `formatPeso(500000000)` === "₱5,000,000"
+- `formatPeso(50025)` === "₱500.25"
+- `fracToString(1, 2)` === "1/2"
+- `stringToFrac("1/2")` === `{numer: 1, denom: 2}`
+- Type-level tests: EngineInput requires all 6 fields, Person requires id + name + relationship
+
+### Stage 3 — Zod Schemas
+
+**Read**: `../inheritance-frontend-reverse/analysis/synthesis/schemas.ts`
+
+Produce `src/schemas/index.ts` containing:
+- All Zod schemas from the spec synthesis
+- DateSchema, FracSchema, MoneySchema, CentavosValueSchema
+- All enum schemas (12)
+- PersonSchema with conditional superRefine (adoption for AC, filiation for IC, blood_type for Sibling, line for LP/LA)
+- DonationSchema with 11 exemption flags + mutual exclusion
+- WillSchema, InstitutionOfHeirSchema, LegacySchema, DeviseSchema, DisinheritanceSchema
+- EngineInputSchema with all 7 top-level superRefine constraints
+
+**Tests** (`src/schemas/__tests__/schemas.test.ts`):
+- Valid EngineInput parses successfully
+- Invalid date format rejected ("2026/01/15" → error, "2026-01-15" → ok)
+- Invalid Frac format rejected ("1:2" → error, "1/2" → ok)
+- Money: negative centavos rejected, string centavos accepted
+- Person: AdoptedChild without adoption record → error
+- Person: IllegitimateChild without filiation_proved → error
+- Person: Sibling without blood_type → error
+- Donation: multiple exemption flags → error
+- Will date after death date → error
+- Duplicate person IDs → error
+- Multiple SurvivingSpouse → error
+- At least 15 test cases covering edge cases from `invalid-combinations.md`
+
+### Stage 4 — WASM Bridge Mock
+
+**Read**: `../inheritance-frontend-reverse/analysis/engine-output.md`, `../inheritance-frontend-reverse/analysis/scenario-field-mapping.md`
+
+Produce `src/wasm/bridge.ts`:
+- `async function compute(input: EngineInput): Promise<EngineOutput>` — the public API
+- Mock implementation that:
+  1. Validates input with EngineInputSchema (throw on failure)
+  2. Counts heir types from `family_tree` to predict scenario code
+  3. Returns synthetic `EngineOutput` with:
+     - Plausible `InheritanceShare` entries (equal split among heirs)
+     - Placeholder `HeirNarrative` entries with `**bold**` markers
+     - Empty `warnings[]`
+     - Single-entry `computation_log`
+     - Correct `final_scenario` based on heir counts
+- The mock doesn't need to be legally accurate — just structurally correct for UI development
+
+**Tests** (`src/wasm/__tests__/bridge.test.ts`):
+- `compute()` returns EngineOutput matching the type
+- `compute()` with intestate input returns I-prefix scenario
+- `compute()` with testate input returns T-prefix scenario
+- `compute()` with invalid input throws
+- Output `shares[]` has entries for each heir in input
+- Output `narratives[]` has entries for each heir
+- `formatPeso()` correctly formats output centavo amounts
+
+### Stage 5 — Shared Components
+
+**Read**: `../inheritance-frontend-reverse/analysis/shared-components.md`
+
+Produce 5 Tier-1 shared components in `src/components/shared/`:
+
+1. **MoneyInput** — Text input that accepts peso amounts, converts to centavos. Props: `name`, `label`, `control` (from RHF), `error`. Displays "₱" prefix. Formats on blur.
+2. **DateInput** — Date picker with YYYY-MM-DD format. Props: `name`, `label`, `control`, `error`, `maxDate?`.
+3. **FractionInput** — Two number inputs (numerator/denominator) that serialize to "n/d" string. Props: `name`, `label`, `control`, `error`.
+4. **PersonPicker** — Select dropdown listing persons from the family tree. Props: `name`, `label`, `control`, `persons` (array), `filter?` (callback). Shows person name + relationship badge.
+5. **EnumSelect** — Generic select for any PascalCase enum. Props: `name`, `label`, `control`, `options` (array of {value, label}), `error`.
+
+**Tests** (`src/components/shared/__tests__/*.test.tsx`):
+- MoneyInput: entering "500" → form value is 50000 centavos
+- MoneyInput: displays "₱500.00" on blur
+- DateInput: accepts valid dates, rejects invalid
+- FractionInput: entering 1 and 2 → form value is "1/2"
+- PersonPicker: renders options, selects person
+- EnumSelect: renders all options, fires onChange
+
+### Stage 6 — Wizard Steps 1-2 (Estate + Decedent)
+
+**Read**: `../inheritance-frontend-reverse/analysis/synthesis/wizard-steps.md` — Step 1 and Step 2 sections
+
+Produce:
+- `src/components/wizard/WizardContainer.tsx` — step navigation, form state management with `useForm<EngineInput>()`
+- `src/components/wizard/EstateStep.tsx` — Step 1: MoneyInput for estate + hasWill toggle
+- `src/components/wizard/DecedentStep.tsx` — Step 2: name, date_of_death, is_illegitimate, is_married, marriage cascade (6 conditional fields), articulo mortis cascade
+
+**Key behaviors from spec**:
+- `hasWill` toggle → sets `will: null` or `will: {date_executed: "", institutions: [], legacies: [], devises: [], disinheritances: []}`
+- `is_married = false` → reset all 6 marriage fields to MARRIAGE_DEFAULTS
+- Articulo mortis warning: "Spouse's legitime E/2 → E/3 (Art. 900)" when all 4 conditions met + cohabitation < 5
+
+**Tests**:
+- EstateStep: renders MoneyInput + hasWill toggle
+- EstateStep: toggling hasWill sets will field appropriately
+- DecedentStep: marriage fields hidden when is_married=false
+- DecedentStep: toggling is_married off resets all marriage fields
+- DecedentStep: articulo mortis cascade (3-deep conditional visibility)
+- WizardContainer: step navigation forward/back, step indicator
+
+### Stage 7 — Wizard Step 3 (Family Tree)
+
+**Read**: `../inheritance-frontend-reverse/analysis/synthesis/wizard-steps.md` — Step 3 section
+
+This is the most complex step. Produce:
+- `src/components/wizard/FamilyTreeStep.tsx` — repeater for persons
+- `src/components/wizard/PersonCard.tsx` — card with all conditional fields per relationship
+- `src/components/wizard/AdoptionSubForm.tsx` — adoption details (8 fields, conditional cascade)
+- `src/components/wizard/FiliationSection.tsx` — filiation proof (IC only)
+
+**Key behaviors from spec**:
+- 11 relationship types with different conditional fields per type
+- Auto-generated person IDs: `{prefix}{index}` (lc1, sp, ic1, etc.)
+- Degree defaults and ranges per relationship
+- AdoptedChild → show adoption sub-form
+- IllegitimateChild → show filiation section
+- Sibling → show blood_type (Full/Half)
+- LP/LA → show line (Paternal/Maternal)
+- SurvivingSpouse + has_legal_separation → show guilty_party toggle
+- Deceased person with children_relevant → show children picker
+- Max 1 SurvivingSpouse (hard error)
+- Info badges: "Excluded by descendants", "Art. 1002: Excluded", etc.
+
+**Tests**:
+- PersonCard: renders correct conditional fields per relationship type (test all 11)
+- PersonCard: switching relationship resets conditional fields
+- AdoptionSubForm: visible only for AdoptedChild
+- AdoptionSubForm: stepparent toggle reveals biological_parent_spouse
+- FiliationSection: visible only for IllegitimateChild
+- FamilyTreeStep: add/remove persons
+- FamilyTreeStep: auto-generates unique person IDs
+- FamilyTreeStep: max 1 SurvivingSpouse validation
+
+### Stage 8 — Wizard Step 4 (Will & Dispositions)
+
+**Read**: `../inheritance-frontend-reverse/analysis/synthesis/wizard-steps.md` — Step 4 section
+
+Produce:
+- `src/components/wizard/WillStep.tsx` — 4 sub-tabs container, only visible when hasWill=true
+- `src/components/wizard/InstitutionsTab.tsx` — repeater for InstitutionOfHeir
+- `src/components/wizard/LegaciesTab.tsx` — repeater for Legacy
+- `src/components/wizard/DevisesTab.tsx` — repeater for Devise
+- `src/components/wizard/DisinheritancesTab.tsx` — repeater for Disinheritance
+- `src/components/wizard/ShareSpecForm.tsx` — 6-variant share spec selector
+- `src/components/wizard/HeirReferenceForm.tsx` — person_id + name + is_collective + class_designation
+
+**Key behaviors from spec**:
+- will.date_executed (DateInput, <= date_of_death)
+- Institutions: HeirReferenceForm + ShareSpec (hidden when is_residuary) + Conditions repeater + Substitutes repeater
+- Legacies: HeirReferenceForm + LegacySpec (3 variants: FixedAmount/SpecificAsset/GenericClass)
+- Devises: HeirReferenceForm + DeviseSpec (2 variants: SpecificProperty/FractionalInterest)
+- Disinheritances: PersonPicker (compulsory only) + cause_code (filtered by relationship) + 3 toggles + validity indicator
+- Preterition warning when compulsory heirs omitted from all dispositions
+- Max 1 is_residuary institution
+- ShareSpec serialization: `"EntireFreePort"` (string) vs `{"Fraction": "1/2"}` (tagged object)
+
+**Tests**:
+- WillStep: not rendered when hasWill=false
+- InstitutionsTab: add/remove institutions, ShareSpec variant switching
+- LegaciesTab: LegacySpec variant switching (FixedAmount shows MoneyInput, SpecificAsset shows text, GenericClass shows text + money)
+- DevisesTab: DeviseSpec variant switching
+- DisinheritancesTab: cause codes filtered by heir relationship group
+- DisinheritancesTab: validity indicator shows correct status
+- ShareSpecForm: serializes each variant correctly
+
+### Stage 9 — Wizard Steps 5-6 (Donations + Review)
+
+**Read**: `../inheritance-frontend-reverse/analysis/synthesis/wizard-steps.md` — Steps 5 and 6
+
+Produce:
+- `src/components/wizard/DonationsStep.tsx` — repeater for donations
+- `src/components/wizard/DonationCard.tsx` — card with 11 exemption flags + conditional fields
+- `src/components/wizard/ReviewStep.tsx` — read-only summary + advanced settings + Layer 3 warnings
+
+**Key behaviors from spec**:
+- Donation: stranger toggle hides all exemption flags + resets them
+- Professional expense → unlocks parent_required → unlocks imputed_savings (3-level cascade)
+- At most 1 exemption flag active
+- ReviewStep: summary cards (one per step), predicted scenario badge
+- AdvancedSettings (collapsed): max_pipeline_restarts (1-100, default 10), retroactive_ra_11642 (toggle, default false)
+- 13 pre-submission warnings (dismissable, severity-based)
+
+**Tests**:
+- DonationCard: stranger toggle hides exemption flags
+- DonationCard: only 1 exemption flag active at a time
+- DonationCard: professional expense cascade
+- ReviewStep: renders summary of all steps
+- ReviewStep: advanced settings collapsed by default
+- ReviewStep: pre-submission warnings render correctly
+- ReviewStep: predicted scenario badge matches heir configuration
+
+### Stage 10 — Results View
+
+**Read**: `../inheritance-frontend-reverse/analysis/synthesis/results-view.md`
+
+Produce:
+- `src/components/results/ResultsView.tsx` — container with 5 sections
+- `src/components/results/ResultsHeader.tsx` — scenario badge + succession type + estate total
+- `src/components/results/DistributionSection.tsx` — pie chart + heir table with 7 layout variants
+- `src/components/results/NarrativePanel.tsx` — expandable narrative items
+- `src/components/results/WarningsPanel.tsx` — manual flag cards (forward-compatible)
+- `src/components/results/ComputationLog.tsx` — collapsed, step list
+- `src/components/results/ActionsBar.tsx` — edit input, export JSON, copy narratives
+
+**Key behaviors from spec**:
+- 7 layout variants: standard-distribution, testate-with-dispositions, mixed-succession, preterition-override, collateral-weighted, escheat, no-compulsory-full-fp
+- Pie chart: Recharts PieChart, one slice per heir with net > 0, category-based colors
+- Heir table: standard columns always shown, secondary columns conditional
+- Excluded heirs: collapsed section for zero-share heirs
+- Narrative panel: first item expanded, Markdown bold rendering (`**text**` → `<strong>`)
+- Category badge colors: blue (LC), purple (IC), green (SS), orange (LA), gray (Collateral)
+- Actions: edit input (return to wizard), export JSON, copy narratives (stripped Markdown)
+- `formatPeso()` with BigInt for large amounts
+
+**Tests**:
+- ResultsHeader: renders scenario badge with correct color
+- DistributionSection: renders pie chart with correct slices
+- DistributionSection: renders correct layout variant per scenario
+- DistributionSection: excluded heirs section for zero-share heirs
+- NarrativePanel: first item expanded, rest collapsed
+- NarrativePanel: renders Markdown bold as `<strong>`
+- ActionsBar: export JSON produces valid EngineInput/EngineOutput
+- ActionsBar: copy narratives strips Markdown
+- Layout variant: escheat shows single card
+- Layout variant: collateral-weighted shows blood type + units columns
+
+### Stage 11 — Validation Layer 3
+
+**Read**: `../inheritance-frontend-reverse/analysis/invalid-combinations.md`, `../inheritance-frontend-reverse/analysis/conditional-visibility.md`
+
+Produce:
+- `src/hooks/useValidationWarnings.ts` — hook that computes Layer 3 warnings from form state
+- `src/hooks/usePredictScenario.ts` — hook that predicts scenario code from heir counts
+- `src/components/wizard/ValidationWarnings.tsx` — warning card component
+- Update ReviewStep to integrate validation warnings
+
+**13 pre-submission warnings** (from spec):
+1. IC with filiation_proved=false → "Art. 887 ¶3: IC excluded"
+2. Rescinded adoption → "RA 8552 Sec. 20: AC excluded"
+3. Unworthy + not condoned → "Art. 1032: Excluded unless condoned"
+4. Spouse guilty in legal sep → "Art. 1002: Spouse excluded"
+5. Invalid disinheritance → "Art. 918: Heir reinstated"
+6. Preterition detected → "Art. 854: All institutions annulled"
+7. Inofficiousness risk → "Art. 911 reduction may apply"
+8. LC-group + ascendants → "Ascendants excluded by descendants"
+9. Compulsory heirs + collaterals → "Collaterals excluded"
+10. Empty will → "Will has no dispositions"
+11. Spouse but unmarried decedent → "Inconsistency"
+12. Empty family tree → "Estate escheats to State (I15)"
+13. All heirs marked deceased → "Pipeline restart likely"
+
+**Tests**:
+- Each of the 13 warnings triggers under correct conditions
+- Warnings don't trigger when conditions aren't met
+- predictScenario returns correct codes for common configurations
+- Warnings display with correct severity styling (error/warning/info)
+
+### Stage 12 — Integration & Polish
+
+**Read**: `../inheritance-frontend-reverse/analysis/synthesis/spec-summary.md`
+
+Produce:
+- Full wizard → compute() → results view flow working end-to-end
+- `src/wasm/bridge.ts` — prepare for real WASM (add `computeWasm()` that loads .wasm module)
+- Integration tests: fill wizard from scratch, submit, verify results render
+- Export JSON: produces valid EngineInput that could be passed to real engine
+- Scenario prediction matches mock compute() output
+
+**Tests**:
+- Integration test: intestate scenario (2 LC + spouse) → fill all steps → submit → results show 3 heirs
+- Integration test: testate scenario → will step visible → fill institutions → submit → results
+- Integration test: export JSON → parse as EngineInput → valid
+- Integration test: copy narratives → clipboard content matches
+- Integration test: edit input → returns to wizard with state preserved
+
+## Serialization Rules (CRITICAL)
+
+These serialization rules MUST be followed exactly. The engine will reject malformed input silently.
+
+| Type | Wire Format | Common Mistake |
+|------|---|---|
+| Money | `{"centavos": number\|string}` | Sending pesos instead of centavos |
+| Frac | `"1/2"` bare string | Sending `{numer:1, denom:2}` |
+| ShareSpec::Fraction | `{"Fraction": "1/2"}` | Sending `{"Fraction": {numer:1, denom:2}}` |
+| LegacySpec::GenericClass | `["desc", {"centavos":N}]` 2-tuple | Sending object |
+| DeviseSpec::FractionalInterest | `["asset-id", "1/2"]` 2-tuple | Sending object |
+| ShareSpec unit variants | `"EntireFreePort"` plain string | Sending `{"EntireFreePort": null}` |
+| `will` field | `null` for intestate | Omitting field |
+| Enums | `"LegitimateChild"` PascalCase | `"legitimate_child"` snake_case |
+
+## Rules
+
+- Do ONE unit of work, then exit. Do not do multiple priorities in one iteration.
+- Always read the spec before writing code. The spec is the source of truth.
+- Every type name, enum variant, field name, and validation rule comes from the spec — never invent.
+- Use React Hook Form's `useForm<EngineInput>()` with Zod resolver for all form state.
+- Use `useFieldArray` for all repeater fields (family_tree, institutions, legacies, devises, disinheritances, donations).
+- All components must be typed — no `any` types.
+- Tailwind classes for styling — no CSS modules or styled-components.
+- Never modify a passing test to keep it passing after a code change.
+- If a test contradicts the spec, fix the test AND note it in your commit message.
+- Keep components focused: one wizard step per file, shared components in `shared/`.
+- Test each component in isolation using Testing Library. Mock form context with a wrapper.
+- Do NOT import from `../inheritance-frontend-reverse/` at runtime — the spec files are for reading, not importing. Copy types and schemas into the app's source tree.
+
+## Commit Convention
+
+```
+forward: stage {N} - {description}
+```
+
+Examples:
+- `forward: stage 1 - scaffold vite + react + tailwind project`
+- `forward: stage 2 - write type definition tests`
+- `forward: stage 3 - implement zod schemas with superRefine`
+- `forward: stage 7 - fix person card conditional visibility for adopted child`
+- `forward: stage 10 - implement collateral-weighted layout variant`

--- a/loops/inheritance-frontend-forward/forward-ralph.sh
+++ b/loops/inheritance-frontend-forward/forward-ralph.sh
@@ -1,0 +1,297 @@
+#!/bin/bash
+# Forward Ralph Loop — Inheritance Frontend (React + TypeScript)
+# Runs Claude Code repeatedly to build one stage at a time.
+#
+# Usage:
+#   ./forward-ralph.sh [stage_number]   # Build a specific stage (1-12)
+#   ./forward-ralph.sh                  # Auto-detect lowest incomplete stage
+#   ./forward-ralph.sh all              # Build all stages sequentially
+
+set -uo pipefail
+
+unset CLAUDECODE 2>/dev/null || true
+
+WORK_DIR="$(cd "$(dirname "$0")" && pwd)"
+APP_DIR="$WORK_DIR/app"
+PROMPT_FILE="$WORK_DIR/PROMPT.md"
+CURRENT_STAGE_FILE="$WORK_DIR/frontier/current-stage.md"
+MAX_ITERATIONS=${2:-40}
+SLEEP_BETWEEN=5
+
+# Dev order (sequential)
+DEV_ORDER=(1 2 3 4 5 6 7 8 9 10 11 12)
+
+# Stage names for display
+declare -A STAGE_NAMES=(
+    [1]="Project Scaffold"
+    [2]="Types & Enums"
+    [3]="Zod Schemas"
+    [4]="WASM Bridge Mock"
+    [5]="Shared Components"
+    [6]="Wizard Steps 1-2"
+    [7]="Wizard Step 3 (Family Tree)"
+    [8]="Wizard Step 4 (Will & Dispositions)"
+    [9]="Wizard Steps 5-6 (Donations + Review)"
+    [10]="Results View"
+    [11]="Validation Layer 3"
+    [12]="Integration & Polish"
+)
+
+# Stage dependencies (space-separated upstream stage numbers)
+declare -A STAGE_DEPS=(
+    [1]=""
+    [2]="1"
+    [3]="2"
+    [4]="2"
+    [5]="1"
+    [6]="3 5"
+    [7]="3 5"
+    [8]="7"
+    [9]="7"
+    [10]="4"
+    [11]="6 7 8 9"
+    [12]="1 2 3 4 5 6 7 8 9 10 11"
+)
+
+# Test filter patterns for vitest
+declare -A STAGE_TEST_FILTERS=(
+    [1]="smoke"
+    [2]="types"
+    [3]="schemas"
+    [4]="wasm"
+    [5]="shared"
+    [6]="wizard-step1|wizard-step2|estate|decedent"
+    [7]="wizard-step3|family-tree|person"
+    [8]="wizard-step4|will|institution|legacy|devise|disinheritance"
+    [9]="wizard-step5|wizard-step6|donation|review"
+    [10]="results"
+    [11]="validation|warning"
+    [12]="integration|e2e"
+)
+
+cd "$WORK_DIR"
+
+if [ ! -f "$PROMPT_FILE" ]; then
+    echo "ERROR: PROMPT.md not found at $PROMPT_FILE"
+    exit 1
+fi
+
+# --- Helper functions ---
+
+stage_complete() {
+    [ -f "$WORK_DIR/status/stage-${1}-complete.txt" ]
+}
+
+check_dependencies() {
+    local stage=$1
+    local deps="${STAGE_DEPS[$stage]}"
+    for dep in $deps; do
+        if ! stage_complete "$dep"; then
+            echo "ERROR: Stage $stage depends on Stage $dep, which is not complete."
+            echo "Run: ./forward-ralph.sh $dep"
+            return 1
+        fi
+    done
+    return 0
+}
+
+auto_detect_stage() {
+    for s in "${DEV_ORDER[@]}"; do
+        if ! stage_complete "$s"; then
+            echo "$s"
+            return
+        fi
+    done
+    echo "-1"  # All complete
+}
+
+run_tests() {
+    local stage=$1
+    local filter="${STAGE_TEST_FILTERS[$stage]}"
+
+    # No package.json = no tests possible (stage 1 hasn't run yet)
+    if [ ! -f "$APP_DIR/package.json" ]; then
+        echo "NO_TESTS"
+        return
+    fi
+
+    # Check if node_modules exists
+    if [ ! -d "$APP_DIR/node_modules" ]; then
+        echo "MISSING_DEPS"
+        return
+    fi
+
+    local output
+    output=$(cd "$APP_DIR" && npx vitest run --reporter=verbose 2>&1) || true
+    echo "$output"
+}
+
+tests_pass() {
+    local test_output="$1"
+    # Vitest outputs "Tests  X passed" on success
+    echo "$test_output" | grep -q "FAIL" && return 1
+    echo "$test_output" | grep -qE "Tests\s+[1-9][0-9]*\s+passed" || return 1
+    return 0
+}
+
+update_frontier() {
+    local stage=$1
+    local test_output="$2"
+    local iteration=$3
+
+    # Preserve existing work log
+    local existing_log
+    existing_log=$(grep "^- iter" "$CURRENT_STAGE_FILE" 2>/dev/null || echo "(no iterations yet)")
+
+    local spec_sections=""
+    case $stage in
+        1)  spec_sections="- No spec needed — scaffold from tech stack requirements\n- Tech: Vite + React 18 + TypeScript + Tailwind CSS 4 + React Hook Form + Zod + Recharts + Vitest" ;;
+        2)  spec_sections="- Types: synthesis/types.ts\n- 17 interfaces + 12 enums + utility functions" ;;
+        3)  spec_sections="- Schemas: synthesis/schemas.ts\n- 7 superRefine constraints + all enum schemas" ;;
+        4)  spec_sections="- Engine output: engine-output.md\n- Scenario mapping: scenario-field-mapping.md" ;;
+        5)  spec_sections="- Shared components: shared-components.md\n- 5 Tier-1 components: MoneyInput, DateInput, FractionInput, PersonPicker, EnumSelect" ;;
+        6)  spec_sections="- Wizard steps: synthesis/wizard-steps.md §1-2\n- Estate + Decedent steps" ;;
+        7)  spec_sections="- Wizard steps: synthesis/wizard-steps.md §3\n- Family Tree — most complex step (11 relationship types)" ;;
+        8)  spec_sections="- Wizard steps: synthesis/wizard-steps.md §4\n- Will & Dispositions — 4 sub-tabs" ;;
+        9)  spec_sections="- Wizard steps: synthesis/wizard-steps.md §5-6\n- Donations + Review & Config" ;;
+        10) spec_sections="- Results view: synthesis/results-view.md\n- 5 sections, 7 layout variants, Recharts pie chart" ;;
+        11) spec_sections="- Validation: invalid-combinations.md\n- Conditional visibility: conditional-visibility.md\n- 13 pre-submission warnings" ;;
+        12) spec_sections="- Full integration: synthesis/spec-summary.md\n- WASM bridge prep, export, e2e flow" ;;
+    esac
+
+    cat > "$CURRENT_STAGE_FILE" << FRONTIER_EOF
+# Current Stage: $stage (${STAGE_NAMES[$stage]})
+
+## Spec Sections
+$(echo -e "$spec_sections")
+
+## Test Results (updated by loop — iteration $iteration)
+\`\`\`
+$test_output
+\`\`\`
+
+## Work Log
+$existing_log
+FRONTIER_EOF
+}
+
+write_completion() {
+    local stage=$1
+    local test_output="$2"
+    local iteration=$3
+
+    local test_count
+    test_count=$(echo "$test_output" | grep -oE "[0-9]+ passed" | head -1 || echo "unknown")
+
+    cat > "$WORK_DIR/status/stage-${stage}-complete.txt" << COMPLETE_EOF
+COMPLETE
+Stage: $stage (${STAGE_NAMES[$stage]})
+Tests: $test_count
+Iterations: $iteration
+Timestamp: $(date -Iseconds)
+COMPLETE_EOF
+
+    echo "=== Stage $stage COMPLETE ==="
+    cat "$WORK_DIR/status/stage-${stage}-complete.txt"
+}
+
+# --- Main logic ---
+
+run_stage() {
+    local stage=$1
+
+    echo "=== Forward Ralph: Stage $stage (${STAGE_NAMES[$stage]}) ==="
+
+    # Check dependencies
+    if ! check_dependencies "$stage"; then
+        exit 1
+    fi
+
+    # Already complete?
+    if stage_complete "$stage"; then
+        echo "Stage $stage is already complete."
+        cat "$WORK_DIR/status/stage-${stage}-complete.txt"
+        return 0
+    fi
+
+    local iteration=0
+    local failures=0
+
+    while [ "$iteration" -lt "$MAX_ITERATIONS" ]; do
+        iteration=$((iteration + 1))
+        echo ""
+        echo "--- Stage $stage, Iteration $iteration / $MAX_ITERATIONS ---"
+        echo "$(date '+%Y-%m-%d %H:%M:%S')"
+
+        # Run tests and update frontier
+        local test_output
+        test_output=$(run_tests "$stage")
+
+        update_frontier "$stage" "$test_output" "$iteration"
+
+        # Check convergence
+        if [ "$test_output" != "NO_TESTS" ] && [ "$test_output" != "MISSING_DEPS" ] && tests_pass "$test_output"; then
+            write_completion "$stage" "$test_output" "$iteration"
+            return 0
+        fi
+
+        # Run Claude
+        local iter_log="/tmp/forward-ralph-frontend-stage-${stage}-iter-${iteration}.log"
+        if timeout 1800 bash -c \
+            'unset CLAUDECODE; cat "$1" | stdbuf -oL claude --print --dangerously-skip-permissions' \
+            _ "$PROMPT_FILE" 2>&1 | stdbuf -oL tee "$iter_log"; then
+            echo ""
+            echo "Iteration $iteration completed successfully."
+            failures=0
+        else
+            local iter_exit=$?
+            if [ "$iter_exit" -eq 124 ]; then
+                echo "WARNING: Iteration $iteration timed out after 1800s"
+            else
+                echo "WARNING: Iteration $iteration exited with code $iter_exit"
+            fi
+            failures=$((failures + 1))
+            if [ "$failures" -ge 3 ]; then
+                echo "ERROR: 3 consecutive failures. Stopping."
+                return 1
+            fi
+        fi
+
+        echo "Sleeping ${SLEEP_BETWEEN}s..."
+        sleep "$SLEEP_BETWEEN"
+    done
+
+    echo "ERROR: Stage $stage did not converge in $MAX_ITERATIONS iterations."
+    return 1
+}
+
+# --- Entry point ---
+
+MODE="${1:-auto}"
+
+if [ "$MODE" = "all" ]; then
+    for s in "${DEV_ORDER[@]}"; do
+        if ! stage_complete "$s"; then
+            run_stage "$s" || exit 1
+        fi
+    done
+    echo ""
+    echo "=== All stages complete ==="
+elif [ "$MODE" = "auto" ]; then
+    while true; do
+        STAGE=$(auto_detect_stage)
+        if [ "$STAGE" = "-1" ]; then
+            echo "All stages are already complete."
+            exit 0
+        fi
+        echo "Auto-detected: Stage $STAGE (${STAGE_NAMES[$STAGE]})"
+        run_stage "$STAGE" || exit 1
+    done
+else
+    STAGE="$MODE"
+    if [ -z "${STAGE_NAMES[$STAGE]+x}" ]; then
+        echo "ERROR: Unknown stage '$STAGE'. Valid: 1 2 3 4 5 6 7 8 9 10 11 12 all"
+        exit 1
+    fi
+    run_stage "$STAGE"
+fi

--- a/loops/inheritance-frontend-forward/frontier/analysis-log.md
+++ b/loops/inheritance-frontend-forward/frontier/analysis-log.md
@@ -1,0 +1,4 @@
+# Analysis Log
+
+| # | Timestamp | Stage | Iteration | Duration | Key Changes |
+|---|-----------|-------|-----------|----------|-------------|

--- a/loops/inheritance-frontend-forward/frontier/current-stage.md
+++ b/loops/inheritance-frontend-forward/frontier/current-stage.md
@@ -1,0 +1,13 @@
+# Current Stage: 1 (Project Scaffold)
+
+## Spec Sections
+- No spec needed — scaffold from tech stack requirements
+- Tech: Vite + React 18 + TypeScript + Tailwind CSS 4 + React Hook Form + Zod + Recharts + Vitest
+
+## Test Results (updated by loop — iteration 0)
+```
+(no tests yet — project not scaffolded)
+```
+
+## Work Log
+(no iterations yet)

--- a/loops/inheritance-frontend-forward/frontier/stage-plan.md
+++ b/loops/inheritance-frontend-forward/frontier/stage-plan.md
@@ -1,0 +1,20 @@
+# Forward Ralph — Stage Plan
+
+Dev order: 1 → 2 → 3 → 4 → 5 → 6 → 7 → 8 → 9 → 10 → 11 → 12
+
+| Stage | Name                          | Test Filter                              | Depends On | Status  |
+|-------|-------------------------------|------------------------------------------|------------|---------|
+| 1     | Project Scaffold              | smoke                                    | —          | pending |
+| 2     | Types & Enums                 | types                                    | 1          | blocked |
+| 3     | Zod Schemas                   | schemas                                  | 2          | blocked |
+| 4     | WASM Bridge Mock              | wasm                                     | 2          | blocked |
+| 5     | Shared Components             | shared                                   | 1          | blocked |
+| 6     | Wizard Steps 1-2              | wizard-step1\|wizard-step2\|estate\|decedent | 3, 5   | blocked |
+| 7     | Wizard Step 3                 | wizard-step3\|family-tree\|person        | 3, 5       | blocked |
+| 8     | Wizard Step 4                 | wizard-step4\|will\|institution\|legacy  | 7          | blocked |
+| 9     | Wizard Steps 5-6              | wizard-step5\|wizard-step6\|donation\|review | 7      | blocked |
+| 10    | Results View                  | results                                  | 4          | blocked |
+| 11    | Validation Layer 3            | validation\|warning                      | 6, 7, 8, 9 | blocked |
+| 12    | Integration & Polish          | integration\|e2e                         | all        | blocked |
+
+Status values: blocked | pending | active | complete


### PR DESCRIPTION
## Summary

- Scaffolds a 12-stage forward ralph loop to build the PH Inheritance Wizard frontend
- Tech stack: Vite + React 18 + TypeScript + Tailwind CSS 4 + React Hook Form + Zod + Recharts + Vitest
- Spec source: `inheritance-frontend-reverse` (converged 2026-02-25, 25 aspects, ~5,300 lines of spec)
- Mock-first WASM approach: frontend builds against a mock `compute()`, real WASM integration in Stage 12

## Stages

| # | Stage | Key Output |
|---|-------|-----------|
| 1 | Project Scaffold | Vite + React skeleton |
| 2 | Types & Enums | 17 interfaces + 12 enums |
| 3 | Zod Schemas | All validation schemas + 7 superRefine |
| 4 | WASM Bridge Mock | Mock compute() with synthetic output |
| 5 | Shared Components | MoneyInput, DateInput, FractionInput, PersonPicker, EnumSelect |
| 6 | Wizard Steps 1-2 | Estate + Decedent steps |
| 7 | Wizard Step 3 | Family Tree (11 relationship types) |
| 8 | Wizard Step 4 | Will & Dispositions (4 sub-tabs) |
| 9 | Wizard Steps 5-6 | Donations + Review & Config |
| 10 | Results View | 7 layout variants + Recharts pie chart |
| 11 | Validation Layer 3 | 13 pre-submission warnings |
| 12 | Integration & Polish | Full wizard → compute → results flow |

## Test plan

- [ ] Review PROMPT.md for completeness and autonomous operability
- [ ] Verify stage dependencies are correct
- [ ] Merge and run `./forward-ralph.sh` to start autonomous loop

🤖 Generated with [Claude Code](https://claude.com/claude-code)