### PR TITLE
loop: angkin-design-system-reverse

### DIFF
--- a/loops/_registry.yaml
+++ b/loops/_registry.yaml
@@ -261,3 +261,11 @@ loops:
     status: converged
     created: 2026-03-06
     converged_at: "2026-03-07"
+  angkin-design-system-reverse:
+    description: "Explore 10 exhaustive frontend design system options for the Angkin suite — 148 PH compliance tools, each with competitive benchmarking, full spec, live HTML mockup, and visual QA"
+    type: reverse
+    schedule: "*/30 * * * *"
+    max_iterations: 60
+    timeout_minutes: 30
+    status: active
+    created: 2026-03-10

--- a/loops/angkin-design-system-reverse/PROMPT.md
+++ b/loops/angkin-design-system-reverse/PROMPT.md
@@ -1,0 +1,241 @@
+# Angkin Design System Exploration
+
+You are running in `--print` mode. You MUST output text describing what you are doing. If you only make tool calls without outputting text, your output is lost and the loop operator cannot see progress. Always:
+1. Start by printing which aspect you detected and what you're about to do
+2. Print progress as you work
+3. End with a summary of what you did and whether you committed
+
+## Goal
+
+Produce 10 exhaustive, fully-rendered frontend design system options for **Angkin** — a unified suite of 148 Philippine compliance calculator tools. Each tool has its own name (e.g., "TaxKlaro by Angkin," "RetireMath by Angkin") but must feel obviously part of the same family.
+
+Brand values: **friendly, trustworthy, easy to use, clean, distinct.** Anti-references: government websites, enterprise SaaS, gamified super-apps. Positive reference: Wise (TransferWise).
+
+The loop converges when all 10 options have:
+- Complete written specs (persona, colors, typography, components, animations, accessibility, scalability)
+- Live HTML mockups built following the frontend-design skill guidelines
+- Visual QA pass — each mockup reviewed and refined until pixel-perfect
+- A synthesis matrix comparing all 10 across 12+ dimensions
+
+## How Each Iteration Works
+
+1. Read `frontier/aspects.md` to find the next pending aspect
+2. Execute that aspect fully
+3. Mark it done in `frontier/aspects.md` and update statistics
+4. Log the work in `frontier/analysis-log.md`
+5. Commit all changes
+
+## Frontend Design Skill
+
+Before generating ANY mockup, read `skills/frontend-design.md` in this loop directory. Follow its guidelines exactly — distinctive typography, bold color choices, no generic AI aesthetics. Each of the 10 options must look like it was designed by a different human designer with a strong point of view.
+
+---
+
+## Wave 1 — Deep Research
+
+Research and catalog everything needed to inform the 10 design options.
+
+### Aspect 1: Audit TaxKlaro Frontend
+Read every file in `apps/taxklaro/frontend/src/`. Extract: every CSS variable/design token, color palette, typography (DM Sans + DM Serif Display), component patterns, spacing system, animation usage, layout patterns, responsive breakpoints. Write findings to `analysis/audit-taxklaro.md`.
+
+### Aspect 2: Audit Inheritance Frontend
+Read every file in `apps/inheritance/frontend/src/`. Same extraction as Aspect 1. Fonts: Inter + Lora. Navy + Gold palette. Write to `analysis/audit-inheritance.md`.
+
+### Aspect 3: Audit PodPlay Frontend
+Read every file in `apps/podplay/src/`. Same extraction. Fonts: Geist Variable. OKLch color system. Write to `analysis/audit-podplay.md`.
+
+### Aspect 4: Benchmark Wise
+Web research Wise's design system. What makes it feel trustworthy + warm? Typography, color, whitespace, micro-copy tone, form design, result presentation, error handling UX, mobile experience. Write to `analysis/benchmark-wise.md`.
+
+### Aspect 5: Benchmark TurboTax / H&R Block
+Web research tax calculator UX. What works (step-by-step guidance, progress indicators, plain-language). What's bloated (upsells, account walls, unnecessary complexity). Write to `analysis/benchmark-tax-calculators.md`.
+
+### Aspect 6: Benchmark gov.uk
+Web research gov.uk's design system (design-system.service.gov.uk). The gold standard of humane government info. Typography, content patterns, form design, accessibility-first philosophy. Write to `analysis/benchmark-govuk.md`.
+
+### Aspect 7: Benchmark SmartAsset / NerdWallet / Bankrate
+Web research calculator-as-content model. How calculators are embedded in editorial content, SEO strategy, input UX, result visualization, lead capture vs. pure utility. Write to `analysis/benchmark-calculator-content.md`.
+
+### Aspect 8: Benchmark Canva / Notion
+Web research "powerful tool that feels simple" philosophy. Progressive disclosure, empty states, onboarding without wizards, how complexity is hidden, delight moments. Write to `analysis/benchmark-simple-powerful.md`.
+
+### Aspect 9: Benchmark Stripe / Linear
+Web research developer-beloved design systems. What makes them iconic: consistency, token architecture, component APIs, documentation quality, how the system scales to hundreds of pages. Write to `analysis/benchmark-dev-design-systems.md`.
+
+### Aspect 10: Survey Design System Architectures
+Research approaches for multi-app design systems: monorepo shared package (like Radix), design tokens only (like Tailwind presets), shadcn-style registry (copy-paste + customize), CSS-only theme layer, Figma-to-code pipelines. Evaluate each for a 148-tool suite. Write to `analysis/design-system-architectures.md`.
+
+### Aspect 11: Catalog 148 Tools by UI Archetype
+Read the tool lists from `loops/ph-compliance-moats-reverse/` and `loops/ph-regulatory-atlas-reverse/`. Categorize every tool into UI archetypes: single-form calculator, multi-step wizard, lookup table, timeline/calendar tracker, decision tree, comparison engine, document generator, dashboard/tracker. Count how many tools fall into each archetype. Write to `analysis/tool-archetypes.md`.
+
+### Aspect 12: Filipino Digital Design Landscape
+Web research what Philippine users encounter daily (GCash, Maya, BDO, BPI, SSS portal, BIR eFPS, PhilHealth, Grab PH). Cultural color associations, typography norms, Tagalog/English code-switching in UI, mobile-first realities (85%+ mobile traffic). Write to `analysis/filipino-design-landscape.md`.
+
+---
+
+## Wave 2 — Generate 10 Design System Options
+
+Each option is a COMPLETE design system exploration. The mockup should render a sample "Retirement Pay Calculator (RA 7641)" page — same tool, 10 radically different presentations.
+
+For EVERY option, produce a spec file at `analysis/option-{N}-{slug}.md` containing ALL of the following sections. No section may be skipped or abbreviated.
+
+### Required Sections Per Option
+
+1. **Design Philosophy** — 2-3 sentence manifesto. What does this design BELIEVE?
+2. **Persona Narrative** — Who is the primary user? What device? What emotional state when they arrive? What's their story? (e.g., "Maria, 34, OFW in Dubai, checking retirement pay on her phone during break, anxious about whether her employer computed it correctly")
+3. **Competitive DNA** — "Inspired by X + Y, differentiated by Z." Specific references to benchmarked products from Wave 1.
+4. **Brand Expression** — How "by Angkin" appears. Logo placement. How you know this is an Angkin tool vs. a standalone site. Suite cohesion strategy across 148 tools.
+5. **Color System** — Full palette: primary, secondary, accent, success, warning, error, muted, background, surface, border. Hex values + semantic rationale. Show how palette adapts across different tool domains (tax = ?, labor = ?, property = ?).
+6. **Typography System** — Display font + body font pairing. Full scale (hero, h1-h4, body, small, caption). Weight usage rules. WHY these fonts — what do they communicate? Must be Google Fonts or freely available.
+7. **Spatial Philosophy** — Density level (airy/moderate/dense). Whitespace strategy. Grid system (columns, gutters, max-width). Responsive breakpoints and how layout transforms. Padding/margin scale.
+8. **Component Patterns** — Button styles (primary, secondary, ghost, destructive). Input treatment (labels, placeholders, validation states, helper text). Card design. Result/output display (how computed values are shown — this is THE key moment). Progress indicators. Navigation pattern.
+9. **Animation Philosophy** — Micro-interactions (hover, focus, click). Page transitions. Loading states. Calculation moment (what happens visually when the user hits "compute"). Celebration/result reveal (e.g., "You save ₱42,000!"). CSS-only vs. library-driven.
+10. **Accessibility Approach** — WCAG level target. Contrast ratios. Focus visible strategy. Screen reader considerations. Color-blind safe palette verification. Touch target sizes.
+11. **Icon & Illustration Style** — Line weight. Filled vs. outline. Custom vs. Lucide/Phosphor/other library. Illustration approach (none, spot illustrations, full scenes). How icons adapt across 148 different tool domains.
+12. **Dark Mode Strategy** — Yes/no. If yes: how does the palette transform? Automatic vs. toggle? Does it change the personality?
+13. **Multi-Tool Cohesion** — How do 148 different tools all feel "Angkin"? What's the invariant (always the same) vs. the variant (changes per tool)? How does a user landing on tool #47 immediately know it's the same family as tool #3?
+14. **Developer Ergonomics** — How does a developer spin up a new Angkin tool using this system? Token file structure. Component API surface. Estimated time to build a new single-form calculator from scratch using the system.
+15. **Deployment Model** — Monolithic app / hub + micro-apps / independent PWAs / shared package. How this design system is distributed and consumed.
+16. **Scalability Assessment** — Does this design hold at 10 tools? 50? 148? What breaks first? What needs to be built to prevent that?
+17. **Trade-offs** — What does this option EXPLICITLY sacrifice and why that's acceptable for this audience.
+
+### The 10 Options
+
+**Option 1: Wise-Inspired Trust Minimalism** (Aspect 13)
+Maximum whitespace, muted palette, one action per screen. Audience: scared first-timer. Deployment: hub + micro-apps.
+
+**Option 2: Gov.uk Radical Clarity** (Aspect 14)
+No decoration, near-monochrome, content-first, brutally functional. Audience: low digital literacy. Deployment: monolithic app.
+
+**Option 3: Filipino Warmth** (Aspect 15)
+Warm earth tones, rounded shapes, culturally rooted color choices, Tagalog-first micro-copy patterns. Audience: everyday Filipino. Deployment: hub + micro-apps.
+
+**Option 4: Stripe-Grade Developer System** (Aspect 16)
+Neutral token foundation, composable primitives, obsessive consistency, documentation-first. Audience: HR/accounting professionals. Deployment: shared package + micro-apps.
+
+**Option 5: Playful Utility** (Aspect 17)
+Bold colors, chunky typography, illustration-driven, almost toy-like but deeply competent. Audience: young professional / OFW. Deployment: single app with sections.
+
+**Option 6: Editorial Calculator** (Aspect 18)
+Serif-forward, asymmetric layouts, content as hero, calculator embedded in explanatory context. Audience: mixed (content-first discovery via search). Deployment: content hub + embedded tools.
+
+**Option 7: Dashboard-Native Power Tool** (Aspect 19)
+Data-dense, multi-panel, saved computations, keyboard shortcuts, batch operations. Audience: accountant doing 50 computations/day. Deployment: single SaaS app.
+
+**Option 8: Mobile-First Micro-App** (Aspect 20)
+Card-based, swipeable, one-thumb operation, PWA-optimized, offline-capable. Audience: phone-only user (85% of PH traffic). Deployment: independent PWAs.
+
+**Option 9: Soft Institutional** (Aspect 21)
+Muted blues/greens, traditional serif + clean sans, feels like a trusted institution but modern. Audience: mixed (builds trust with older users). Deployment: hub + micro-apps.
+
+**Option 10: Bold Geometric** (Aspect 22)
+Strong grid, high-contrast accents, geometric shapes, art-deco-adjacent, memorable and shareable. Audience: young, design-conscious. Deployment: single app with sections.
+
+### Mockup Generation
+
+For each option, after writing the spec, read `skills/frontend-design.md` then build a LIVE HTML mockup of a "Retirement Pay Calculator (RA 7641)" page. The mockup must:
+- Be a complete, working HTML page (inputs, compute button, results display)
+- Use the exact color palette, typography, and component patterns from the spec
+- Include realistic Filipino content (₱ currency, Tagalog labels where appropriate for that option)
+- Show both the empty/input state and a computed result state (use tabs or scroll to show both states)
+- Be responsive (must work at 1280px and 375px)
+- Save to `raw/mockup-option-{N}-{slug}.html`
+
+### Visual QA Pass
+
+After generating each mockup, open it in the browser using Playwright and perform visual QA:
+- Does it match the written spec exactly?
+- Are fonts loading correctly (check Google Fonts CDN links)?
+- Are colors matching the specified hex values?
+- Is the responsive layout working at both 1280px and 375px breakpoints?
+- Are animations/transitions smooth?
+- Is the result display moment impactful?
+- Does it feel like the stated design philosophy?
+- Take screenshots at both breakpoints, save to `raw/screenshot-option-{N}-desktop.png` and `raw/screenshot-option-{N}-mobile.png`
+
+If ANY issue is found, fix the HTML and re-verify. Do NOT move to the next option until the current mockup is pixel-perfect. Write QA findings to `analysis/qa-option-{N}.md`.
+
+---
+
+## Wave 3 — Synthesis & Comparison
+
+### Aspect 23: Side-by-Side Comparison Matrix
+Create a comprehensive matrix scoring all 10 options across these dimensions (1-5 scale):
+- Friendliness (does it feel welcoming to a first-time user?)
+- Trustworthiness (would you enter your salary into this?)
+- Distinctiveness (would you remember this site tomorrow?)
+- Simplicity (can a non-technical user figure it out in 10 seconds?)
+- Scalability (does the system hold at 148 tools?)
+- Developer ergonomics (how fast can a dev spin up tool #149?)
+- Brand cohesion (do all tools feel like one family?)
+- Mobile readiness (does it work on a ₱5,000 Android phone?)
+- Accessibility (WCAG AA compliance achievable?)
+- Filipino cultural fit (does it feel natural to PH users?)
+- Content adaptability (works for single-form AND multi-step wizard AND dashboard?)
+- Visual memorability (screenshot-worthy? shareable?)
+Write to `analysis/comparison-matrix.md`.
+
+### Aspect 24: Audience-Fit Analysis
+Map each option to the user segments it serves best:
+- Scared first-time filer
+- Busy HR/payroll staff
+- OFW checking remotely on mobile
+- Small business owner
+- Accountant/bookkeeper doing bulk work
+- Young professional (first job)
+- Retiree checking pension
+Write to `analysis/audience-fit.md`.
+
+### Aspect 25: Developer Experience Comparison
+For each option, estimate:
+- Time to implement the design system foundation (tokens, base components)
+- Time to build a new single-form calculator using the system
+- Time to build a new multi-step wizard using the system
+- Maintenance burden (how much per-tool customization needed?)
+- Compatibility with existing stack (React 19 + Vite + Tailwind + shadcn)
+Write to `analysis/developer-experience.md`.
+
+### Aspect 26: Brand Strength Analysis
+For each option, assess:
+- Name-design fit (does the visual identity match "Angkin"?)
+- "By Angkin" badge visibility and elegance
+- Cross-domain coherence (does a tax tool feel related to a maritime tool?)
+- Competitive differentiation (would this stand out against BIR, SSS portal, GCash?)
+- Shareability (would someone screenshot a result and send it?)
+Write to `analysis/brand-strength.md`.
+
+### Aspect 27: Final Ranked Recommendation
+Synthesize all analysis into:
+- Top 3 options ranked with detailed rationale
+- Suggested hybrid possibilities (e.g., "Option 1's color system + Option 6's typography + Option 8's mobile patterns")
+- Recommended next steps (which option to prototype first, what to test with users)
+Write to `analysis/final-recommendation.md`.
+
+---
+
+## Convergence Criteria
+
+The loop has NOT converged until ALL of the following are true:
+1. All 12 Wave 1 research aspects have analysis files committed
+2. All 10 Wave 2 options have complete spec files (all 17 sections, no section skipped)
+3. All 10 Wave 2 options have live HTML mockups in `raw/`
+4. All 10 mockups have passed Visual QA — opened in browser, verified against spec, iterated until pixel-perfect
+5. All 5 Wave 3 synthesis aspects have analysis files committed
+6. The final recommendation file exists with top 3 ranked
+
+When all criteria are met, write convergence summary to `status/converged.txt`.
+
+## Rules
+
+1. ONE aspect per iteration. Do not attempt multiple aspects in a single run.
+2. Always read `frontier/aspects.md` first to determine which aspect to work on next.
+3. After completing an aspect, update `frontier/aspects.md` to mark it done and update statistics.
+4. After completing an aspect, update `frontier/analysis-log.md` with timestamp and key findings.
+5. Commit after every aspect. Commit message format: `loop(angkin-design-system-reverse): wave N — aspect description`
+6. For Wave 2 mockups: read `skills/frontend-design.md` BEFORE generating any HTML. Follow it exactly.
+7. For Wave 2 mockups: each must be a COMPLETE standalone HTML file (inline CSS, Google Fonts via CDN, no external deps).
+8. For Visual QA: use Playwright to open each mockup at 1280x800 AND 375x812. Take screenshots. Compare against spec. Fix issues and re-screenshot until perfect.
+9. Wave 2 options must be RADICALLY different from each other. If two options look similar, rework one.
+10. All currency in Filipino Peso (₱). All example content uses realistic Filipino names, amounts, and scenarios.
+11. Do not skip or abbreviate any section of the 17-section option spec. Every section must be substantive.
+12. Web research aspects (Wave 1: 4-9, 12) should use WebSearch and WebFetch tools to gather real data.

--- a/loops/angkin-design-system-reverse/frontier/analysis-log.md
+++ b/loops/angkin-design-system-reverse/frontier/analysis-log.md
@@ -1,0 +1,4 @@
+# Analysis Log
+
+| # | Timestamp | Aspect | Duration | Key Findings |
+|---|-----------|--------|----------|--------------|

--- a/loops/angkin-design-system-reverse/frontier/aspects.md
+++ b/loops/angkin-design-system-reverse/frontier/aspects.md
@@ -1,0 +1,54 @@
+# Frontier — Angkin Design System Exploration
+
+## Statistics
+
+- **Total aspects:** 27
+- **Analyzed:** 0
+- **Pending:** 27
+- **Convergence:** 0%
+
+---
+
+## Wave 1 — Deep Research (12 aspects)
+
+| # | Aspect | Status | Output File |
+|---|--------|--------|-------------|
+| 1 | Audit TaxKlaro Frontend | pending | `analysis/audit-taxklaro.md` |
+| 2 | Audit Inheritance Frontend | pending | `analysis/audit-inheritance.md` |
+| 3 | Audit PodPlay Frontend | pending | `analysis/audit-podplay.md` |
+| 4 | Benchmark Wise | pending | `analysis/benchmark-wise.md` |
+| 5 | Benchmark TurboTax / H&R Block | pending | `analysis/benchmark-tax-calculators.md` |
+| 6 | Benchmark gov.uk | pending | `analysis/benchmark-govuk.md` |
+| 7 | Benchmark SmartAsset / NerdWallet / Bankrate | pending | `analysis/benchmark-calculator-content.md` |
+| 8 | Benchmark Canva / Notion | pending | `analysis/benchmark-simple-powerful.md` |
+| 9 | Benchmark Stripe / Linear | pending | `analysis/benchmark-dev-design-systems.md` |
+| 10 | Survey Design System Architectures | pending | `analysis/design-system-architectures.md` |
+| 11 | Catalog 148 Tools by UI Archetype | pending | `analysis/tool-archetypes.md` |
+| 12 | Filipino Digital Design Landscape | pending | `analysis/filipino-design-landscape.md` |
+
+## Wave 2 — Generate 10 Options (10 aspects)
+
+Each aspect produces: spec file + HTML mockup + visual QA pass.
+
+| # | Option | Status | Spec File | Mockup | QA |
+|---|--------|--------|-----------|--------|----|
+| 13 | Option 1: Wise-Inspired Trust Minimalism | pending | `analysis/option-1-trust-minimalism.md` | `raw/mockup-option-1-trust-minimalism.html` | `analysis/qa-option-1.md` |
+| 14 | Option 2: Gov.uk Radical Clarity | pending | `analysis/option-2-radical-clarity.md` | `raw/mockup-option-2-radical-clarity.html` | `analysis/qa-option-2.md` |
+| 15 | Option 3: Filipino Warmth | pending | `analysis/option-3-filipino-warmth.md` | `raw/mockup-option-3-filipino-warmth.html` | `analysis/qa-option-3.md` |
+| 16 | Option 4: Stripe-Grade Developer System | pending | `analysis/option-4-stripe-grade.md` | `raw/mockup-option-4-stripe-grade.html` | `analysis/qa-option-4.md` |
+| 17 | Option 5: Playful Utility | pending | `analysis/option-5-playful-utility.md` | `raw/mockup-option-5-playful-utility.html` | `analysis/qa-option-5.md` |
+| 18 | Option 6: Editorial Calculator | pending | `analysis/option-6-editorial-calculator.md` | `raw/mockup-option-6-editorial-calculator.html` | `analysis/qa-option-6.md` |
+| 19 | Option 7: Dashboard-Native Power Tool | pending | `analysis/option-7-dashboard-native.md` | `raw/mockup-option-7-dashboard-native.html` | `analysis/qa-option-7.md` |
+| 20 | Option 8: Mobile-First Micro-App | pending | `analysis/option-8-mobile-first.md` | `raw/mockup-option-8-mobile-first.html` | `analysis/qa-option-8.md` |
+| 21 | Option 9: Soft Institutional | pending | `analysis/option-9-soft-institutional.md` | `raw/mockup-option-9-soft-institutional.html` | `analysis/qa-option-9.md` |
+| 22 | Option 10: Bold Geometric | pending | `analysis/option-10-bold-geometric.md` | `raw/mockup-option-10-bold-geometric.html` | `analysis/qa-option-10.md` |
+
+## Wave 3 — Synthesis & Comparison (5 aspects)
+
+| # | Aspect | Status | Output File |
+|---|--------|--------|-------------|
+| 23 | Side-by-Side Comparison Matrix | pending | `analysis/comparison-matrix.md` |
+| 24 | Audience-Fit Analysis | pending | `analysis/audience-fit.md` |
+| 25 | Developer Experience Comparison | pending | `analysis/developer-experience.md` |
+| 26 | Brand Strength Analysis | pending | `analysis/brand-strength.md` |
+| 27 | Final Ranked Recommendation | pending | `analysis/final-recommendation.md` |

--- a/loops/angkin-design-system-reverse/loop.sh
+++ b/loops/angkin-design-system-reverse/loop.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Ralph Loop — Standard Runner
+# Runs Claude Code repeatedly until convergence.
+#
+# Usage: cd loops/<idea-name> && ./loop.sh [max_iterations]
+
+set -uo pipefail
+
+# Allow nested Claude Code sessions
+unset CLAUDECODE 2>/dev/null || true
+
+WORK_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOOP_NAME="$(basename "$WORK_DIR")"
+PROMPT_FILE="$WORK_DIR/PROMPT.md"
+CONVERGED_FILE="$WORK_DIR/status/converged.txt"
+PAUSED_FILE="$WORK_DIR/status/paused.txt"
+MAX_ITERATIONS=${1:-40}
+SLEEP_BETWEEN=5
+
+cd "$WORK_DIR"
+
+if [ ! -f "$PROMPT_FILE" ]; then
+    echo "ERROR: PROMPT.md not found at $PROMPT_FILE"
+    exit 1
+fi
+
+if [ -f "$PAUSED_FILE" ]; then
+    echo "Loop '$LOOP_NAME' is paused. Remove status/paused.txt to resume."
+    exit 0
+fi
+
+if [ -f "$CONVERGED_FILE" ]; then
+    echo "Loop '$LOOP_NAME' already converged."
+    exit 0
+fi
+
+mkdir -p status
+
+iteration=0
+failures=0
+
+echo "=== Ralph Loop Starting: $LOOP_NAME ==="
+echo "Working directory: $WORK_DIR"
+echo "Max iterations: $MAX_ITERATIONS"
+echo ""
+
+while [ ! -f "$CONVERGED_FILE" ] && [ "$iteration" -lt "$MAX_ITERATIONS" ]; do
+    iteration=$((iteration + 1))
+    echo "--- Iteration $iteration / $MAX_ITERATIONS ---"
+    echo "$(date '+%Y-%m-%d %H:%M:%S')"
+
+    iter_log="/tmp/ralph-${LOOP_NAME}-iter-${iteration}.log"
+    if timeout 1800 bash -c 'unset CLAUDECODE; cat "$1" | stdbuf -oL claude --print --dangerously-skip-permissions' _ "$PROMPT_FILE" 2>&1 | stdbuf -oL tee "$iter_log"; then
+        echo ""
+        echo "Iteration $iteration completed successfully."
+        failures=0
+    else
+        iter_exit=$?
+        if [ "$iter_exit" -eq 124 ]; then
+            echo "WARNING: Iteration $iteration timed out after 1800s"
+        else
+            echo "WARNING: Iteration $iteration exited with code $iter_exit"
+        fi
+        failures=$((failures + 1))
+        if [ "$failures" -ge 3 ]; then
+            echo "ERROR: 3 consecutive failures. Stopping loop."
+            break
+        fi
+    fi
+
+    echo "Sleeping ${SLEEP_BETWEEN}s..."
+    sleep "$SLEEP_BETWEEN"
+done
+
+echo ""
+echo "=== Loop Summary: $LOOP_NAME ==="
+echo "Iterations run: $iteration"
+echo "Failures: $failures"
+
+if [ -f "$CONVERGED_FILE" ]; then
+    echo "Status: CONVERGED"
+    cat "$CONVERGED_FILE"
+elif [ "$iteration" -ge "$MAX_ITERATIONS" ]; then
+    echo "Status: STOPPED (max iterations reached)"
+    echo "Check frontier/ for remaining work."
+else
+    echo "Status: STOPPED (failures)"
+    echo "Check /tmp/ralph-${LOOP_NAME}-iter-*.log for details."
+fi

--- a/loops/angkin-design-system-reverse/skills/frontend-design.md
+++ b/loops/angkin-design-system-reverse/skills/frontend-design.md
@@ -1,0 +1,42 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, or applications. Generates creative, polished code that avoids generic AI aesthetics.
+license: Complete terms in LICENSE.txt
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+
+Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+Focus on:
+- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+
+Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+
+Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.


### PR DESCRIPTION
## Summary

- Scaffolds a 27-aspect reverse ralph loop to explore **10 exhaustive frontend design system options** for the Angkin suite
- Each option gets: competitive benchmarking, full 17-section spec, live HTML mockup (via embedded frontend-design skill), and visual QA pass with Playwright screenshots
- Wave 1 (12 aspects): audit existing apps + benchmark Wise/gov.uk/Stripe/TurboTax/Canva/etc + catalog 148 tool archetypes + Filipino design landscape research
- Wave 2 (10 aspects): 10 radically different design philosophies from trust minimalism to bold geometric, each targeting different audience segments and deployment models
- Wave 3 (5 aspects): comparison matrix, audience fit, developer experience, brand strength, final ranked recommendation

## Test plan

- [ ] Merge to main, then `gh workflow run ralph-loops.yml -f loop=angkin-design-system-reverse`
- [ ] Verify first iteration picks up Aspect 1 and produces `analysis/audit-taxklaro.md`
- [ ] Monitor Wave 2 iterations for mockup quality (check `raw/` directory for HTML files)
- [ ] Review convergence output after all 27 aspects complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)