### PR TITLE
Document PodPlay training overview and update trip details

### DIFF
--- a/entities/businesses/pod-play.md
+++ b/entities/businesses/pod-play.md
@@ -49,8 +49,26 @@ Software/booking platform originally built for [[Ping Pod]], now a separate comp
 
 PodPlay is a hybrid cloud + on-premises system. See [[PodPlay Asia Infrastructure Analysis]] for full breakdown.
 
-- **Cloud**: Admin dashboard, booking API, payment processing (Stripe US), Mosyle MDM, Apple Business Manager
+- **Cloud**: Admin dashboard, booking API, payment processing (Stripe US), Mosyle MDM, Apple Business Manager, Google Cloud (storage + alerting)
 - **On-premises per venue**: Unifi network stack (UDM + Switch + PDU), Mac Mini running Node.js replay service, cameras (1/court), iPads (1/court), Apple TVs (1/court), Samsung SSD for clip storage
 - **Communication**: Mac Mini ↔ PodPlay backend via port 4000; DDNS via FreeDNS (podplaydns.com)
-- **Replay flow**: Cameras → Mac Mini (local VLAN 192.168.32.x) → Apple TV (instant replay); clips uploaded async to cloud
+- **Replay flow**: Cameras → RTSP streams → Mac Mini (local VLAN 192.168.32.x) → Apple TV (instant replay); clips uploaded async to Google Cloud
+- **Health monitoring**: Google Cloud alerting pings each site's health endpoint every 5 minutes; checks SSD storage (<80%), CPU, memory, rename service, link status; alerts via Slack
 - **Configuration guide**: See [[PodPlay Config Guide v1]] (written by [[Stan Wu]], dated Sept 2024)
+
+### V2 Replay Service (In Testing — ~1 month out as of 2026-02-25)
+
+- Eliminates the deployment server dependency — code runs locally from GitHub
+- Configuration moves from Google Docs into the PodPlay dashboard
+- Much easier install and redeployment process
+- Camera coefficients entered via dashboard instead of VPN → deployment server → manual entry
+- Migration from V1 is straightforward
+- ~70 live locations currently on V1
+
+### Key People (Technical)
+
+| Person | Role |
+|--------|------|
+| [[Nico]] | Hardware, replay service, installs (works under [[Chad]]) |
+| [[Andy]] | Project manager — specs, camera positions, installer kickoffs |
+| [[Chad]] | Head of operations — account decisions, credentials |

--- a/entities/meetings/2026-02-25-nico-podplay-training-overview.md
+++ b/entities/meetings/2026-02-25-nico-podplay-training-overview.md
@@ -1,0 +1,144 @@
+---
+type: meeting
+date: 2026-02-25
+attendees: [[Nico]], [[Ethan]], [[Julius]], [[Carlos]]
+projects: [[Pod Play SEA]], [[Ping Pod Asia Franchise]]
+businesses: [[Pod Play]], [[Ping Pod]]
+tags: [podplay, training, infrastructure, replay-service, hardware]
+---
+
+# Nico — PodPlay Training & Infrastructure Overview
+
+Pre-training call with [[Nico]] (PodPlay hardware/replay service lead) ahead of the [[2026-03 NJ PodPlay Training]] trip. [[Ethan]] and [[Julius]] also on the call — they previously helped set up the Mandaluyong site.
+
+## Key Topics Discussed
+
+### 1. Replay Service Architecture (Current — V1)
+
+- Each site has a **Mac Mini** running the replay service on a local VLAN (192.168.32.x)
+- Cameras stream via **RTSP** — Mac Mini pulls these streams for replays and instant replays
+- Each minute, one video file is written per camera; files get renamed with timestamps (e.g., `0225` for today's date)
+- If files don't get renamed, replays for that time window won't generate — the **rename service** was built recently to fix this
+- Mac Mini uploads clips to **Google Cloud** (the cloud provider for everything)
+- All replay service data flows through **port 4000** — this is an absolute must; port 4000 traffic must reach the UDM
+- **CGNAT** (e.g., Starlink) blocks port forwarding entirely — kills the whole system
+- Configuration currently lives in a **Google Doc** — area names, server hosts, ports, usernames, passwords, cloud buckets, camera coefficients, RTSP streams
+
+### 2. V2 Replay Service (Coming Soon)
+
+- In **final stages of testing** — probably a month or so out
+- Currently: must screen share into deployment server, run `deploy.py` to create a package, copy to Mac Mini, deploy
+- V2: will be able to run locally from your own GitHub — much easier install
+- Configuration will move from the Google Doc into the **PodPlay dashboard** itself
+- Migration from V1 to V2 is straightforward — Nico will show how
+- **Recommendation**: set up current site on V1, then migrate once V2 is ready
+
+### 3. deploy.py Process
+
+- `deploy.py` lives on the deployment server, creates a package with all replay service code and data
+- Package gets copied to the new Mac Mini and deployed there
+- Current process is tedious: VPN into lab → deployment server → enter new coefficients
+- V2 eliminates the need for this — coefficients entered via dashboard
+- Nico offered to help run `deploy.py` for initial setups before V2 is ready
+
+### 4. Camera Calibration & Coefficients
+
+- On initial setup, leave all coefficients at **zero** to get the raw camera image
+- Coefficients adjust for lens distortion — values change as cameras are calibrated
+- If the baseline image is warped, coefficients need to be adjusted to even it out
+- Each redeployment requires entering new coefficients into the deployment server (V1) or dashboard (V2)
+- Following camera position specs is **extremely important** to avoid calibration issues
+
+### 5. Health Check & Monitoring
+
+- DDNS set up for each club (e.g., `areaname.podplaydns.com`)
+- Health check endpoint: `ddns:4000/health` — returns JSON with system status
+- Google Cloud alerting pings the health URL every 5 minutes
+- Checks: system storage (SSD < 80%), memory/swap, CPU load, rename service status, link/SSD status
+- Alerts sent to **Slack** when errors detected (can also configure other destinations)
+- Nico has ~70 live locations monitored this way
+- **Recommendation**: set up Google Cloud alerting for our own locations — Nico will show how
+
+### 6. Hardware & Network
+
+- **UniFi** for networking — already familiar with this (Marco knows it)
+- All equipment on the **32 VLAN** (192.168.32.x) — keep it consistent
+- Mac Mini IP always **192.168.32.100**
+- Mac Minis prone to overheating if installed too close to other equipment — needs breathing room
+- If Mac Mini crashes: screen share shows black screen → SSH in and restart
+- **Gigabit internet** recommended, though the service can handle slower
+- 6-court site uses ~105 Gbps/week upload
+- Bandwidth isn't a major concern; **latency** could matter since servers are in New York/New Jersey
+- Nico doesn't foresee latency issues for Philippines (estimated 300-400ms should be OK)
+- **PDU** is the only hardware component that differs for overseas (voltage differences)
+
+### 7. iPads & Mosyle MDM
+
+- iPads managed via **Mosyle** (MDM platform) — ordered through Apple, auto-enroll on power-on
+- Mosyle features: device naming, grouping by location, app restriction (only PodPlay app), wallpaper, OS update blocking, remote restart
+- **Never send a shutdown** from Mosyle — only restart (shutdown requires someone on-site to turn back on)
+- App lock: recommended on, but buttons can't be paired with app lock active — source of confusion
+- iPads can run on **Wi-Fi** instead of PoE — some locations do this successfully (e.g., portable setups)
+- PoE adapters are **fragile** — cable runs must be clean, not bunched up
+- App updates can be scheduled through Mosyle; newer iPads handle this better
+- Separate Mosyle account may be needed for our installs to avoid device enrollment confusion
+- Over 500 devices currently in PodPlay's Mosyle
+
+### 8. Dashboard & Site Setup
+
+- Each location gets its own **individual dashboard** with its own URL (not reskinned — separately built by PodPlay developers)
+- Dashboard shows courts, camera/kiosk names, replay service config (API URL, local URL)
+- Booking, court management all through the dashboard
+- Franchisees (like Pickleball Kingdom) get their own; independent locations also get their own
+
+### 9. Payment Integration (Philippines)
+
+- **Stripe doesn't work in the Philippines** — alternative payment integration already in progress
+- [[Julius]] confirmed the developers know about the region-specific payment requirement
+- As long as the app detects the region and uses the correct payment provider, it should work with the same App Store build
+- Nico confirmed this is **outside his scope** but developers are handling it
+- [[Marcelo]] is the developer working on payment integration
+
+### 10. Credentials & Account Access
+
+- Need credentials for: **UniFi**, **Mosyle**, **deployment server**, **Google Cloud** (for alerting)
+- Google Cloud alerting: can set up our own account — don't need PodPlay's
+- DDNS: PodPlay uses **Free Afraid DDNS** — free to use a different provider, just needs DDNS capability
+- Account setup decisions (shared vs. separate) need to go through **Chad** (head of operations)
+
+### 11. Mandaluyong Site (Existing)
+
+- [[Ethan]] and [[Julius]] handled the setup at the Mandaluyong location
+- They were "securing the dynamic list setup" and "deployment at LOC"
+- Apple TV also part of the setup
+- Current PodPlay app build installed — managed through Mosyle
+
+## People & Roles Clarified
+
+| Person | Role |
+|--------|------|
+| [[Nico]] | Hardware, replay service, installs — works under [[Chad]] |
+| [[Andy]] | PodPlay project manager — handles specs, kickoff calls with installers, will send install document |
+| [[Chad]] | Head of operations — decisions on account setup and credentials |
+| [[Julius]] | Developer — aware of Philippines payment integration needs |
+| [[Marcelo]] | Developer — working on payment integration |
+| CS team | Customer success — handles booking/credits questions, routes to right developer |
+
+## Next Steps
+
+- [ ] Andy to send comprehensive install document with camera positions, specs, hardware placement
+- [ ] Andy to schedule kickoff call with Carlos (as installer)
+- [ ] Chad to decide on account setup (shared vs. separate for Mosyle, UniFi, etc.)
+- [ ] Nico to walk through hardware setup in person during NJ visit (Tuesday–Friday)
+- [ ] Nico to share SOPs and troubleshooting docs for common issues
+- [ ] Nico to show Google Cloud alerting setup
+- [ ] Set up with CS team for booking/credits questions
+- [ ] Test RTSP streams with VLC during setup
+- [ ] Confirm Philippines latency is acceptable once site is live
+
+## Logistics
+
+- Carlos and [[Marco]] visiting NJ, staying at **Hampton Inn Newark Harrison Riverwalk**
+- In-person training Tuesday through Friday
+- PodPlay office hit by snowstorm — inventory pushed back, boxes everywhere
+- V2 replay service in final testing — timing is good for learning both versions

--- a/entities/people/andy.md
+++ b/entities/people/andy.md
@@ -1,0 +1,16 @@
+---
+type: person
+name: Andy
+businesses: [[Pod Play]]
+tags: [podplay, project-manager]
+---
+
+# Andy
+
+Project manager at [[Pod Play]]. Handles specs, camera positions, and kickoff calls with installers.
+
+## Role
+
+- Sends comprehensive install documents (hardware placement, camera positions, specs)
+- Runs kickoff calls with installers before site deployments
+- Point of contact for hardware specs and installation planning

--- a/entities/people/ethan.md
+++ b/entities/people/ethan.md
@@ -1,0 +1,17 @@
+---
+type: person
+name: Ethan
+aliases: [Aiden]
+related: [[Julius]], [[Nico]], [[Pod Play SEA]]
+tags: [installer, mandaluyong]
+---
+
+# Ethan
+
+Works alongside [[Nico]] but at a different company. Helped set up the PodPlay site in Mandaluyong together with [[Julius]].
+
+## Context
+
+- Present on the 2026-02-25 training overview call with Nico
+- Previously told Carlos that he and Nico worked together
+- Handled the dynamic list setup and deployment at the Mandaluyong location

--- a/entities/people/julius.md
+++ b/entities/people/julius.md
@@ -1,0 +1,17 @@
+---
+type: person
+name: Julius
+businesses: [[Pod Play]]
+related: [[Ethan]], [[Nico]], [[Pod Play SEA]]
+tags: [developer, mandaluyong, payment]
+---
+
+# Julius
+
+Developer connected to [[Pod Play]]. Helped set up the Mandaluyong site with [[Ethan]]. Aware of the Philippines payment integration requirements (Stripe alternative).
+
+## Context
+
+- Present on the 2026-02-25 training overview call with Nico
+- Confirmed the dev team knows about the Philippines payment region requirement
+- Helped with deployment at the Mandaluyong location

--- a/entities/people/nico.md
+++ b/entities/people/nico.md
@@ -1,11 +1,27 @@
 ---
 type: person
 name: Nico
-aliases: []
-businesses: [[Pod Play]]
-tags: [podplay]
+aliases: [Niko]
+businesses: [[Pod Play]], [[Ping Pod]]
+related: [[Chad]], [[Andy]], [[Pod Play SEA]]
+last_contact: 2026-02-25
+tags: [podplay, hardware, replay-service, operations]
 ---
 
 # Nico
 
-Involved in [[Pod Play]] operations. Meeting tentatively planned for the week of Feb 23, 2026 — pending confirmation.
+Hardware and replay service lead at [[Pod Play]], working under [[Chad]] (head of operations). Manages ~70 live locations. Primary contact for hardware setup, replay service deployment, troubleshooting, and site monitoring.
+
+## Responsibilities
+
+- Hardware installation and configuration (Mac Minis, cameras, iPads, Apple TVs, networking)
+- Replay service deployment (V1 via deploy.py, V2 coming soon)
+- Mosyle MDM management (500+ devices)
+- UniFi network setup per site
+- Google Cloud alerting / health check monitoring
+- Troubleshooting and SOPs for common issues
+- Training new installers
+
+## Key Meeting: 2026-02-25
+
+Had a comprehensive training overview call covering the full PodPlay infrastructure — see [[2026-02-25 Nico PodPlay Training Overview]]. Will do hands-on training during the [[2026-03 NJ PodPlay Training]] trip.

--- a/entities/people/niko.md
+++ b/entities/people/niko.md
@@ -1,11 +1,11 @@
 ---
 type: person
 name: Niko
-aliases: []
-related: [[Pod Play SEA]]
-tags: [business]
+aliases: [Nico]
+canonical: "[[Nico]]"
+tags: [redirect]
 ---
 
 # Niko
 
-Emailed 2026-02-18 to set up a meeting for week of 2026-02-23 — related to [[Pod Play SEA]].
+→ See [[Nico]] (canonical entity). Same person, alternate spelling.

--- a/entities/projects/pod-play-sea.md
+++ b/entities/projects/pod-play-sea.md
@@ -19,12 +19,14 @@ Master distribution and franchise operation for [[Pod Play]] and [[Ping Pod]] ac
 - **HQ location**: [[Singapore]] being evaluated — EDB supportive with tax incentives and visa support
 - **First venue target**: [[Tela Park]] in Las Piñas — facility checklist created, pre-installation site survey needed
 
-### Current Activity (as of 2026-02-18)
+### Current Activity (as of 2026-02-25)
 
-- Syncing with [[Dominic]] tomorrow (2026-02-19) — PodPlay coordination
-- Syncing with [[Marco Basug]] next week — TBD
-- Emailed [[Niko]] to set up a meeting next week — TBD
-- [[2026-03 NJ PodPlay Training]] booked for March 2–10
+- Nico training overview call completed (2026-02-25) — see [[2026-02-25 Nico PodPlay Training Overview]]
+- [[Andy]] (PodPlay project manager) to send install document and schedule kickoff call
+- [[Chad]] to decide on account setup (shared vs. separate Mosyle, UniFi, etc.)
+- Payment integration (Stripe alternative) confirmed in progress by developer team ([[Julius]])
+- V2 replay service in final testing — will learn both V1 and V2 during NJ trip
+- [[2026-03 NJ PodPlay Training]] booked for March 2–10; staying at Hampton Inn Newark Harrison Riverwalk
 - [[Tela Park]] facility checklist created — need someone to do site survey before NJ training
 
 ## Revenue Model
@@ -47,13 +49,15 @@ Master distribution and franchise operation for [[Pod Play]] and [[Ping Pod]] ac
 - **Infrastructure Analysis**: [[PodPlay Asia Infrastructure Analysis]] — shared vs. local components, payment questions, PAL/NTSC issues
 - Key blocker: Payment integration (Stripe → [[Magpie]]) needs API surface understanding from training
 
-## Current Status (2026-02-18)
+## Current Status (2026-02-25)
 
-- Meeting with [[Dominic]] tomorrow (Feb 19) — PodPlay sync
-- Meeting with [[Marco Basu]] planned for this weekend or next week
-- Meeting with [[Nico]] tentatively next week — pending confirmation
-- Number of courts to be set up TBD
-- NJ training trip in ~12 days (March 2-10)
+- Nico training overview call completed — full infrastructure walkthrough done
+- Andy to send detailed install document (camera positions, specs, hardware placement)
+- Andy to schedule installer kickoff call with Carlos
+- Chad deciding on credential/account setup for Asia operations
+- Payment integration nearly done — devs aware of Philippines requirements
+- NJ training trip in ~5 days (March 2-10)
+- Carlos and [[Marco]] traveling together
 
 ## Automation
 
@@ -63,10 +67,12 @@ Master distribution and franchise operation for [[Pod Play]] and [[Ping Pod]] ac
 ## Action Items
 
 - **Site survey [[Tela Park]]** — send someone or go personally to check all items on the facility checklist before NJ training
-- Sync with [[Dominic]] (2026-02-19)
-- Sync with [[Marco Basug]] (week of 2026-02-23)
-- Meeting with [[Niko]] (week of 2026-02-23, pending confirmation)
+- ~~Meeting with [[Nico]] (week of 2026-02-23)~~ — completed 2026-02-25
+- Wait for [[Andy]] to send install document and schedule kickoff call
+- Wait for [[Chad]] to decide on account setup (Mosyle, UniFi, deployment server)
 - Complete NJ training trip and document all Asia-specific configuration differences
+- Learn V2 replay service migration during NJ trip
+- Set up Google Cloud alerting for our own locations
 - Get PodPlay Stripe integration details for Magpie compatibility assessment
 - Finalize legal agreements urgently
 - Follow up with Cutie on legal completion

--- a/entities/trips/2026-03-nj-podplay-training.md
+++ b/entities/trips/2026-03-nj-podplay-training.md
@@ -3,8 +3,9 @@ type: trip
 name: New Jersey PodPlay Training
 status: booked
 dates: [2026-03-02, 2026-03-10]
-destinations: [[Jersey City]]
-people: [[Stan Wu]], [[Chad]]
+destinations: [[Jersey City]], [[Newark]]
+people: [[Stan Wu]], [[Chad]], [[Nico]], [[Marco]]
+accommodation: Hampton Inn Newark Harrison Riverwalk
 related: [[Pod Play]], [[Pod Play SEA]], [[Ping Pod Asia Franchise]], [[Magpie]]
 tags: [training, business, podplay, infrastructure]
 ---
@@ -17,6 +18,16 @@ Training trip to Jersey City to learn how to configure and deploy PodPlay hardwa
 
 Someone on the team needs to be trained on full PodPlay hardware setup so deployments can happen independently in the Philippines/Asia without relying on US-based support. This trip is that training.
 
+## Attendees
+
+- Carlos and [[Marco]] traveling together
+- Primary trainer: [[Nico]] (hardware/replay service)
+- Also meeting: [[Andy]] (project manager — specs, kickoff), [[Chad]] (head of ops — account decisions)
+
+## Accommodation
+
+**Hampton Inn Newark Harrison Riverwalk** — Newark, NJ
+
 ## Key Objectives
 
 1. **Learn the full PodPlay hardware configuration process** — unboxing through testing
@@ -24,6 +35,9 @@ Someone on the team needs to be trained on full PodPlay hardware setup so deploy
 3. **Clarify payment integration for Asia** — Stripe won't work in the Philippines; need to understand what [[Magpie]] needs to integrate
 4. **Get access to all required accounts and services** — or understand which ones need separate instances for Asia
 5. **Document region-specific differences** — PAL vs NTSC, ISP differences, deployment server access from Asia
+6. **Learn V2 replay service** — final stages of testing, migration path from V1
+7. **Get troubleshooting SOPs** — Nico has documents for common issues across 70+ live sites
+8. **Set up Google Cloud alerting** — health check monitoring for our own locations
 
 ## Infrastructure Questions to Resolve
 
@@ -35,6 +49,19 @@ See [[PodPlay Asia Infrastructure Analysis]] for the full breakdown of shared vs
 - **Training:** March 2–10, 2026
 - **Return:** March 10, 2026
 
+## Pre-Trip: From 2026-02-25 Call with Nico
+
+Key info already gathered (see [[2026-02-25 Nico PodPlay Training Overview]]):
+- V2 replay service in final testing — will learn both V1 and V2
+- Google Cloud is the cloud provider for everything
+- Gigabit internet recommended; ~105 Gbps/week for a 6-court site
+- Latency to NJ servers from Philippines (~300-400ms) should be acceptable
+- PDU is the only hardware that changes for overseas (voltage)
+- Payment integration (Stripe alternative) already being handled by devs — [[Julius]] confirmed
+- Separate Mosyle account likely needed for our installs
+- DDNS can use any provider (PodPlay uses Free Afraid DDNS)
+- Andy sending install document with camera specs before the trip
+
 ## Training Checklist
 
 Before leaving NJ, confirm:
@@ -42,10 +69,15 @@ Before leaving NJ, confirm:
 - [ ] Access to all accounts (Mosyle, FreeDNS, 1Password, Unifi, Admin Dashboard, Apple Business Manager, Deployment Server)
 - [ ] Complete hardware list with exact model numbers
 - [ ] Documentation for region-specific configuration differences (PAL, ISP, etc.)
-- [ ] Contact info for technical support (Stan, Chad)
+- [ ] Contact info for technical support (Stan, Chad, Nico)
 - [ ] Access to deployment server (or own instance)
 - [ ] Clear understanding of software licensing model for Asia
 - [ ] Ability to train own installers using the config guide
 - [ ] Sample BOM template adapted for Asian deployments
 - [ ] Clear answer on payment gateway integration path for [[Magpie]]
 - [ ] Understanding of what `deploy.py` generates and whether it can run locally
+- [ ] Receive troubleshooting SOPs from Nico
+- [ ] Set up Google Cloud alerting for health monitoring
+- [ ] Walk through V2 replay service migration process
+- [ ] Understand camera calibration coefficient workflow
+- [ ] Test SSH recovery for crashed Mac Minis


### PR DESCRIPTION
## Summary

Added comprehensive documentation from the 2026-02-25 PodPlay training overview call with Nico, including detailed infrastructure architecture, deployment processes, and hardware setup procedures. Updated related entities to reflect current project status and attendees.

## Key Changes

- **New meeting notes** (`2026-02-25-nico-podplay-training-overview.md`): Complete infrastructure walkthrough covering:
  - V1 replay service architecture (Mac Mini, RTSP streams, port 4000 requirements, CGNAT limitations)
  - V2 replay service (in final testing, GitHub-based deployment, dashboard configuration)
  - Camera calibration and coefficient workflow
  - Health monitoring via Google Cloud alerting
  - Hardware setup (UniFi, VLAN 192.168.32.x, Mac Mini specifications)
  - iPad/Mosyle MDM management (500+ devices)
  - Payment integration status for Philippines (Stripe alternative in progress)
  - Credentials and account access requirements
  - Next steps and logistics

- **Updated trip details** (`2026-03-nj-podplay-training.md`):
  - Added Newark as destination and accommodation (Hampton Inn Newark Harrison Riverwalk)
  - Added Nico and Marco to attendees
  - Expanded objectives to include V2 replay service learning and Google Cloud alerting setup
  - Added pre-trip context from Nico call
  - Enhanced training checklist with infrastructure-specific items

- **Updated project status** (`pod-play-sea.md`):
  - Reflected completion of Nico training call
  - Updated current activity with next steps (Andy's install document, Chad's account decisions)
  - Confirmed payment integration progress
  - Updated timeline context (5 days to NJ trip as of 2026-02-25)

- **Updated infrastructure documentation** (`pod-play.md`):
  - Added Google Cloud as explicit component (storage + alerting)
  - Documented V2 replay service details and timeline
  - Added key technical personnel (Nico, Andy, Chad) with roles

- **Created/updated person entities**:
  - Expanded `nico.md` with full responsibilities and meeting context
  - Created `ethan.md`, `julius.md`, `andy.md` with roles and context
  - Converted `niko.md` to redirect to `nico.md` (canonical entity)

## Notable Details

- Established port 4000 as critical for replay service communication
- Documented CGNAT as a blocker for certain ISP configurations
- Clarified V2 timeline (~1 month from 2026-02-25) and migration path
- Captured ~70 live locations currently monitored by Nico
- Documented bandwidth requirements (~105 Gbps/week for 6-court site)
- Confirmed latency expectations for Philippines deployment (300-400ms acceptable)

https://claude.ai/code/session_01FKFxvUzo5GiuPDGtnv3wiY