### PR TITLE
loop: mm-transit-routes-reverse

### DIFF
--- a/loops/_registry.yaml
+++ b/loops/_registry.yaml
@@ -95,3 +95,11 @@ loops:
     timeout_minutes: 30
     status: active
     created: 2026-02-25
+  mm-transit-routes-reverse:
+    description: "Research all Metro Manila jeepney/bus/UV Express routes → comprehensive GTFS database"
+    type: reverse
+    schedule: "*/30 * * * *"
+    max_iterations: 40
+    timeout_minutes: 30
+    status: active
+    created: 2026-02-25

--- a/loops/mm-transit-routes-reverse/PROMPT.md
+++ b/loops/mm-transit-routes-reverse/PROMPT.md
@@ -1,0 +1,101 @@
+# Metro Manila Transit Routes — Reverse Ralph Loop
+
+You are an analysis agent in a ralph loop. Each time you run, you do ONE unit of work, then exit.
+
+## Your Working Directory
+
+You are running from `loops/mm-transit-routes-reverse/`. All paths below are relative to this directory.
+
+## Your Goal
+
+Build a comprehensive, accurate GTFS database of all jeepney, bus, UV Express, and P2P bus routes in Metro Manila (NCR). Existing transit maps are incomplete, inaccurate, or outdated. This loop researches every available data source, cross-references findings, and synthesizes a validated GTFS feed with route shapes, stops, fare rules, and frequency estimates.
+
+The final output is a complete GTFS feed in `analysis/gtfs/` ready for import into routing engines.
+
+## What To Do This Iteration
+
+1. **Read the frontier**: Open `frontier/aspects.md`
+2. **Find the first unchecked `- [ ]` aspect** in dependency order (Wave 1 before Wave 2 before Wave 3)
+   - If ALL aspects are checked `- [x]`: write convergence summary to `status/converged.txt` and exit
+3. **Analyze that ONE aspect** using the appropriate method (see below)
+4. **Write findings** to `analysis/{aspect-name}.md`
+   - For route data, also write structured data to `raw/{source}-routes.json` using the schema below
+5. **Update the frontier**:
+   - Mark the aspect as `- [x]`
+   - Update Statistics (increment Analyzed, decrement Pending, update Convergence %)
+   - If you discovered new data sources or routes that need investigation, add them as new aspects
+   - Add a row to `frontier/analysis-log.md`
+6. **Commit**: `git add -A && git commit -m "loop(mm-transit-routes-reverse): {aspect-name}"`
+7. **Exit**
+
+## Analysis Methods
+
+### Wave 1: Data Source Research
+
+For each data source, extract as much route information as possible:
+
+**Method**: Use `WebSearch` and `WebFetch` to find and scrape route data. For each source:
+1. Search for the source and assess what data is available
+2. Extract route names, endpoints, key stops, fare info, and any geographic data
+3. Assess data quality: how current, how complete, how accurate
+4. Write structured findings to `analysis/{source-name}.md`
+5. Write machine-readable route data to `raw/{source-name}-routes.json`
+
+**Raw route JSON schema**:
+```json
+{
+  "source": "ltfrb|sakay|osm|academic|blog|government|social",
+  "retrieved_date": "2026-02-25",
+  "routes": [
+    {
+      "route_id": "string",
+      "route_name": "string",
+      "mode": "jeepney|bus|uv_express|p2p",
+      "origin": "string",
+      "destination": "string",
+      "key_stops": ["string"],
+      "fare_min": null,
+      "fare_max": null,
+      "frequency_notes": "string",
+      "geometry_available": false,
+      "geometry_source": null,
+      "confidence": "high|medium|low",
+      "notes": "string"
+    }
+  ]
+}
+```
+
+### Wave 2: Cross-Reference & Validation
+
+For each validation aspect:
+1. Load route data from `raw/*.json` files across sources
+2. Match routes across sources (same route may have different names/IDs)
+3. Identify: confirmed routes (2+ sources agree), contested routes (sources conflict), orphan routes (single source)
+4. For contested routes, determine the most likely accurate version
+5. Write validated route list to `analysis/validated-{group}.md`
+6. Flag gaps: known corridors or areas with no route data
+
+### Wave 3: GTFS Synthesis
+
+Compile validated routes into GTFS format:
+1. Generate `agency.txt`, `routes.txt`, `trips.txt`, `stops.txt`, `stop_times.txt`, `shapes.txt`, `fare_attributes.txt`, `fare_rules.txt`, `frequencies.txt`
+2. Use best available geometry; for routes with no geometry, estimate paths using road network
+3. Place stops at known landmarks, intersections, and terminals
+4. Derive frequency estimates from source data and reasonable defaults
+5. Write GTFS files to `analysis/gtfs/`
+6. Write a quality report: coverage stats, confidence levels, known gaps
+
+## Rules
+
+- Do ONE aspect per run, then exit.
+- Check dependencies before starting an aspect (Wave 2 needs Wave 1 complete, Wave 3 needs Wave 2 complete).
+- Every route extracted must include: name, mode, origin, destination, and confidence level.
+- When sources conflict, note the conflict explicitly — don't silently pick one.
+- Use Filipino route naming conventions (e.g., "Cubao-Divisoria" not "Route 47").
+- Prefer official LTFRB route designations where available.
+- For fare data, note whether it's minimum fare, per-km, or flat rate.
+- For frequency, "peak" vs "off-peak" distinction matters — note both when available.
+- Write findings in markdown with specific numbers and examples.
+- Discover new data sources and add them as Wave 1 aspects.
+- Keep analysis files focused. One aspect = one file.

--- a/loops/mm-transit-routes-reverse/frontier/analysis-log.md
+++ b/loops/mm-transit-routes-reverse/frontier/analysis-log.md
@@ -1,0 +1,4 @@
+# Analysis Log
+
+| # | Timestamp | Aspect | Duration | Key Findings |
+|---|-----------|--------|----------|--------------|

--- a/loops/mm-transit-routes-reverse/frontier/aspects.md
+++ b/loops/mm-transit-routes-reverse/frontier/aspects.md
@@ -1,0 +1,134 @@
+# Metro Manila Transit Routes — Frontier
+
+## Statistics
+- Total aspects: 78
+- Analyzed: 0
+- Pending: 78
+- Convergence: 0%
+
+---
+
+## Wave 1: Data Source Research
+
+### Official Government Sources
+- [ ] LTFRB franchise database — jeepney route franchises, route designations, operator names
+- [ ] LTFRB franchise database — bus route franchises, provincial and city bus operators
+- [ ] LTFRB franchise database — UV Express route franchises and operator lists
+- [ ] LTFRB fare matrices — current fare tables for jeepney, bus, UV Express by route type
+- [ ] DOTr (Department of Transportation) — published transit plans, route maps, modernization data
+- [ ] MMDA traffic engineering — bus route assignments, EDSA Busway routes, traffic management data
+- [ ] EDSA Busway system — all carousel routes, stops, schedules, fare structure
+- [ ] LTFRB modernization program — modern jeepney routes, consolidated routes, new franchises
+- [ ] LTO/LTFRB route rationalization studies — planned vs actual route changes
+- [ ] Congress/Senate transportation committee — hearing transcripts on route changes, published reports
+- [ ] Philippine Statistics Authority — transport sector data, commuter surveys
+
+### Transit App & Platform Data
+- [ ] Sakay.ph — all routes in their database, route shapes, coverage assessment
+- [ ] Google Maps transit layer — Manila routes available in Google Transit, GTFS feeds already submitted
+- [ ] Moovit Manila — routes, user-contributed data, coverage
+- [ ] Transit app — Manila coverage, real-time data availability
+- [ ] Apple Maps transit — Manila routes available
+- [ ] Grab transport — GrabBus routes, Grab shuttle routes if any
+
+### Open Data & Mapping Projects
+- [ ] OpenStreetMap — transit relations for NCR, bus routes, jeepney routes tagged
+- [ ] OpenStreetMap — stop/station nodes tagged as bus_stop, platform, etc.
+- [ ] Mapillary/KartaView — street-level imagery of route signage and terminals
+- [ ] Open Transit Data initiatives — any GTFS feeds published for Manila
+- [ ] Citizen mapping projects — community-driven route mapping efforts (OpenRouteService, etc.)
+
+### Academic & International Organization Studies
+- [ ] JICA Metro Manila transport studies — MMUTIS, Dream Plan, route surveys
+- [ ] World Bank Manila transport projects — route data from feasibility studies
+- [ ] Asian Development Bank — Manila public transport improvement projects, route data
+- [ ] UP NCTS (National Center for Transportation Studies) — academic papers on Manila routes
+- [ ] DLSU/Ateneo/UST transport research — thesis papers on jeepney/bus routes
+- [ ] Other academic papers — Google Scholar search for "Metro Manila jeepney routes" and "Metro Manila bus routes"
+
+### Terminal & Operator Sources
+- [ ] Cubao terminal complex — all routes departing from Araneta, Ali Mall area, Gateway
+- [ ] Pasay/EDSA terminal — all routes from Pasay rotonda, MRT Taft area
+- [ ] Monumento terminal area — all routes from Monumento, Victory Liner, etc.
+- [ ] SM North EDSA terminal — all jeepney/bus routes from SM North transport hub
+- [ ] Fairview terminal area — all routes originating from Fairview
+- [ ] Baclaran terminal area — all routes from Baclaran, LRT-1 terminus
+- [ ] Other major terminals — Divisoria, Quiapo, Lawton, Santa Cruz, Blumentritt
+- [ ] Provincial bus operators — Victory Liner, Philtranco, DLTB, JAM, Five Star, Genesis, etc.
+- [ ] P2P bus operators — HM Transport, Froehlich, Rrcg, other premium bus services
+- [ ] City bus operators — list and routes for each (e.g., Herrera Transport, RRCG, etc.)
+
+### Community & Social Sources
+- [ ] Facebook commuter groups — PH Commuters, Manila Commuters, area-specific groups
+- [ ] Reddit r/Philippines — transit route discussions, commuter advice threads
+- [ ] Twitter/X — #ManilaCommute, transit-related accounts, LTFRB announcements
+- [ ] Transit blogs and enthusiast sites — PinoyCommuter, commute guides, route blogs
+- [ ] YouTube — jeepney/bus route documentation videos, commuter vlogs with route info
+- [ ] Waze community — traffic and route data contributed by Manila drivers
+
+### Specialized Data
+- [ ] PNR commuter rail — feeder routes to/from PNR stations
+- [ ] LRT-1 feeder routes — jeepney/bus routes connecting to each LRT-1 station
+- [ ] LRT-2 feeder routes — jeepney/bus routes connecting to each LRT-2 station
+- [ ] MRT-3 feeder routes — jeepney/bus routes connecting to each MRT-3 station
+- [ ] BGC Bus system — all BGC bus routes, stops, schedules
+- [ ] Makati Loop shuttle — routes and stops if still operating
+- [ ] University shuttle services — UP Ikot, DLSU shuttle, and other campus loops that serve as public transit
+
+---
+
+## Wave 2: Cross-Reference & Validation
+
+### By Major Corridor
+- [ ] EDSA corridor — all routes using any segment of EDSA, cross-referenced across sources
+- [ ] C5 corridor — all routes along C5, including partial-overlap routes
+- [ ] Commonwealth Avenue corridor — all routes from Quezon Ave to Fairview
+- [ ] España-Quezon Avenue corridor — all routes along this University Belt axis
+- [ ] Taft Avenue corridor — all routes along Taft, Buendia, through Pasay
+- [ ] Aurora Boulevard corridor — all routes along Aurora from Cubao to Marikina
+- [ ] Marcos Highway corridor — all routes from Masinag to Cubao/Santolan
+- [ ] Ortigas Avenue corridor — all routes from Pasig to Manila via Ortigas
+- [ ] Shaw Boulevard corridor — all routes along Shaw from Mandaluyong to Pasig
+- [ ] Rizal Avenue/Marikina corridor — routes through Caloocan, Malabon, into Marikina
+- [ ] Coastal/Roxas Boulevard corridor — all routes along Manila Bay coast
+
+### By NCR City/Municipality
+- [ ] Manila (city proper) — validate all routes within/through Manila
+- [ ] Quezon City — validate all routes within/through QC
+- [ ] Makati — validate all routes within/through Makati
+- [ ] Pasig — validate all routes within/through Pasig
+- [ ] Taguig/BGC — validate all routes within/through Taguig
+- [ ] Mandaluyong — validate all routes within/through Mandaluyong
+- [ ] Caloocan — validate all routes within/through Caloocan
+- [ ] Las Piñas, Parañaque, Muntinlupa — validate southern Metro Manila routes
+- [ ] Marikina, San Juan, Pasay, Malabon, Navotas, Valenzuela, Pateros — remaining cities
+
+### By Mode Validation
+- [ ] All jeepney routes — deduplicated master list, confidence scores, gap analysis
+- [ ] All city bus routes — deduplicated master list, confidence scores, gap analysis
+- [ ] All provincial bus routes (NCR segments) — deduplicated list of NCR portions
+- [ ] All UV Express routes — deduplicated master list
+- [ ] All P2P premium bus routes — deduplicated master list
+- [ ] All shuttle/loop services — BGC, Makati, campus shuttles
+
+### Transfer Points
+- [ ] Rail-to-road transfer mapping — every LRT/MRT/PNR station with connecting jeepney/bus routes
+- [ ] Terminal-to-terminal connections — how to transfer between major terminals
+- [ ] Fare integration analysis — where transfers require separate fares vs integrated payment
+
+---
+
+## Wave 3: GTFS Synthesis
+
+- [ ] Generate agency.txt — list all operators/agencies
+- [ ] Generate routes.txt — all validated routes with type, color codes, names
+- [ ] Generate stops.txt — all stop locations with lat/lon coordinates
+- [ ] Generate stop_times.txt — estimated arrival/departure times per stop
+- [ ] Generate shapes.txt — route geometry from best available sources
+- [ ] Generate trips.txt — trip patterns for each route
+- [ ] Generate fare_attributes.txt and fare_rules.txt — fare structure per route/mode
+- [ ] Generate frequencies.txt — headway estimates for peak/off-peak
+- [ ] Generate calendar.txt — service patterns (weekday vs weekend vs holiday)
+- [ ] GTFS validation — run against GTFS specification, fix errors
+- [ ] Coverage quality report — stats on routes mapped, confidence distribution, known gaps
+- [ ] Final convergence summary — what's complete, what needs field validation, recommended next steps

--- a/loops/mm-transit-routes-reverse/loop.sh
+++ b/loops/mm-transit-routes-reverse/loop.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Ralph Loop — Metro Manila Transit Routes (Reverse)
+# Researches all available data sources to build a comprehensive GTFS
+# database of jeepney, bus, UV Express, and P2P routes in Metro Manila.
+#
+# Usage: cd loops/mm-transit-routes-reverse && ./loop.sh [max_iterations]
+
+set -uo pipefail
+
+# Allow nested Claude Code sessions
+unset CLAUDECODE 2>/dev/null || true
+
+WORK_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_NAME="$(basename "$WORK_DIR")"
+PROMPT_FILE="$WORK_DIR/PROMPT.md"
+CONVERGED_FILE="$WORK_DIR/status/converged.txt"
+PAUSED_FILE="$WORK_DIR/status/paused.txt"
+MAX_ITERATIONS=${1:-40}
+SLEEP_BETWEEN=5
+
+cd "$WORK_DIR"
+
+if [ ! -f "$PROMPT_FILE" ]; then
+    echo "ERROR: PROMPT.md not found at $PROMPT_FILE"
+    exit 1
+fi
+
+if [ -f "$PAUSED_FILE" ]; then
+    echo "Loop '$LOOP_NAME' is paused. Remove status/paused.txt to resume."
+    exit 0
+fi
+
+if [ -f "$CONVERGED_FILE" ]; then
+    echo "Loop '$LOOP_NAME' already converged."
+    exit 0
+fi
+
+mkdir -p status
+
+iteration=0
+failures=0
+
+echo "=== Ralph Loop Starting: $LOOP_NAME ==="
+echo "Working directory: $WORK_DIR"
+echo "Max iterations: $MAX_ITERATIONS"
+echo ""
+
+while [ ! -f "$CONVERGED_FILE" ] && [ "$iteration" -lt "$MAX_ITERATIONS" ]; do
+    iteration=$((iteration + 1))
+    echo "--- Iteration $iteration / $MAX_ITERATIONS ---"
+    echo "$(date '+%Y-%m-%d %H:%M:%S')"
+
+    iter_log="/tmp/ralph-${LOOP_NAME}-iter-${iteration}.log"
+    if timeout 1800 bash -c 'unset CLAUDECODE; cat "$1" | stdbuf -oL claude --print --dangerously-skip-permissions' _ "$PROMPT_FILE" 2>&1 | stdbuf -oL tee "$iter_log"; then
+        echo ""
+        echo "Iteration $iteration completed successfully."
+        failures=0
+    else
+        iter_exit=$?
+        if [ "$iter_exit" -eq 124 ]; then
+            echo "WARNING: Iteration $iteration timed out after 1800s"
+        else
+            echo "WARNING: Iteration $iteration exited with code $iter_exit"
+        fi
+        failures=$((failures + 1))
+        if [ "$failures" -ge 3 ]; then
+            echo "ERROR: 3 consecutive failures. Stopping loop."
+            break
+        fi
+    fi
+
+    echo "Sleeping ${SLEEP_BETWEEN}s..."
+    sleep "$SLEEP_BETWEEN"
+done
+
+echo ""
+echo "=== Loop Summary: $LOOP_NAME ==="
+echo "Iterations run: $iteration"
+echo "Failures: $failures"
+
+if [ -f "$CONVERGED_FILE" ]; then
+    echo "Status: CONVERGED"
+    cat "$CONVERGED_FILE"
+elif [ "$iteration" -ge "$MAX_ITERATIONS" ]; then
+    echo "Status: STOPPED (max iterations reached)"
+    echo "Check frontier/ for remaining work."
+else
+    echo "Status: STOPPED (failures)"
+    echo "Check /tmp/ralph-${LOOP_NAME}-iter-*.log for details."
+fi


### PR DESCRIPTION
## Summary
- Scaffold reverse ralph loop to build a comprehensive GTFS database of all Metro Manila transit routes (jeepney, bus, UV Express, P2P)
- 78 aspects across 3 waves: data source research (47), cross-reference & validation (19), GTFS synthesis (12)
- Sources include LTFRB records, Sakay.ph, OpenStreetMap, JICA studies, transit apps, community/social data, terminal surveys, and academic papers

## Test plan
- [ ] Verify loop.sh is executable and runs without errors
- [ ] Verify PROMPT.md instructs the agent correctly for Wave 1 research
- [ ] Verify frontier/aspects.md has correct statistics and well-structured aspects
- [ ] Merge and let CI pick up the loop for autonomous execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)