### PR TITLE
loop: cheerful-ig-dm-reverse

### DIFF
--- a/loops/_registry.yaml
+++ b/loops/_registry.yaml
@@ -91,14 +91,15 @@ loops:
     status: active
     created: 2026-02-25
   cheerful-reverse:
-    description: "Distill Cheerful codebase → ultra-comprehensive modular rebuild spec with full user stories"
+    description: "Distill Cheerful codebase + production usage data → ultra-comprehensive modular rebuild spec with full user stories"
     type: reverse
     schedule: "*/30 * * * *"
-    max_iterations: 40
+    max_iterations: 50
     timeout_minutes: 30
     status: converged
     created: 2026-02-25
     converged_at: "2026-02-26"
+    wave4_added: "2026-02-27"
   mm-transit-routes-reverse:
     description: "Research all Metro Manila jeepney/bus/UV Express routes → comprehensive GTFS database"
     type: reverse
@@ -124,3 +125,11 @@ loops:
     timeout_minutes: 30
     status: active
     created: 2026-02-27
+  cheerful-ig-dm-reverse:
+    description: "Explore all approaches for Instagram DM inbound support → exhaustive options catalog (API methods, architecture patterns, trade-offs)"
+    type: reverse
+    schedule: "*/30 * * * *"
+    max_iterations: 40
+    timeout_minutes: 30
+    status: active
+    created: 2026-02-28

--- a/loops/cheerful-ig-dm-reverse/PROMPT.md
+++ b/loops/cheerful-ig-dm-reverse/PROMPT.md
@@ -1,0 +1,237 @@
+# Cheerful Instagram DM Integration — Reverse Ralph Loop
+
+You are an analysis agent in a ralph loop. Each time you run, you do ONE unit of work, then exit.
+
+## Your Working Directory
+
+You are running from `loops/cheerful-ig-dm-reverse/`. All paths below are relative to this directory.
+
+## Your Goal
+
+Produce an exhaustive **options catalog** for adding Instagram DM support to the Cheerful platform. The focus is **inbound-first**: capturing creator DM replies and mapping them to the existing thread/campaign/creator model. Outreach still happens via email.
+
+The catalog must explore every viable approach at both the **design level** (data model, thread mapping, channel abstraction patterns) and **implementation abstraction level** (specific APIs, webhook configurations, auth flows, third-party services). For each approach, document trade-offs, constraints, effort estimates, and compatibility with Cheerful's existing architecture.
+
+**Do NOT pick a winner.** The output is a comprehensive options catalog that enumerates all approaches with honest pros/cons.
+
+### Reference Material
+
+- **Cheerful codebase**: `../../projects/cheerful/`
+- **Cheerful reverse spec** (converged): `../cheerful-reverse/analysis/` — especially:
+  - `synthesis/spec-data-model.md` — current ER diagram, thread tables, event-sourced state
+  - `synthesis/spec-integrations.md` — Gmail/SMTP pipeline, external services
+  - `synthesis/spec-backend-api.md` — API surface
+  - `synthesis/spec-workflows.md` — Temporal workflow patterns
+  - `synthesis/spec-webapp.md` — frontend architecture, mail inbox UI
+
+### Tech Stack Reference
+
+| Layer | Technologies |
+|-------|-------------|
+| Backend API | FastAPI, Python, Pydantic, SQLAlchemy Core |
+| Workflows | Temporal.io (durable execution) |
+| Database | Supabase (PostgreSQL + RLS + Auth) |
+| Frontend | Next.js, React, TypeScript, TanStack Query, Zustand |
+| Styling | Tailwind CSS, shadcn/ui |
+| AI/LLM | Claude API, structured outputs, RAG |
+| Context Engine | Claude agent with MCP tools, Slack bot |
+| External Services | Gmail API, SMTP, Apify, Shopify, YouTube, Slack, PostHog |
+| Deployment | Fly.io (backend), Vercel (frontend), Docker (local dev) |
+
+### Key Architecture Context
+
+Cheerful currently has a **dual-path email system**:
+- **Gmail path**: `user_gmail_account` → `gmail_message` → `gmail_thread_state` (append-only)
+- **SMTP path**: `user_smtp_account` → `smtp_message` → `smtp_thread_state` (append-only)
+- Threads are linked to campaigns via `campaign_thread`
+- Creators are global entities mapped to campaigns via `campaign_creator`
+- Thread state is event-sourced (append-only rows, latest = current state)
+- Trigger-maintained denormalization for latest message per thread
+
+Instagram DMs would be a **third channel** alongside Gmail/SMTP.
+
+### Output
+
+An options catalog in `analysis/synthesis/`:
+- One file per major topic area (API options, architecture patterns, data model approaches, etc.)
+- A final `options-catalog.md` that cross-references everything into a comparison matrix
+- Each option must include: description, how it works, constraints/limitations, effort estimate (relative), compatibility with existing architecture, risks
+
+## What To Do This Iteration
+
+1. **Read the frontier**: Open `frontier/aspects.md`
+2. **Find the first unchecked `- [ ]` aspect** in dependency order (Wave 1 before Wave 2 before Wave 3 before Wave 4)
+   - If ALL aspects are checked `- [x]`: write convergence summary to `status/converged.txt` and exit
+3. **Analyze that ONE aspect** using the appropriate method (see below)
+4. **Write findings** to `analysis/{aspect-name}.md`
+5. **Update the frontier**:
+   - Mark the aspect as `- [x]`
+   - Update Statistics (increment Analyzed, decrement Pending, update Convergence %)
+   - If you discovered new aspects, add them to the appropriate Wave
+   - Add a row to `frontier/analysis-log.md`
+6. **Commit**: `git add -A && git commit -m "loop(cheerful-ig-dm-reverse): {aspect-name}"`
+7. **Exit**
+
+## Analysis Methods
+
+### Wave 1: External Landscape — Instagram DM Access Methods
+
+Research every way to programmatically access Instagram DMs. For each approach, document: authentication requirements, capabilities (read/write/webhooks), rate limits, approval process, cost, and constraints.
+
+#### `meta-instagram-messaging-api`
+1. Research the Instagram Messaging API (part of Messenger Platform)
+2. Document: supported message types, webhook events (`messages`, `messaging_postbacks`), thread model, 24-hour messaging window rules
+3. Note: Instagram Professional accounts (Business/Creator) requirements
+4. Document the app review process and required permissions (`instagram_manage_messages`, `pages_messaging`)
+5. Produce: complete API capability map with constraints
+
+#### `meta-graph-api-conversations`
+1. Research the Instagram Graph API conversation endpoints (`/conversations`, `/messages`)
+2. Document: what's available vs deprecated, differences from Messenger Platform approach
+3. Note: relationship between Facebook Page, Instagram Professional Account, and API access
+4. Produce: capability comparison with Messaging API approach
+
+#### `meta-webhooks-realtime`
+1. Research Meta webhook infrastructure for Instagram messaging
+2. Document: webhook event types, delivery guarantees, verification flow, payload format
+3. Document: webhook subscription setup, test mode, production requirements
+4. Produce: webhook architecture requirements
+
+#### `third-party-manychat`
+1. Research ManyChat's Instagram DM API/integration capabilities
+2. Document: what they expose (API, webhooks, export), pricing, limitations
+3. Evaluate: can ManyChat act as a proxy/relay for DMs into Cheerful?
+4. Produce: ManyChat as intermediary — capabilities and constraints
+
+#### `third-party-messagebird-bird`
+1. Research MessageBird (now Bird) Instagram channel support
+2. Document: API capabilities, webhook support, pricing model
+3. Evaluate: suitability as DM relay/proxy
+4. Produce: Bird as intermediary assessment
+
+#### `third-party-composio`
+1. Research Composio's Instagram integration (Cheerful already uses Composio for some workflows)
+2. Document: Instagram DM actions/triggers available, limitations
+3. Evaluate: leverage existing Composio integration vs new direct integration
+4. Produce: Composio path assessment
+
+#### `third-party-others`
+1. Research other potential intermediaries: Sendbird, Twilio, Zendesk, Intercom Instagram integrations
+2. For each: brief capability assessment for DM relay use case
+3. Produce: survey of other third-party options
+
+#### `unofficial-approaches`
+1. Research unofficial/scraping approaches (Apify Instagram actors, browser automation)
+2. Document: capabilities, reliability, TOS risks, rate limits
+3. Note: Cheerful already uses Apify for Instagram profile scraping
+4. Produce: unofficial approach risk/capability assessment
+
+### Wave 2: Internal Landscape — Cheerful's Current Architecture
+
+Analyze Cheerful's existing thread/email/creator architecture to understand what "adding a DM channel" requires. Read the cheerful-reverse spec files and the actual codebase.
+
+#### `current-thread-model`
+1. Read `../cheerful-reverse/analysis/synthesis/spec-data-model.md`
+2. Read the actual thread-related tables in `../../projects/cheerful/supabase/migrations/`
+3. Document: thread identity model (how threads are keyed — gmail_thread_id, email_thread_id), thread state machine, how threads link to campaigns and creators
+4. Identify: what's Gmail/SMTP-specific vs what's channel-agnostic in the current model
+5. Produce: thread model analysis with abstraction opportunities
+
+#### `current-email-pipeline`
+1. Read `../cheerful-reverse/analysis/synthesis/spec-integrations.md` (Gmail/SMTP sections)
+2. Read `../cheerful-reverse/analysis/synthesis/spec-workflows.md` (email-related workflows)
+3. Document: the inbound email processing pipeline end-to-end (receive → parse → match thread → update state → trigger AI draft)
+4. Identify: which pipeline stages are email-specific vs channel-agnostic
+5. Produce: email pipeline analysis with abstraction boundaries
+
+#### `current-creator-identity`
+1. Read `../cheerful-reverse/analysis/synthesis/spec-data-model.md` (creator tables)
+2. Read creator-related services in `../../projects/cheerful/apps/backend/src/services/`
+3. Document: how creators are identified (email, social handles, enrichment), how they're linked to threads
+4. Identify: does Cheerful already store Instagram handles for creators? How would DM sender → creator matching work?
+5. Produce: creator identity resolution analysis for Instagram
+
+#### `current-inbox-ui`
+1. Read `../cheerful-reverse/analysis/synthesis/spec-webapp.md` (mail inbox section)
+2. Document: how the inbox UI renders threads, what's hardcoded to email vs what's abstract
+3. Identify: UI changes needed to display DM threads alongside email threads
+4. Produce: inbox UI abstraction analysis
+
+#### `current-ai-drafting`
+1. Read `../cheerful-reverse/analysis/synthesis/spec-integrations.md` (Claude API section)
+2. Read `../cheerful-reverse/analysis/ai-features.md`
+3. Document: how AI drafts are generated for email replies, what context is used
+4. Identify: what changes for DM drafts (shorter format, different tone, no subject line, media support)
+5. Produce: AI drafting adaptation analysis
+
+### Wave 3: Options Cross-Product
+
+For each viable API approach from Wave 1, combined with architectural insights from Wave 2, document the full integration path. Each option should be a complete, self-contained design.
+
+#### `option-direct-meta-api`
+1. Read Wave 1 `meta-instagram-messaging-api` + `meta-webhooks-realtime` + all Wave 2 analyses
+2. Design the full integration: auth flow, webhook handler, message ingestion, thread mapping, creator resolution, data model changes, UI changes
+3. Document: end-to-end architecture, effort estimate, constraints, risks
+4. Produce: complete option writeup
+
+#### `option-graph-api-polling`
+1. Read Wave 1 `meta-graph-api-conversations` + all Wave 2 analyses
+2. Design: polling-based approach (if viable given API constraints)
+3. Document: polling architecture, sync strategy, trade-offs vs webhooks
+4. Produce: complete option writeup (or document why this approach is not viable)
+
+#### `option-composio-relay`
+1. Read Wave 1 `third-party-composio` + all Wave 2 analyses
+2. Design: using Composio as the DM bridge, leveraging existing integration
+3. Document: what Composio handles vs what Cheerful handles, data flow, limitations
+4. Produce: complete option writeup
+
+#### `option-third-party-relay`
+1. Read Wave 1 third-party analyses + all Wave 2 analyses
+2. For the most promising third-party (from Wave 1 findings): design the full relay architecture
+3. Document: vendor dependency trade-offs, cost analysis, integration complexity
+4. Produce: complete option writeup
+
+#### `option-channel-abstraction`
+1. Read all Wave 2 analyses
+2. Design a generic channel abstraction layer that unifies email (Gmail/SMTP) and Instagram DMs under one model
+3. Document: abstract interfaces, concrete implementations, migration strategy for existing email tables
+4. This is an ARCHITECTURE PATTERN option, not an API choice — it can be combined with any Wave 3 API option
+5. Produce: channel abstraction architecture
+
+#### `option-parallel-tables`
+1. Read all Wave 2 analyses
+2. Design the "third path" approach: add `ig_dm_*` tables mirroring the Gmail/SMTP pattern
+3. Document: new tables, minimal changes to existing code, trade-offs vs abstraction
+4. This is an ARCHITECTURE PATTERN option, not an API choice
+5. Produce: parallel tables architecture
+
+### Wave 4: Synthesis
+
+Read ALL Wave 1, 2, and 3 analysis files before starting any Wave 4 aspect.
+
+#### `synthesis-options-catalog`
+1. Read every analysis file
+2. Build the master options catalog:
+   - **API/Access options**: each approach with capability matrix
+   - **Architecture options**: each pattern with trade-off matrix
+   - **Combination matrix**: which API options work with which architecture patterns
+   - **Constraint summary**: 24-hour windows, approval processes, rate limits, cost
+   - **Effort estimates**: relative sizing for each combination
+   - **Risk register**: per-option risks and mitigations
+3. Write to `analysis/synthesis/options-catalog.md`
+4. Produce: the definitive options reference document
+
+## Rules
+
+- Do ONE aspect per run, then exit.
+- Check dependencies: all Wave 1 before Wave 2, all Wave 2 before Wave 3, all Wave 3 before Wave 4.
+- Write findings in markdown with specifics — API endpoint URLs, payload examples, code references.
+- When researching APIs, use `WebSearch` and `WebFetch` to get current documentation. APIs change frequently.
+- When analyzing Cheerful code, reference specific file paths and line numbers.
+- When you discover a new viable approach not covered by existing aspects, add it to the appropriate Wave.
+- Keep analysis files focused. One aspect = one file.
+- Do NOT modify any files in `../../projects/cheerful/`. The codebase is read-only.
+- Do NOT pick a "recommended" option. Present all options neutrally with honest trade-offs.
+- For third-party services, include pricing information where available.
+- Every option must assess compatibility with Cheerful's existing Temporal workflow patterns and event-sourced thread model.

--- a/loops/cheerful-ig-dm-reverse/frontier/analysis-log.md
+++ b/loops/cheerful-ig-dm-reverse/frontier/analysis-log.md
@@ -1,0 +1,4 @@
+# Analysis Log
+
+| # | Timestamp | Aspect | Duration | Key Findings |
+|---|-----------|--------|----------|--------------|

--- a/loops/cheerful-ig-dm-reverse/frontier/aspects.md
+++ b/loops/cheerful-ig-dm-reverse/frontier/aspects.md
@@ -1,0 +1,44 @@
+# Frontier — Cheerful Instagram DM Integration
+
+## Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total aspects | 20 |
+| Analyzed | 0 |
+| Pending | 20 |
+| Convergence | 0% |
+
+---
+
+## Wave 1: External Landscape — Instagram DM Access Methods
+
+- [ ] `meta-instagram-messaging-api` — Instagram Messaging API (Messenger Platform): webhook events, 24-hour window, permissions, app review
+- [ ] `meta-graph-api-conversations` — Graph API conversation endpoints: capabilities vs Messaging API, deprecation status
+- [ ] `meta-webhooks-realtime` — Meta webhook infrastructure: event types, delivery guarantees, verification, payloads
+- [ ] `third-party-manychat` — ManyChat as DM relay: API, webhooks, pricing, limitations
+- [ ] `third-party-messagebird-bird` — Bird (MessageBird) Instagram channel: API, webhooks, pricing
+- [ ] `third-party-composio` — Composio Instagram integration: leverage existing Cheerful integration
+- [ ] `third-party-others` — Survey: Sendbird, Twilio, Zendesk, Intercom Instagram integrations
+- [ ] `unofficial-approaches` — Apify actors, browser automation: capabilities, TOS risks, reliability
+
+## Wave 2: Internal Landscape — Cheerful's Current Architecture
+
+- [ ] `current-thread-model` — Thread identity, state machine, campaign/creator linking: what's email-specific vs channel-agnostic
+- [ ] `current-email-pipeline` — Inbound email pipeline end-to-end: abstraction boundaries
+- [ ] `current-creator-identity` — Creator identification, Instagram handle storage, DM sender → creator matching
+- [ ] `current-inbox-ui` — Mail inbox UI: what's hardcoded to email vs abstract, changes for DM threads
+- [ ] `current-ai-drafting` — AI draft generation: adaptation for DMs (shorter, no subject, media, tone)
+
+## Wave 3: Options Cross-Product
+
+- [ ] `option-direct-meta-api` — Full integration via Instagram Messaging API + webhooks
+- [ ] `option-graph-api-polling` — Polling-based approach via Graph API (or document why not viable)
+- [ ] `option-composio-relay` — Composio as DM bridge, leveraging existing integration
+- [ ] `option-third-party-relay` — Best third-party candidate as relay (from Wave 1 findings)
+- [ ] `option-channel-abstraction` — Architecture pattern: generic channel layer unifying email + DMs
+- [ ] `option-parallel-tables` — Architecture pattern: add `ig_dm_*` tables mirroring Gmail/SMTP
+
+## Wave 4: Synthesis
+
+- [ ] `synthesis-options-catalog` — Master catalog: API capability matrix, architecture trade-offs, combination matrix, effort estimates, risk register

--- a/loops/cheerful-ig-dm-reverse/loop.sh
+++ b/loops/cheerful-ig-dm-reverse/loop.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+# Ralph Loop — Cheerful Instagram DM Integration
+# Explores all approaches for adding Instagram DM inbound support to Cheerful.
+# Runs Claude Code repeatedly until convergence.
+#
+# Usage: cd loops/cheerful-ig-dm-reverse && ./loop.sh [max_iterations]
+
+set -uo pipefail
+
+# Allow nested Claude Code sessions
+unset CLAUDECODE 2>/dev/null || true
+
+WORK_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_NAME="$(basename "$WORK_DIR")"
+PROMPT_FILE="$WORK_DIR/PROMPT.md"
+CONVERGED_FILE="$WORK_DIR/status/converged.txt"
+PAUSED_FILE="$WORK_DIR/status/paused.txt"
+MAX_ITERATIONS=${1:-40}
+SLEEP_BETWEEN=5
+
+cd "$WORK_DIR"
+
+if [ ! -f "$PROMPT_FILE" ]; then
+    echo "ERROR: PROMPT.md not found at $PROMPT_FILE"
+    exit 1
+fi
+
+if [ -f "$PAUSED_FILE" ]; then
+    echo "Loop '$LOOP_NAME' is paused. Remove status/paused.txt to resume."
+    exit 0
+fi
+
+if [ -f "$CONVERGED_FILE" ]; then
+    echo "Loop '$LOOP_NAME' already converged."
+    exit 0
+fi
+
+mkdir -p status
+
+iteration=0
+failures=0
+
+echo "=== Ralph Loop Starting: $LOOP_NAME ==="
+echo "Working directory: $WORK_DIR"
+echo "Max iterations: $MAX_ITERATIONS"
+echo ""
+
+while [ ! -f "$CONVERGED_FILE" ] && [ "$iteration" -lt "$MAX_ITERATIONS" ]; do
+    iteration=$((iteration + 1))
+    echo "--- Iteration $iteration / $MAX_ITERATIONS ---"
+    echo "$(date '+%Y-%m-%d %H:%M:%S')"
+
+    iter_log="/tmp/ralph-${LOOP_NAME}-iter-${iteration}.log"
+    if timeout 1800 bash -c 'unset CLAUDECODE; cat "$1" | stdbuf -oL claude --print --dangerously-skip-permissions' _ "$PROMPT_FILE" 2>&1 | stdbuf -oL tee "$iter_log"; then
+        echo ""
+        echo "Iteration $iteration completed successfully."
+        failures=0
+    else
+        iter_exit=$?
+        if [ "$iter_exit" -eq 124 ]; then
+            echo "WARNING: Iteration $iteration timed out after 1800s"
+        else
+            echo "WARNING: Iteration $iteration exited with code $iter_exit"
+        fi
+        failures=$((failures + 1))
+        if [ "$failures" -ge 3 ]; then
+            echo "ERROR: 3 consecutive failures. Stopping loop."
+            break
+        fi
+    fi
+
+    echo "Sleeping ${SLEEP_BETWEEN}s..."
+    sleep "$SLEEP_BETWEEN"
+done
+
+echo ""
+echo "=== Loop Summary: $LOOP_NAME ==="
+echo "Iterations run: $iteration"
+echo "Failures: $failures"
+
+if [ -f "$CONVERGED_FILE" ]; then
+    echo "Status: CONVERGED"
+    cat "$CONVERGED_FILE"
+elif [ "$iteration" -ge "$MAX_ITERATIONS" ]; then
+    echo "Status: STOPPED (max iterations reached)"
+    echo "Check frontier/ for remaining work."
+else
+    echo "Status: STOPPED (failures)"
+    echo "Check /tmp/ralph-${LOOP_NAME}-iter-*.log for details."
+fi


### PR DESCRIPTION
## Summary

- Scaffolds a new reverse ralph loop to explore all approaches for adding Instagram DM inbound support to Cheerful
- Maps DMs to threads and creators at both design and implementation abstraction levels
- Produces an exhaustive options catalog (no winner picked) across 4 waves:
  - **Wave 1** (8 aspects): External landscape — Meta APIs (Messaging API, Graph API, webhooks), third-party services (ManyChat, Bird, Composio, others), unofficial approaches
  - **Wave 2** (5 aspects): Internal landscape — Cheerful's thread model, email pipeline, creator identity, inbox UI, AI drafting
  - **Wave 3** (6 aspects): Options cross-product — full integration designs for each viable approach + architecture patterns (channel abstraction vs parallel tables)
  - **Wave 4** (1 aspect): Synthesis — master options catalog with comparison matrices, effort estimates, risk register

## Test plan

- [ ] Verify loop.sh is executable
- [ ] Verify PROMPT.md references correct paths to cheerful-reverse specs and codebase
- [ ] Verify registry entry is valid YAML
- [ ] Merge and let CI pick it up for autonomous execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)