### PR TITLE
loop: cheerful-ce-parity-reverse

### DIFF
--- a/loops/_registry.yaml
+++ b/loops/_registry.yaml
@@ -201,3 +201,11 @@ loops:
     timeout_minutes: 30
     status: active
     created: 2026-03-01
+  cheerful-ce-parity-reverse:
+    description: "Exhaustive context engine tool spec for 101% frontend parity — OpenAPI-level tool definitions per domain"
+    type: reverse
+    schedule: "*/30 * * * *"
+    max_iterations: 60
+    timeout_minutes: 30
+    status: active
+    created: 2026-03-01

--- a/loops/cheerful-ce-parity-reverse/PROMPT.md
+++ b/loops/cheerful-ce-parity-reverse/PROMPT.md
@@ -1,0 +1,323 @@
+# Cheerful Context Engine Parity — Reverse Loop
+
+You are an analysis agent in a ralph loop. Each time you run, you do ONE unit of work: extract capabilities, design tools, or write exhaustive tool specifications, then commit and exit.
+
+You are running in `--print` mode. You MUST output text describing what you are doing. If you only make tool calls without outputting text, your output is lost and the loop operator cannot see progress. Always:
+1. Start by printing which stage/aspect you detected and what you're about to do
+2. Print progress as you work
+3. End with a summary of what you did and whether you committed
+
+## Your Working Directory
+
+You are running from `loops/cheerful-ce-parity-reverse/`. All paths below are relative to this directory.
+
+## Your Goal
+
+Produce **per-domain specification files** in the `specs/` directory that define EVERY context engine tool needed for **101% parity with the Cheerful frontend**. Every action a user can perform in the webapp must have a corresponding context engine tool specified at OpenAPI level.
+
+The context engine is a Slack bot at `projects/cheerful/apps/context-engine/`. It currently has **7 read-only Cheerful tools**. The frontend (`projects/cheerful/apps/webapp/`) and backend API (`projects/cheerful/apps/backend/`) together expose ~110 endpoints covering campaign management, email workflows, creator enrichment, integrations, team management, analytics, and more.
+
+**Your job**: Close the gap to 101%. Every single frontend capability must map to a context engine tool — reads, writes, creates, updates, deletes, launches, approves, sends. No exceptions.
+
+### What Already Exists
+
+The `loops/cheerful-reverse/` loop has already produced comprehensive analysis docs:
+
+| Source | Path | What It Contains |
+|--------|------|-----------------|
+| Context Engine Spec | `loops/cheerful-reverse/analysis/synthesis/spec-context-engine.md` | Full architecture, all 38 tools, FCIS pattern, DB patterns |
+| Webapp Spec | `loops/cheerful-reverse/analysis/synthesis/spec-webapp.md` | All routes, components, wizard steps, stores, user flows |
+| Backend API Spec | `loops/cheerful-reverse/analysis/synthesis/spec-backend-api.md` | All ~110 endpoints, request/response shapes, auth model |
+| Data Model Spec | `loops/cheerful-reverse/analysis/synthesis/spec-data-model.md` | Full database schema, all tables, relationships |
+| Integrations Spec | `loops/cheerful-reverse/analysis/synthesis/spec-integrations.md` | Gmail, Shopify, Sheets, Slack integration details |
+| Workflows Spec | `loops/cheerful-reverse/analysis/synthesis/spec-workflows.md` | Temporal workflows, activities, campaign lifecycle |
+| User Stories | `loops/cheerful-reverse/analysis/synthesis/spec-user-stories.md` | Complete user journey maps |
+
+**Use these as your primary source.** Read them first. Only go to actual source code when you need to verify details, find enum values, check parameter types, or discover something the specs missed.
+
+### Current Context Engine Cheerful Tools (Baseline)
+
+These 7 tools already exist. Your spec must include them (verified against source) PLUS all new tools:
+
+1. `cheerful_list_campaigns` — List user's campaigns
+2. `cheerful_search_emails` — Full-text search within campaign
+3. `cheerful_get_thread` — Fetch full email thread
+4. `cheerful_find_similar_emails` — Semantic search via pgvector
+5. `cheerful_list_campaign_creators` — List creators in campaign
+6. `cheerful_get_campaign_creator` — Full creator profile
+7. `cheerful_search_campaign_creators` — Cross-campaign creator search
+
+## Output: The specs/ Directory
+
+Each domain gets its own spec file. Every tool definition is exhaustive — OpenAPI-level detail.
+
+```
+specs/
+├── README.md                          # Index: every tool, grouped by domain, with one-line description
+├── campaigns.md                       # Campaign CRUD, wizard, products, senders, recipients, outbox, launch
+├── email.md                           # Thread listing, filtering, status, drafts, AI drafting, sending
+├── creators.md                        # Creator listing, search, enrichment, profiles, notes, bulk ops
+├── integrations.md                    # Gmail OAuth, Google Sheets, Shopify, Slack config
+├── users-and-team.md                  # User profile, team management, onboarding, permissions
+├── analytics.md                       # Dashboard metrics, campaign stats, reporting
+├── search-and-discovery.md            # AI creator discovery, semantic email search
+├── shared-conventions.md              # Auth model, error codes, pagination patterns, shared schemas
+└── parity-matrix.md                   # Frontend feature → tool name mapping, 100% coverage check
+```
+
+### Tool Definition Format
+
+Every tool MUST include ALL of the following:
+
+```markdown
+### `cheerful_<tool_name>`
+
+**Purpose**: One sentence describing what this tool does.
+
+**Maps to**: `METHOD /api/endpoint/path` (the backend API endpoint(s) this tool calls)
+
+**Parameters**:
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| param_name | string | yes | — | Full description including constraints |
+| param_name | integer | no | 50 | Description. Valid range: 1-100 |
+| param_name | enum | no | "all" | One of: "value1", "value2", "value3" |
+
+**Parameter Validation Rules**:
+- [Every validation rule, with exact error message when violated]
+
+**Return Schema**:
+```json
+{
+  "field_name": "string — description",
+  "nested_object": {
+    "sub_field": "integer — description"
+  },
+  "items": [
+    {
+      "array_item_field": "string — description"
+    }
+  ]
+}
+```
+
+**Error Responses**:
+
+| Condition | Error Message | HTTP Status (underlying) |
+|-----------|--------------|-------------------------|
+| Campaign not found | "Campaign {id} not found" | 404 |
+| No permission | "Access denied to campaign {id}" | 403 |
+
+**Pagination** (if applicable):
+- Default limit: N, max limit: M
+- Cursor/offset based
+- Response includes `total` count
+
+**Example Request**:
+```
+cheerful_tool_name(param="value", other_param=123)
+```
+
+**Example Response** (realistic data):
+```json
+{ ... }
+```
+
+**Slack Formatting Notes**:
+- How the agent should format this data for Slack display
+- Any special rendering considerations (tables, threads, code blocks)
+
+**Edge Cases**:
+- [Every edge case and how the tool handles it]
+```
+
+**Rules for tool definitions**:
+- **No summarizing.** If an endpoint accepts 15 query parameters, specify all 15.
+- **No "etc." or "and so on."** Every enum value, every error condition, every field.
+- **No placeholders.** Every type, every default, every constraint must be concrete.
+- **Verify against source.** If the existing spec says an endpoint exists, verify the actual parameter names and types in the backend source code at `projects/cheerful/apps/backend/src/api/route/`.
+- **Include all enum values.** If a field accepts specific string values, list every single one. Check the actual Pydantic models or SQLAlchemy enums in the backend source.
+- **Include nullable fields.** Mark which return fields can be null and when.
+
+## What To Do This Iteration
+
+1. **Read the frontier**: Open `frontier/aspects.md`
+2. **Find the first unchecked `- [ ]` aspect** in dependency order (Wave 1 before Wave 2, etc.)
+   - If a later-wave aspect depends on data that doesn't exist yet, skip to an earlier-wave aspect
+   - If ALL aspects are checked `- [x]`: proceed to convergence check (see below)
+3. **Analyze that ONE aspect** using the appropriate method (see Wave descriptions below)
+4. **Write findings** to the appropriate file(s) in `specs/`
+   - Create the file if it doesn't exist (with a header and table of contents)
+   - Append to the file if it does exist
+   - Also write working notes to `analysis/{aspect-name}.md` for traceability
+5. **Update the frontier**:
+   - Mark the aspect as `- [x]` in `frontier/aspects.md`
+   - Update the Statistics section (increment Analyzed, decrement Pending, update Convergence %)
+   - **If you discovered new aspects** (tools you didn't know about, edge cases, etc.), add them to the appropriate Wave
+   - Add a row to `frontier/analysis-log.md`
+6. **Update specs/README.md**: Add or update the index entry for any tools you defined
+7. **Commit**: `git add -A && git commit -m "loop(cheerful-ce-parity-reverse): {aspect-name}"`
+8. **Exit**
+
+### Convergence Check
+
+When all aspects are `- [x]`, do NOT immediately write `status/converged.txt`. Instead:
+
+1. **Read every file in specs/** — all of them
+2. **Run the parity audit** — check every item below:
+   - [ ] Every frontend page/route has tools covering all its actions
+   - [ ] Every backend API endpoint maps to at least one tool
+   - [ ] Every tool has complete parameter definitions (type, required, default, validation)
+   - [ ] Every tool has a complete return schema (all fields, types, nullable markers)
+   - [ ] Every tool has error responses for all failure conditions
+   - [ ] Every enum parameter lists ALL possible values (verified against source)
+   - [ ] Every tool has at least one realistic example request and response
+   - [ ] Shared conventions doc covers auth, pagination, and error patterns
+   - [ ] The parity matrix has no empty cells — every frontend feature maps to a tool
+   - [ ] No file contains "TODO", "TBD", "placeholder", "etc.", or "similar to above"
+   - [ ] Existing 7 tools are documented with any corrections needed
+3. **If ANY check fails**: Add new aspects to the frontier for each gap found, update statistics, commit, and exit — do NOT write converged.txt
+4. **If ALL checks pass**: Write `status/converged.txt` with:
+   - Total tool count
+   - Tools per domain
+   - Parity percentage
+   - Any known limitations or future considerations
+
+## Wave Definitions
+
+### Wave 1: Capability Extraction (per domain)
+
+Read existing cheerful-reverse specs AND verify against actual source code. For each domain, produce a raw capability list of every action the frontend/backend supports.
+
+**Method**:
+1. Read the relevant cheerful-reverse spec(s) — see the source table above
+2. For each capability found, note:
+   - What the user can do (action description)
+   - Which backend endpoint handles it (method + path)
+   - What parameters it accepts
+   - What it returns
+3. Verify against actual source code:
+   - Check `projects/cheerful/apps/backend/src/api/route/` for actual endpoint signatures
+   - Check `projects/cheerful/apps/webapp/` for any frontend-only capabilities
+   - Check `projects/cheerful/apps/context-engine/app/src_v2/mcp/tools/cheerful/` for existing tool implementations
+4. Write the raw capability list to `analysis/capabilities-{domain}.md`
+
+**Output format** (write to `analysis/capabilities-{domain}.md`):
+```markdown
+# {Domain} — Capability Extraction
+
+## Existing Context Engine Tools
+| Tool | Description | Coverage |
+|------|-------------|----------|
+
+## Frontend/Backend Capabilities (Not Yet in Context Engine)
+| # | Action | Backend Endpoint | Method | Key Parameters | Returns |
+|---|--------|-----------------|--------|----------------|---------|
+```
+
+### Wave 2: Tool Design (per domain)
+
+Take each capability list from Wave 1 and design the tool definitions. This is the architectural step — deciding tool names, parameter shapes, and grouping.
+
+**Method**:
+1. Read the capability list from `analysis/capabilities-{domain}.md`
+2. Group capabilities into tools. Rules for grouping:
+   - One tool per distinct action (don't combine create + delete into one tool)
+   - CRUD operations on the same resource get separate tools (list, get, create, update, delete)
+   - Bulk operations get their own tool (e.g., `cheerful_bulk_upsert_recipients`)
+   - Multi-step flows can be broken into atomic tools (Claude orchestrates the sequence)
+3. For each tool, decide:
+   - Tool name (`cheerful_` prefix, snake_case, verb_noun pattern)
+   - Parameters (from the backend endpoint signature)
+   - Return type (from the backend response shape)
+   - Which backend endpoint(s) it maps to
+4. Write the tool designs to the domain spec file in `specs/`
+
+**Naming conventions**:
+- `cheerful_list_*` — List/query operations (returns array)
+- `cheerful_get_*` — Get single item by ID
+- `cheerful_create_*` — Create new resource
+- `cheerful_update_*` — Modify existing resource
+- `cheerful_delete_*` — Remove resource
+- `cheerful_send_*` — Trigger an outbound action (email, notification)
+- `cheerful_launch_*` — Start a workflow/process
+- `cheerful_search_*` — Search with query string
+- `cheerful_connect_*` — Establish integration connection
+- `cheerful_generate_*` — AI-powered generation (draft, enrichment)
+
+### Wave 3: Full OpenAPI-Level Specs (per domain)
+
+Flesh each tool into exhaustive detail. This is the big one.
+
+**Method**:
+1. Read the domain spec file from `specs/{domain}.md`
+2. For each tool that has only a skeleton definition:
+   a. Go to the actual backend source code: `projects/cheerful/apps/backend/src/api/route/`
+   b. Find the endpoint handler function
+   c. Read the Pydantic request/response models
+   d. Read the service layer for business logic, validation rules, error conditions
+   e. Check for SQLAlchemy model definitions for exact field types
+   f. Document EVERYTHING:
+      - Every parameter with exact type, validation, and constraints
+      - Every return field with exact type and nullability
+      - Every error condition with exact message and status code
+      - Every enum value (from Pydantic/SQLAlchemy enums)
+      - Realistic example with production-like data
+      - Slack formatting guidance for the response
+      - Edge cases discovered during code reading
+
+**Verification checklist per tool**:
+- [ ] Parameter names match actual backend endpoint parameter names
+- [ ] Types match Pydantic model field types
+- [ ] Enum values are complete (all variants listed)
+- [ ] Return schema matches actual response serialization
+- [ ] Error conditions come from actual raise statements in the code
+- [ ] Pagination matches actual implementation (limit/offset vs cursor)
+
+### Wave 4: Cross-Domain Synthesis
+
+Final wave — shared conventions, parity matrix, and completeness audit.
+
+**Shared Conventions** (`specs/shared-conventions.md`):
+1. Authentication model:
+   - How context engine authenticates to the backend (API key vs JWT)
+   - What user context is available (which user's data to access)
+   - Permission model (what the context engine is authorized to do)
+2. Error handling conventions:
+   - Standard error response format
+   - How tools should surface errors to the Claude agent
+   - Retry-worthy vs non-retry-worthy errors
+3. Pagination conventions:
+   - Standard pagination parameters and response shape
+   - How the agent should handle paginated results in Slack
+4. Rate limiting:
+   - Backend rate limits per endpoint tier
+   - How tools should handle 429 responses
+5. Shared schemas:
+   - Common types used across multiple tools (Campaign, Thread, Creator, etc.)
+   - Defined once, referenced from tool definitions
+
+**Parity Matrix** (`specs/parity-matrix.md`):
+```markdown
+| Frontend Page/Feature | User Action | Context Engine Tool | Status |
+|----------------------|-------------|--------------------|---------|
+| /campaigns | View campaigns list | cheerful_list_campaigns | EXISTS |
+| /campaigns/new step 1 | Set campaign name | cheerful_create_campaign | NEW |
+| ... | ... | ... | ... |
+```
+
+Every row must have a tool in the "Context Engine Tool" column. If any row is empty, the spec is incomplete.
+
+## Rules
+
+- Do ONE aspect per run, then exit. Do not analyze multiple aspects.
+- **Be exhaustive.** The #1 failure mode is being too concise. If an endpoint accepts 20 parameters, document all 20. If a response has 30 fields, document all 30.
+- **No summarizing.** If there are 12 thread statuses, list all 12. If there are 8 campaign types, list all 8.
+- **No "etc." or "and so on" or "similar to above."** Every value, every variant, every field.
+- **Verify against source code.** The cheerful-reverse specs are your map, but the actual backend source code is ground truth. When in doubt, read the code.
+- **Discover new aspects.** When reading source code, you will find endpoints, parameters, or features the specs missed. Add them to the frontier.
+- **Cross-reference.** Tools in one domain may reference types from another domain. Use shared conventions doc.
+- **Existing tools must be verified.** The 7 existing tools may have bugs, missing parameters, or outdated signatures. Document them accurately.
+- **The forward loop is a typist.** A developer reading this spec must be able to implement every tool with zero questions. If they would need to look at the backend source code, your spec is incomplete.
+- **Think like a Slack user.** Every tool will be invoked conversationally by a Claude agent in Slack. Include Slack formatting notes so the agent knows how to present results (tables, threads, summaries, code blocks).

--- a/loops/cheerful-ce-parity-reverse/frontier/analysis-log.md
+++ b/loops/cheerful-ce-parity-reverse/frontier/analysis-log.md
@@ -1,0 +1,4 @@
+# Analysis Log
+
+| # | Timestamp | Aspect | Duration | Key Findings |
+|---|-----------|--------|----------|--------------|

--- a/loops/cheerful-ce-parity-reverse/frontier/aspects.md
+++ b/loops/cheerful-ce-parity-reverse/frontier/aspects.md
@@ -1,0 +1,66 @@
+# Frontier — Cheerful Context Engine Parity
+
+## Statistics
+
+- **Total Aspects**: 36
+- **Analyzed**: 0
+- **Pending**: 36
+- **Convergence**: 0%
+
+---
+
+## Wave 1: Capability Extraction (8 aspects)
+
+Read existing cheerful-reverse specs + verify against source code. Produce raw capability lists per domain.
+
+- [ ] **w1-campaigns** — Extract all campaign capabilities: CRUD, wizard steps (0-7), products, senders, recipients (single/bulk/CSV/sheet), outbox, launch, draft saving. Sources: `spec-backend-api.md` (Domain 1-2), `spec-webapp.md` (Campaign Wizard), backend routes `campaigns.py`, `campaign_draft.py`, `campaign_launch.py`
+- [ ] **w1-email** — Extract all email/thread capabilities: thread listing with all filter params, thread detail, status marking (all statuses), draft CRUD, AI draft generation, draft sending, follow-up management. Sources: `spec-backend-api.md` (Domain 6-7), `spec-webapp.md` (Inbox UI), backend routes `threads.py`, `gmail.py`
+- [ ] **w1-creators** — Extract all creator capabilities: in-campaign listing with filters, cross-campaign search, full profile with enrichment data, enrichment status polling, email override, bulk operations, notes history. Sources: `spec-backend-api.md` (Domain 5), existing CE tools in `mcp/tools/cheerful/tools.py`
+- [ ] **w1-integrations** — Extract all integration capabilities: Gmail OAuth connect/disconnect/list, Google Sheets tab listing/validation, Shopify token validation/product listing, Slack channel config, integration status checking. Sources: `spec-integrations.md`, `spec-backend-api.md` (Domain 8), backend routes `integrations.py`, `google_sheets.py`, `shopify.py`
+- [ ] **w1-users-team** — Extract all user/team capabilities: user profile (get/update), Gmail account management, onboarding status, team CRUD, member invitations, campaign assignments, permission model. Sources: `spec-backend-api.md` (Additional Endpoints), `spec-webapp.md` (Settings, Team), backend routes `users.py`, `teams.py`
+- [ ] **w1-analytics** — Extract all analytics/dashboard capabilities: campaign metrics (creator count, response rate, emails sent, opt-in rate), active campaigns table, follow-up statistics, gifting/paid pipeline, per-campaign stats. Sources: `spec-webapp.md` (Dashboard), backend routes `analytics.py`, `dashboard.py`
+- [ ] **w1-search** — Extract all search/discovery capabilities: AI creator search (Apify/YouTube), semantic email search (pgvector), full-text email search, creator profile lookup. Sources: `spec-backend-api.md`, existing CE tools, backend routes `creators.py`, `search.py`
+- [ ] **w1-workflows** — Extract all workflow/automation capabilities: workflow CRUD per campaign, workflow execution history, Temporal workflow triggering, campaign lifecycle state machine, follow-up scheduling. Sources: `spec-workflows.md`, `spec-backend-api.md` (Domain 3-4), backend routes `workflows.py`
+
+## Wave 2: Tool Design (8 aspects)
+
+Take Wave 1 capability lists and design tool signatures per domain.
+
+- [ ] **w2-campaigns** — Design all campaign tools: names, parameters, return types, API mappings. Group CRUD ops, wizard steps, and bulk ops into individual tools. Write skeleton definitions to `specs/campaigns.md`
+- [ ] **w2-email** — Design all email tools: thread listing with all filter combos, status mutations, draft lifecycle, AI generation, sending. Write skeleton definitions to `specs/email.md`
+- [ ] **w2-creators** — Design all creator tools: extend existing 3 tools + add enrichment, notes, bulk ops. Write skeleton definitions to `specs/creators.md`
+- [ ] **w2-integrations** — Design all integration tools: OAuth flows, config, validation, status. Write skeleton definitions to `specs/integrations.md`
+- [ ] **w2-users-team** — Design all user/team tools: profile, accounts, team management, permissions. Write skeleton definitions to `specs/users-and-team.md`
+- [ ] **w2-analytics** — Design all analytics tools: dashboard data, campaign metrics, reporting queries. Write skeleton definitions to `specs/analytics.md`
+- [ ] **w2-search** — Design all search/discovery tools: extend existing search + add AI discovery. Write skeleton definitions to `specs/search-and-discovery.md`
+- [ ] **w2-workflows** — Design all workflow tools: automation CRUD, execution history, lifecycle triggers. Write skeleton definitions to `specs/workflows.md`
+
+## Wave 3: Full OpenAPI-Level Specs (12 aspects)
+
+Flesh each tool to exhaustive detail. Verify every parameter, type, and enum against actual source code.
+
+- [ ] **w3-campaigns-crud** — Full specs for campaign create/read/update/delete tools. Verify all Pydantic models, enum values, validation rules against `projects/cheerful/apps/backend/src/api/route/campaigns.py`
+- [ ] **w3-campaigns-wizard** — Full specs for campaign wizard tools: draft save/load, product management, sender management, email sequence config. Verify against `campaign_draft.py`, `campaign_launch.py`
+- [ ] **w3-campaigns-recipients** — Full specs for recipient tools: single add, bulk upsert, CSV upload, Google Sheet import, outbox population. Verify against recipient-related routes
+- [ ] **w3-email-threads** — Full specs for thread listing (all filter params, pagination), thread detail, status marking (all status values). Verify against `threads.py`
+- [ ] **w3-email-drafts** — Full specs for draft CRUD, AI draft generation (tone, style, reply examples), draft sending. Verify against `gmail.py`, draft routes
+- [ ] **w3-creators-full** — Full specs for all creator tools: listing with filters, cross-campaign search, enrichment, email override, profile detail. Verify against creator routes + existing CE tool implementations
+- [ ] **w3-integrations-full** — Full specs for all integration tools: Gmail OAuth, Sheets, Shopify, Slack. Verify actual OAuth flows and validation endpoints
+- [ ] **w3-users-team-full** — Full specs for user profile, Gmail account management, team CRUD, member management, permissions. Verify against user/team routes
+- [ ] **w3-analytics-full** — Full specs for all analytics tools: dashboard queries, campaign metrics, pipeline stats. Verify against analytics routes and actual SQL queries
+- [ ] **w3-search-full** — Full specs for AI creator discovery and semantic search tools. Verify against search routes, Apify integration, pgvector queries
+- [ ] **w3-workflows-full** — Full specs for workflow CRUD, execution history, lifecycle triggers. Verify against workflow routes and Temporal activity definitions
+- [ ] **w3-existing-tools-audit** — Audit all 7 existing Cheerful CE tools against actual implementation. Document any parameter mismatches, missing fields, or needed corrections. Verify against `mcp/tools/cheerful/tools.py`
+
+## Wave 4: Cross-Domain Synthesis (8 aspects)
+
+Shared schemas, conventions, parity matrix, and completeness audit.
+
+- [ ] **w4-shared-schemas** — Define all shared types used across domains: Campaign, Thread, Creator, EmailMessage, Draft, Workflow, User, Team. Write to `specs/shared-conventions.md`
+- [ ] **w4-auth-model** — Document the authentication model for CE → backend: API key auth, user context injection, permission scoping. What user identity does the CE use? How does it scope queries?
+- [ ] **w4-error-conventions** — Standard error handling: error response format, retry logic, how tools surface errors to Claude agent. Common error patterns across all tools
+- [ ] **w4-pagination-conventions** — Standard pagination: limit/offset patterns, default/max values, how paginated results should be presented in Slack threads
+- [ ] **w4-parity-matrix** — Build the complete parity matrix: every frontend page, every user action, mapped to a context engine tool. Flag any gaps. Write to `specs/parity-matrix.md`
+- [ ] **w4-readme-index** — Write `specs/README.md` with complete tool index: every tool name, domain, one-line description, status (exists/new)
+- [ ] **w4-slack-formatting-guide** — Cross-cutting guide for how tools should format responses for Slack: tables, thread summaries, campaign reports, creator profiles. Consistent UX patterns
+- [ ] **w4-completeness-audit** — Final audit: read every spec file, verify no TODOs/TBDs/placeholders, verify every tool has all required sections, verify parity matrix has no gaps. If gaps found, add new aspects and DO NOT converge

--- a/loops/cheerful-ce-parity-reverse/loop.sh
+++ b/loops/cheerful-ce-parity-reverse/loop.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Ralph Loop — Standard Runner
+# Runs Claude Code repeatedly until convergence.
+#
+# Usage: cd loops/<idea-name> && ./loop.sh [max_iterations]
+
+set -uo pipefail
+
+# Allow nested Claude Code sessions
+unset CLAUDECODE 2>/dev/null || true
+
+WORK_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_NAME="$(basename "$WORK_DIR")"
+PROMPT_FILE="$WORK_DIR/PROMPT.md"
+CONVERGED_FILE="$WORK_DIR/status/converged.txt"
+PAUSED_FILE="$WORK_DIR/status/paused.txt"
+MAX_ITERATIONS=${1:-40}
+SLEEP_BETWEEN=5
+
+cd "$WORK_DIR"
+
+if [ ! -f "$PROMPT_FILE" ]; then
+    echo "ERROR: PROMPT.md not found at $PROMPT_FILE"
+    exit 1
+fi
+
+if [ -f "$PAUSED_FILE" ]; then
+    echo "Loop '$LOOP_NAME' is paused. Remove status/paused.txt to resume."
+    exit 0
+fi
+
+if [ -f "$CONVERGED_FILE" ]; then
+    echo "Loop '$LOOP_NAME' already converged."
+    exit 0
+fi
+
+mkdir -p status
+
+iteration=0
+failures=0
+
+echo "=== Ralph Loop Starting: $LOOP_NAME ==="
+echo "Working directory: $WORK_DIR"
+echo "Max iterations: $MAX_ITERATIONS"
+echo ""
+
+while [ ! -f "$CONVERGED_FILE" ] && [ "$iteration" -lt "$MAX_ITERATIONS" ]; do
+    iteration=$((iteration + 1))
+    echo "--- Iteration $iteration / $MAX_ITERATIONS ---"
+    echo "$(date '+%Y-%m-%d %H:%M:%S')"
+
+    iter_log="/tmp/ralph-${LOOP_NAME}-iter-${iteration}.log"
+    if timeout 1800 bash -c 'unset CLAUDECODE; cat "$1" | stdbuf -oL claude --print --dangerously-skip-permissions' _ "$PROMPT_FILE" 2>&1 | stdbuf -oL tee "$iter_log"; then
+        echo ""
+        echo "Iteration $iteration completed successfully."
+        failures=0
+    else
+        iter_exit=$?
+        if [ "$iter_exit" -eq 124 ]; then
+            echo "WARNING: Iteration $iteration timed out after 1800s"
+        else
+            echo "WARNING: Iteration $iteration exited with code $iter_exit"
+        fi
+        failures=$((failures + 1))
+        if [ "$failures" -ge 3 ]; then
+            echo "ERROR: 3 consecutive failures. Stopping loop."
+            break
+        fi
+    fi
+
+    echo "Sleeping ${SLEEP_BETWEEN}s..."
+    sleep "$SLEEP_BETWEEN"
+done
+
+echo ""
+echo "=== Loop Summary: $LOOP_NAME ==="
+echo "Iterations run: $iteration"
+echo "Failures: $failures"
+
+if [ -f "$CONVERGED_FILE" ]; then
+    echo "Status: CONVERGED"
+    cat "$CONVERGED_FILE"
+elif [ "$iteration" -ge "$MAX_ITERATIONS" ]; then
+    echo "Status: STOPPED (max iterations reached)"
+    echo "Check frontier/ for remaining work."
+else
+    echo "Status: STOPPED (failures)"
+    echo "Check /tmp/ralph-${LOOP_NAME}-iter-*.log for details."
+fi


### PR DESCRIPTION
## Summary

- Scaffolds a new reverse ralph loop to produce **exhaustive context engine tool specifications** for 101% parity with the Cheerful frontend
- 36 aspects across 4 waves: capability extraction → tool design → OpenAPI-level specs → cross-domain synthesis
- Builds on existing cheerful-reverse analysis docs (27 completed specs) as primary source, verified against actual source code
- Covers all 8 domains: campaigns, email, creators, integrations, users/team, analytics, search, workflows
- Every tool defined at OpenAPI level: full JSON schemas, all enum values, validation rules, error responses, worked examples, Slack formatting notes
- Targets closing the gap from 7 read-only tools to full read+write coverage of all ~110 backend API endpoints

## Output

Per-domain spec files in `specs/` + parity matrix mapping every frontend feature to a context engine tool.

## Test plan

- [ ] Merge and let CI pick up the loop
- [ ] Monitor first few iterations for correct aspect detection and spec quality
- [ ] Verify Wave 1 capability lists are comprehensive against actual codebase
- [ ] Check convergence produces complete parity matrix with no gaps

🤖 Generated with [Claude Code](https://claude.com/claude-code)