### PR TITLE
revert: restore V2 treatment deck with runner logo and plum/periwinkle palette

### DIFF
--- a/docs/brand/kosmas/ui-treatment-deck.html
+++ b/docs/brand/kosmas/ui-treatment-deck.html
@@ -3,4048 +3,1810 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Kosmas Athletic Ventures — UI Treatment Deck V3</title>
+<title>Kosmas — UI Treatment Deck</title>
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Josefin+Sans:wght@300;400;600;700&family=Outfit:wght@300;400;500;600&display=swap" rel="stylesheet">
+<link href="https://fonts.googleapis.com/css2?family=Rajdhani:wght@300;400;500;600;700&display=swap" rel="stylesheet">
 <style>
   html { scroll-behavior: smooth; }
-
   :root {
-    /* Core palette */
-    --black: #1A1A1A;
-    --cream: #F5F0E8;
-    --cyan: #0CB4CE;
-    --stone: #D4CFC4;
-    --charcoal: #3D3D3D;
-    --white: #FFFFFF;
-    --error: #B33A3A;
-
-    /* Sport tints */
-    --tint-pickleball: #FDF8F0;
-    --tint-volleyball: #F5F8F4;
-    --tint-football: #F6F4F8;
-    --tint-golf: #F2F5F8;
-
-    /* Sport borders */
-    --border-pickleball: #E8DFD0;
-    --border-volleyball: #D8E0D5;
-    --border-football: #DDD8E2;
-    --border-golf: #D5DCE3;
-
-    /* Typography */
-    --font-heading: 'Josefin Sans', sans-serif;
-    --font-body: 'Outfit', sans-serif;
-
-    /* Spacing */
+    --plum: #4A1942;
+    --plum-light: #6B2D63;
+    --gold: #F0DFA0;
+    --gold-dim: #C4B580;
+    --peri: #B8C8E8;
+    --peri-dim: #8A9ABB;
+    --black: #1E1E1E;
+    --black-deep: #111111;
+    --gray-900: #252525;
+    --gray-800: #333333;
+    --gray-700: #444444;
+    --gray-500: #888888;
+    --gray-300: #BBBBBB;
+    --gray-100: #EEEEEE;
+    --white: #FAFAFA;
+    --font: 'Rajdhani', sans-serif;
     --space-unit: 8px;
-    --max-width: 1080px;
   }
 
   * { margin: 0; padding: 0; box-sizing: border-box; }
 
   body {
-    background: var(--cream);
-    color: var(--black);
-    font-family: var(--font-body);
-    font-weight: 300;
+    background: var(--black-deep);
+    color: var(--white);
+    font-family: var(--font);
+    font-weight: 400;
     line-height: 1.6;
   }
 
-  .container {
-    max-width: var(--max-width);
-    margin: 0 auto;
-    padding: 0 32px;
-  }
+  .container { max-width: 1080px; margin: 0 auto; padding: 0 32px; }
 
-  .section {
-    padding: 64px 0;
-    border-bottom: 1px solid var(--stone);
-  }
-
-  .section-number {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    color: var(--charcoal);
-    margin-bottom: 8px;
-  }
-
-  .section-title {
-    font-family: var(--font-heading);
-    font-weight: 600;
-    font-size: 28px;
-    letter-spacing: 2px;
-    color: var(--black);
-    margin-bottom: 40px;
-  }
-
-  /* ==================== HERO ==================== */
+  /* ==================== SECTION: HERO ==================== */
   .hero {
-    background: var(--cream);
+    background: var(--plum);
     padding: 80px 0;
     text-align: center;
-    border-bottom: 1px solid var(--stone);
+    border-bottom: 4px solid var(--gold);
   }
-
-  .hero-logo {
+  .hero img.logo {
     height: 120px;
-    display: block;
-    margin: 0 auto 24px;
+    filter: invert(1);
+    
+    margin-bottom: 32px;
   }
-
-  .hero-tagline {
-    font-family: var(--font-body);
-    font-weight: 300;
+  .hero .brand-statement {
     font-size: 15px;
-    color: var(--charcoal);
+    font-weight: 400;
+    color: rgba(255,255,255,0.6);
+    letter-spacing: 1px;
     max-width: 600px;
     margin: 0 auto;
   }
 
-  /* ==================== STICKY TOC NAV ==================== */
-  .toc-nav {
-    position: sticky;
-    top: 0;
-    z-index: 100;
-    background: var(--cream);
-    border-bottom: 2px solid var(--black);
-    height: 48px;
-    display: flex;
-    align-items: center;
-    overflow-x: auto;
+  /* ==================== SECTION HEADERS ==================== */
+  .section {
+    padding: 64px 0;
+    border-bottom: 1px solid var(--gray-800);
   }
-
-  .toc-nav .container {
-    display: flex;
-    align-items: center;
-    gap: 24px;
-    white-space: nowrap;
-  }
-
-  .toc-link {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    color: var(--charcoal);
-    text-decoration: none;
-    padding-bottom: 4px;
-    border-bottom: 2px solid transparent;
-    transition: color 0.15s, border-color 0.15s;
-  }
-
-  .toc-link:hover {
-    color: var(--black);
-  }
-
-  .toc-link.active {
-    color: var(--black);
-    border-bottom: 2px solid var(--black);
-  }
-
-  /* ==================== COLOR PALETTE ==================== */
-  .palette-row {
-    display: flex;
-    gap: 16px;
-    flex-wrap: wrap;
-    margin-bottom: 40px;
-  }
-
-  .swatch-card {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 8px;
-    flex: 1;
-    min-width: 100px;
-  }
-
-  .swatch-block {
-    width: 80px;
-    height: 80px;
-    border-radius: 6px;
-    border: 1px solid rgba(0,0,0,0.08);
-    flex-shrink: 0;
-  }
-
-  .swatch-name {
-    font-family: var(--font-body);
-    font-weight: 500;
+  .section:last-child { border-bottom: none; }
+  .section-number {
     font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 4px;
+    color: var(--gold-dim);
     text-transform: uppercase;
-    letter-spacing: 1px;
-    color: var(--black);
-  }
-
-  .swatch-hex {
-    font-family: var(--font-body);
-    font-weight: 400;
-    font-size: 12px;
-    font-variant-numeric: tabular-nums;
-    font-feature-settings: "tnum";
-    color: var(--black);
-    font-family: monospace;
-  }
-
-  .swatch-rgb {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 11px;
-    color: var(--charcoal);
-  }
-
-  .usage-bar-wrap {
-    margin-bottom: 40px;
-  }
-
-  .usage-bar-label {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    color: var(--charcoal);
-    margin-bottom: 12px;
-  }
-
-  .usage-bar {
-    display: flex;
-    height: 24px;
-    border-radius: 4px;
-    overflow: hidden;
-    border: 1px solid var(--stone);
     margin-bottom: 8px;
   }
-
-  .usage-bar-segment {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-family: var(--font-body);
-    font-size: 10px;
-    font-weight: 500;
-    letter-spacing: 0.5px;
-  }
-
-  .usage-bar-legend {
-    display: flex;
-    gap: 24px;
-  }
-
-  .usage-bar-legend-item {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-family: var(--font-body);
-    font-size: 11px;
-    font-weight: 300;
-    color: var(--charcoal);
-  }
-
-  .usage-bar-legend-dot {
-    width: 10px;
-    height: 10px;
-    border-radius: 2px;
-    border: 1px solid rgba(0,0,0,0.1);
-  }
-
-  .cyan-callout {
-    border-left: 4px solid var(--cyan);
-    background: var(--white);
-    border-radius: 0 6px 6px 0;
-    padding: 20px 24px;
-    margin-bottom: 40px;
-  }
-
-  .cyan-callout-rule {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 14px;
-    color: var(--charcoal);
-    line-height: 1.5;
+  .section-title {
+    font-size: 36px;
+    font-weight: 700;
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    color: var(--white);
     margin-bottom: 8px;
   }
-
-  .cyan-callout-rule:last-child {
-    margin-bottom: 0;
-  }
-
-  .cyan-callout-rule strong {
-    font-weight: 500;
-    color: var(--black);
-  }
-
-  .sport-tints-row {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 16px;
-  }
-
-  .sport-tint-card {
-    border-radius: 6px;
-    overflow: hidden;
-    border: 1px solid var(--stone);
-  }
-
-  .sport-tint-swatch {
-    height: 64px;
-    width: 100%;
-  }
-
-  .sport-tint-info {
-    background: var(--white);
-    padding: 12px 14px;
-    border-top: 1px solid var(--stone);
-  }
-
-  .sport-tint-name {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    color: var(--black);
-    margin-bottom: 6px;
-  }
-
-  .sport-tint-hex {
-    font-family: monospace;
-    font-size: 11px;
-    color: var(--charcoal);
-    display: block;
-    line-height: 1.6;
-  }
-
-  /* ==================== TYPOGRAPHY ==================== */
-  .type-scale-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-bottom: 48px;
-  }
-
-  .type-scale-row {
-    border-bottom: 1px solid var(--stone);
-    display: grid;
-    grid-template-columns: 120px 1fr 200px;
-    align-items: center;
-    padding: 16px 0;
-    gap: 16px;
-  }
-
-  .type-scale-row:first-child {
-    border-top: 1px solid var(--stone);
-  }
-
-  .type-level-label {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    color: var(--charcoal);
-    align-self: center;
-  }
-
-  .type-sample-display {
-    overflow: hidden;
-  }
-
-  .type-specs {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 12px;
-    color: var(--charcoal);
-    line-height: 1.5;
-    align-self: center;
-  }
-
-  .weight-showcase {
-    margin-bottom: 48px;
-  }
-
-  .weight-row {
-    display: flex;
-    gap: 32px;
-    flex-wrap: wrap;
-    align-items: baseline;
-    padding: 16px 0;
-    border-bottom: 1px solid var(--stone);
-  }
-
-  .weight-row:first-child {
-    border-top: 1px solid var(--stone);
-  }
-
-  .weight-item {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-  }
-
-  .weight-label {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    color: var(--charcoal);
-  }
-
-  .pairing-guidance {
-    background: var(--white);
-    border: 1px solid var(--stone);
-    border-radius: 6px;
-    padding: 20px 24px;
-    margin-bottom: 40px;
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 14px;
-    color: var(--charcoal);
-    line-height: 1.6;
-  }
-
-  .pairing-guidance strong {
-    font-weight: 500;
-    color: var(--black);
-  }
-
-  .body-text-sample {
-    background: var(--white);
-    border: 1px solid var(--stone);
-    border-radius: 6px;
-    padding: 28px 32px;
-  }
-
-  /* ==================== SPACING & GRID ==================== */
-  .spacing-scale {
-    margin-bottom: 48px;
-  }
-
-  .spacing-row {
-    display: flex;
-    align-items: center;
-    gap: 20px;
-    padding: 10px 0;
-    border-bottom: 1px solid var(--stone);
-  }
-
-  .spacing-row:first-child {
-    border-top: 1px solid var(--stone);
-  }
-
-  .spacing-bar-label {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 11px;
-    color: var(--charcoal);
-    width: 96px;
-    flex-shrink: 0;
-  }
-
-  .spacing-bar-track {
-    flex: 1;
-    height: 20px;
-    display: flex;
-    align-items: center;
-  }
-
-  .spacing-bar-fill {
-    height: 8px;
-    background: var(--black);
-    border-radius: 2px;
-    flex-shrink: 0;
-  }
-
-  .grid-demo {
-    background: var(--white);
-    border: 1px solid var(--stone);
-    border-radius: 6px;
-    padding: 32px;
-    position: relative;
-    overflow: hidden;
-  }
-
-  .grid-demo-inner {
-    max-width: 1080px;
-    margin: 0 auto;
-    background: var(--cream);
-    border: 1px dashed var(--stone);
-    border-radius: 4px;
-    height: 64px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    position: relative;
-  }
-
-  .grid-annotation {
-    font-family: var(--font-body);
-    font-weight: 400;
-    font-size: 11px;
-    color: var(--charcoal);
-    text-align: center;
-    margin-top: 12px;
-  }
-
-  .grid-annotation strong {
-    font-weight: 500;
-    color: var(--black);
-  }
-
-  .grid-padding-indicator {
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    width: 32px;
-    background: rgba(12,180,206,0.12);
-    border: 1px dashed var(--cyan);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .grid-padding-indicator span {
-    font-family: var(--font-body);
-    font-size: 9px;
-    font-weight: 500;
-    color: var(--cyan);
-    writing-mode: vertical-lr;
-    transform: rotate(180deg);
-    letter-spacing: 1px;
-  }
-
-  /* ==================== BUTTONS ==================== */
-  .btn {
-    font-family: var(--font-body);
-    font-weight: 600;
-    font-size: 12px;
-    letter-spacing: 1.5px;
-    text-transform: uppercase;
-    padding: 10px 28px;
-    border-radius: 4px;
-    border: none;
-    cursor: pointer;
-    transition: all 0.15s ease;
-    display: inline-block;
-    text-decoration: none;
-    line-height: 1;
-  }
-
-  .btn-primary {
-    background: var(--black);
-    color: var(--cream);
-  }
-
-  .btn-primary:hover {
-    background: var(--charcoal);
-  }
-
-  .btn-secondary {
-    background: transparent;
-    border: 2px solid var(--black);
-    color: var(--black);
-  }
-
-  .btn-secondary:hover {
-    background: var(--black);
-    color: var(--cream);
-  }
-
-  .btn-ghost {
-    background: transparent;
-    color: var(--charcoal);
-    border: none;
-  }
-
-  .btn-ghost:hover {
-    background: var(--stone);
-  }
-
-  .btn-accent {
-    background: var(--cyan);
-    color: var(--black);
-  }
-
-  .btn-accent:hover {
-    background: #0A9AB3;
-  }
-
-  .btn-disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .btn-grid {
-    display: grid;
-    grid-template-columns: 140px repeat(5, 1fr);
-    gap: 0;
-    border: 1px solid var(--stone);
-    border-radius: 6px;
-    overflow: hidden;
-  }
-
-  .btn-grid-header {
-    background: var(--black);
-    color: var(--cream);
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    padding: 12px 16px;
-    display: flex;
-    align-items: center;
-  }
-
-  .btn-grid-cell {
-    padding: 20px 16px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    border-left: 1px solid var(--stone);
-    border-bottom: 1px solid var(--stone);
-  }
-
-  .btn-grid-cell:nth-child(-n+6) {
-    border-bottom: 1px solid var(--stone);
-  }
-
-  .btn-grid-row-label {
-    padding: 20px 16px;
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    color: var(--charcoal);
-    background: var(--cream);
-    border-bottom: 1px solid var(--stone);
-    display: flex;
-    align-items: center;
-  }
-
-  .btn-grid-row-label.last,
-  .btn-grid-cell.last {
-    border-bottom: none;
-  }
-
-  /* ==================== PHILOSOPHY PILLARS ==================== */
-  .pillars-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 24px;
-  }
-
-  .pillar-card {
-    background: var(--white);
-    border: 1px solid var(--stone);
-    border-radius: 6px;
-    padding: 24px;
-  }
-
-  .pillar-motif {
-    height: 60px;
-    margin-bottom: 16px;
-    border-radius: 4px;
-    overflow: hidden;
-  }
-
-  .pillar-motif--precision {
-    background: repeating-linear-gradient(
-      0deg,
-      var(--black) 0px,
-      var(--black) 1px,
-      transparent 1px,
-      transparent 8px
-    );
-  }
-
-  .pillar-motif--premium {
-    background: linear-gradient(135deg, var(--cream) 0%, var(--white) 100%);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .pillar-motif--energy {
-    background: var(--black);
-    position: relative;
-  }
-
-  .pillar-motif--energy::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    height: 3px;
-    background: var(--cyan);
-  }
-
-  .pillar-name {
-    font-family: var(--font-heading);
-    font-weight: 600;
-    font-size: 20px;
-    letter-spacing: 1px;
-    color: var(--black);
-    margin-bottom: 12px;
-  }
-
-  .pillar-desc {
-    font-family: var(--font-body);
-    font-weight: 300;
+  .section-desc {
     font-size: 15px;
-    color: var(--charcoal);
-    line-height: 1.6;
-  }
-
-  /* ==================== LOGO SYSTEM ==================== */
-  .logo-row {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 24px;
+    color: var(--gray-500);
     margin-bottom: 40px;
+    max-width: 600px;
   }
 
-  .logo-card {
-    border: 1px solid var(--stone);
-    border-radius: 6px;
-    overflow: hidden;
-  }
-
-  .logo-card-display {
+  /* ==================== 2. LOGO SYSTEM ==================== */
+  .logo-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; margin-top: 24px; }
+  .logo-variant {
+    background: var(--gray-900);
+    border: 1px solid var(--gray-800);
+    border-radius: 8px;
     padding: 32px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 140px;
-  }
-
-  .logo-card-display--cream { background: var(--cream); }
-  .logo-card-display--dark  { background: var(--black); }
-  .logo-card-display--white { background: var(--white); }
-
-  .logo-card-label {
-    background: var(--white);
-    border-top: 1px solid var(--stone);
-    padding: 10px 16px;
-    font-family: var(--font-body);
-    font-size: 11px;
-    font-weight: 500;
-    color: var(--charcoal);
-    text-transform: uppercase;
-    letter-spacing: 1px;
-  }
-
-  .logo-card-label .caption {
-    font-size: 10px;
-    font-weight: 300;
-    color: var(--stone);
-    text-transform: none;
-    letter-spacing: 0;
-    display: block;
-    margin-top: 2px;
-  }
-
-  .logo-img      { max-height: 100px; max-width: 100%; }
-  .logo-img--dark { max-height: 100px; max-width: 100%; mix-blend-mode: multiply; }
-  .logo-img--mono { max-height: 100px; max-width: 100%; filter: grayscale(1); }
-
-  .subsection-label {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    color: var(--charcoal);
-    margin-bottom: 16px;
-    padding-bottom: 8px;
-    border-bottom: 1px solid var(--stone);
-  }
-
-  /* Safe zone */
-  .safe-zone-section { margin-bottom: 40px; }
-
-  .safe-zone-demo {
-    display: inline-flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .safe-zone-box {
-    border: 2px dashed var(--stone);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .safe-zone-caption {
-    font-family: var(--font-body);
-    font-size: 12px;
-    font-weight: 300;
-    color: var(--charcoal);
-  }
-
-  /* Min sizes */
-  .min-sizes-section { margin-bottom: 40px; }
-
-  .min-sizes-row {
-    display: flex;
-    gap: 48px;
-    align-items: flex-end;
-    flex-wrap: wrap;
-  }
-
-  .min-size-item {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 8px;
-  }
-
-  .min-size-label {
-    font-family: var(--font-body);
-    font-size: 11px;
-    font-weight: 400;
-    color: var(--charcoal);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-
-  /* Don'ts */
-  .donts-grid {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 16px;
-  }
-
-  .dont-card {
-    border: 1px solid var(--stone);
-    border-radius: 6px;
-    overflow: hidden;
-  }
-
-  .dont-display {
-    background: var(--cream);
-    padding: 28px;
     display: flex;
     align-items: center;
     justify-content: center;
     min-height: 120px;
+  }
+  .logo-variant.light-bg { background: var(--white); }
+  .logo-variant img { max-height: 60px; }
+  .logo-variant .icon-crop {
+    width: 48px;
+    height: 48px;
+    overflow: hidden;
+    display: inline-block;
+  }
+  .logo-variant .icon-crop img {
+    height: 48px;
+    object-fit: cover;
+    object-position: left center;
+  }
+  .logo-subsection { margin-top: 40px; }
+  .logo-subsection-title {
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 2px;
+    color: var(--gray-300);
+    margin-bottom: 16px;
+    text-transform: uppercase;
+  }
+  .safe-zone {
+    display: inline-block;
+    border: 2px dashed var(--gray-500);
+    padding: 24px;
+    border-radius: 4px;
     position: relative;
   }
-
-  .dont-x {
+  .safe-zone::after {
+    content: '1x';
+    position: absolute;
+    top: 4px;
+    right: 8px;
+    font-size: 11px;
+    color: var(--gray-500);
+    letter-spacing: 1px;
+  }
+  .dont-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-top: 16px; }
+  .dont-card {
+    background: var(--gray-900);
+    border: 1px solid var(--gray-800);
+    border-radius: 8px;
+    padding: 24px 16px;
+    text-align: center;
+    position: relative;
+  }
+  .dont-card img { max-height: 40px; margin-bottom: 12px; }
+  .dont-card .dont-x {
     position: absolute;
     top: 8px;
     right: 8px;
-    width: 24px;
-    height: 24px;
   }
+  .dont-card p { font-size: 12px; color: var(--gray-500); letter-spacing: 1px; text-transform: uppercase; }
 
-  .dont-caption {
-    background: var(--white);
-    border-top: 1px solid var(--stone);
-    padding: 8px 12px;
-    font-family: var(--font-body);
-    font-size: 11px;
-    font-weight: 400;
-    color: var(--error);
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-
-  .dont-logo--base    { max-height: 60px; }
-  .dont-logo--rotate  { transform: rotate(15deg); max-height: 60px; }
-  .dont-logo--stretch { transform: scaleX(1.5); max-height: 60px; }
-  .dont-logo--recolor { filter: hue-rotate(90deg); max-height: 60px; }
-
-  .dont-logo-gradient-wrap { position: relative; display: inline-block; }
-  .dont-logo-gradient-wrap img { max-height: 60px; display: block; }
-  .dont-logo-gradient-wrap::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    background: linear-gradient(135deg, rgba(255,100,100,0.4) 0%, rgba(100,100,255,0.4) 100%);
-    mix-blend-mode: color;
-    pointer-events: none;
-  }
-
-  /* ==================== TAGS & BADGES ==================== */
-  .tag-row {
-    display: flex;
-    align-items: flex-start;
-    gap: 32px;
-    padding: 20px 0;
-    border-bottom: 1px solid var(--stone);
-  }
-
-  .tag-row:first-child {
-    border-top: 1px solid var(--stone);
-  }
-
-  .tag-row-label {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    color: var(--charcoal);
-    width: 140px;
-    flex-shrink: 0;
-    padding-top: 4px;
-  }
-
-  .tag-row-examples {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 24px;
-    flex: 1;
-  }
-
-  .tag-example-group {
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-  }
-
-  .tag-size-label {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 10px;
-    color: var(--charcoal);
-    letter-spacing: 1px;
-    text-transform: uppercase;
-  }
-
-  .tag-items {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    align-items: center;
-  }
-
-  /* Sport tags */
-  .tag-sport {
-    border: 1px solid var(--stone);
-    color: var(--black);
-    background: transparent;
-    padding: 3px 10px;
-    border-radius: 3px;
-    font-family: var(--font-body);
-    font-size: 10px;
-    font-weight: 500;
-    letter-spacing: 2px;
-    text-transform: uppercase;
-    display: inline-block;
-  }
-
-  .tag-sport--compact {
-    padding: 2px 7px;
-    font-size: 9px;
-    letter-spacing: 1.5px;
-  }
-
-  /* Status badges */
-  .badge-active {
-    color: var(--cyan);
-    font-family: var(--font-body);
-    font-size: 10px;
-    font-weight: 500;
-    letter-spacing: 2px;
-    text-transform: uppercase;
-    display: inline-block;
-  }
-
-  .badge-active--compact {
-    font-size: 9px;
-    letter-spacing: 1.5px;
-  }
-
-  .badge-soldout {
-    color: var(--charcoal);
-    text-decoration: line-through;
-    font-family: var(--font-body);
-    font-size: 10px;
-    font-weight: 500;
-    letter-spacing: 2px;
-    text-transform: uppercase;
-    display: inline-block;
-  }
-
-  .badge-soldout--compact {
-    font-size: 9px;
-    letter-spacing: 1.5px;
-  }
-
-  .badge-upcoming {
-    background: var(--black);
-    color: var(--cream);
-    padding: 3px 10px;
-    border-radius: 3px;
-    font-family: var(--font-body);
-    font-size: 10px;
-    font-weight: 500;
-    letter-spacing: 2px;
-    text-transform: uppercase;
-    display: inline-block;
-  }
-
-  .badge-upcoming--compact {
-    padding: 2px 7px;
-    font-size: 9px;
-    letter-spacing: 1.5px;
-  }
-
-  /* Location tags */
-  .tag-location {
-    color: var(--charcoal);
-    font-family: var(--font-body);
-    font-size: 10px;
-    font-weight: 500;
-    letter-spacing: 2px;
-    text-transform: uppercase;
-    display: inline-block;
-  }
-
-  .tag-location--compact {
-    font-size: 9px;
-    letter-spacing: 1.5px;
-  }
-
-  /* Category labels */
-  .tag-category {
-    background: rgba(212, 207, 196, 0.3);
-    padding: 3px 10px;
-    border-radius: 3px;
-    font-family: var(--font-body);
-    font-variant: small-caps;
-    font-size: 11px;
-    font-weight: 500;
-    color: var(--black);
-    display: inline-block;
-  }
-
-  .tag-category--compact {
-    padding: 2px 7px;
-    font-size: 10px;
-  }
-
-  /* Metric badges */
-  .badge-metric {
-    color: var(--cyan);
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 11px;
-    display: inline-block;
-  }
-
-  .badge-metric--compact {
-    font-size: 10px;
-  }
-
-  /* ==================== FORM INPUTS ==================== */
-  .form-input {
-    background: var(--white);
-    border: 1px solid var(--stone);
-    border-radius: 4px;
-    padding: 10px 12px;
-    font-family: var(--font-body);
-    font-size: 14px;
-    font-weight: 300;
-    color: var(--black);
-    outline: none;
-    transition: border-color 0.15s;
-    width: 100%;
-  }
-
-  .form-input:focus,
-  .form-input.focus {
-    border-color: var(--cyan);
-  }
-
-  .form-input.error {
-    border-color: var(--error);
-  }
-
-  .form-input:disabled,
-  .form-input.disabled {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  .input-error-msg {
-    color: var(--error);
-    font-size: 12px;
-    margin-top: 4px;
-    font-family: var(--font-body);
-    font-weight: 300;
-  }
-
-  .form-grid {
-    display: grid;
-    grid-template-columns: 140px 1fr 1fr 1fr 1fr;
-    gap: 0;
-    border: 1px solid var(--stone);
-    border-radius: 6px;
-    overflow: hidden;
-    margin-bottom: 0;
-  }
-
-  .form-grid-header {
-    background: var(--black);
-    color: var(--cream);
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    padding: 12px 16px;
-    display: flex;
-    align-items: center;
-  }
-
-  .form-grid-row-label {
-    padding: 20px 16px;
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    color: var(--charcoal);
-    background: var(--cream);
-    border-bottom: 1px solid var(--stone);
-    display: flex;
-    align-items: flex-start;
-    padding-top: 18px;
-  }
-
-  .form-grid-row-label.last {
-    border-bottom: none;
-  }
-
-  .form-grid-cell {
-    padding: 16px;
-    display: flex;
-    flex-direction: column;
-    align-items: stretch;
-    justify-content: flex-start;
-    border-left: 1px solid var(--stone);
-    border-bottom: 1px solid var(--stone);
-  }
-
-  .form-grid-cell.last {
-    border-bottom: none;
-  }
-
-  /* Toggle switch */
-  .toggle-wrap {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-  }
-
-  .toggle {
-    position: relative;
-    width: 36px;
-    height: 20px;
-    flex-shrink: 0;
-  }
-
-  .toggle input {
-    opacity: 0;
-    width: 0;
-    height: 0;
-    position: absolute;
-  }
-
-  .toggle-track {
-    position: absolute;
-    inset: 0;
-    border-radius: 10px;
-    background: var(--stone);
-    transition: background 0.15s;
-    cursor: pointer;
-  }
-
-  .toggle-track::after {
-    content: '';
-    position: absolute;
-    top: 3px;
-    left: 3px;
-    width: 14px;
-    height: 14px;
-    border-radius: 50%;
-    background: var(--white);
-    transition: transform 0.15s;
-  }
-
-  .toggle input:checked + .toggle-track {
-    background: var(--black);
-  }
-
-  .toggle input:checked + .toggle-track::after {
-    transform: translateX(16px);
-  }
-
-  .toggle-label {
-    font-family: var(--font-body);
-    font-size: 13px;
-    font-weight: 300;
-    color: var(--charcoal);
-  }
-
-  /* Toggle disabled */
-  .toggle.disabled .toggle-track {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  /* Checkbox & Radio */
-  .check-wrap,
-  .radio-wrap {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 8px;
-  }
-
-  .check-wrap:last-child,
-  .radio-wrap:last-child {
-    margin-bottom: 0;
-  }
-
-  .custom-checkbox,
-  .custom-radio {
-    position: relative;
-    width: 16px;
-    height: 16px;
-    flex-shrink: 0;
-    cursor: pointer;
-  }
-
-  .custom-checkbox input,
-  .custom-radio input {
-    opacity: 0;
-    width: 0;
-    height: 0;
-    position: absolute;
-  }
-
-  .checkbox-box {
-    position: absolute;
-    inset: 0;
-    border: 1px solid var(--stone);
-    border-radius: 3px;
-    background: var(--white);
-    transition: all 0.15s;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .custom-checkbox input:checked + .checkbox-box {
-    background: var(--black);
-    border-color: var(--black);
-  }
-
-  .checkbox-box::after {
-    content: '';
-    width: 8px;
-    height: 5px;
-    border-left: 2px solid var(--white);
-    border-bottom: 2px solid var(--white);
-    transform: rotate(-45deg) translateY(-1px);
-    opacity: 0;
-  }
-
-  .custom-checkbox input:checked + .checkbox-box::after {
-    opacity: 1;
-  }
-
-  .radio-circle {
-    position: absolute;
-    inset: 0;
-    border: 1px solid var(--stone);
-    border-radius: 50%;
-    background: var(--white);
-    transition: all 0.15s;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  .custom-radio input:checked + .radio-circle {
-    border-color: var(--black);
-  }
-
-  .radio-circle::after {
-    content: '';
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: var(--black);
-    opacity: 0;
-  }
-
-  .custom-radio input:checked + .radio-circle::after {
-    opacity: 1;
-  }
-
-  .check-radio-label {
-    font-family: var(--font-body);
-    font-size: 13px;
-    font-weight: 300;
-    color: var(--charcoal);
-  }
-
-  /* Disabled check/radio */
-  .check-wrap.disabled .checkbox-box,
-  .radio-wrap.disabled .radio-circle {
-    opacity: 0.5;
-    cursor: not-allowed;
-  }
-
-  /* Search input */
-  .search-wrap {
-    position: relative;
-  }
-
-  .search-wrap .search-icon {
-    position: absolute;
-    left: 10px;
-    top: 50%;
-    transform: translateY(-50%);
-    color: var(--charcoal);
-    opacity: 0.6;
-    pointer-events: none;
-    display: flex;
-    align-items: center;
-  }
-
-  .search-wrap .form-input {
-    padding-left: 32px;
-  }
-
-  /* Error state for checkbox/radio rows */
-  .check-wrap.error .checkbox-box,
-  .radio-wrap.error .radio-circle {
-    border-color: var(--error);
-  }
-
-  /* Focus state for checkbox/radio rows */
-  .check-wrap.focus .checkbox-box,
-  .radio-wrap.focus .radio-circle {
-    border-color: var(--cyan);
-  }
-
-  /* ==================== CARDS & CONTAINERS ==================== */
-  .card {
-    background: var(--white);
-    border: 1px solid var(--stone);
-    border-radius: 6px;
-    padding: 24px;
-    transition: all 0.15s ease;
-  }
-
-  .card:hover {
-    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
-    transform: translateY(-2px);
-  }
-
-  .cards-section-label {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    color: var(--charcoal);
-    margin-bottom: 16px;
-    margin-top: 40px;
-  }
-
-  .cards-section-label:first-child {
-    margin-top: 0;
-  }
-
-  .cards-grid {
+  /* ==================== 3. COLOR PALETTE ==================== */
+  .color-grid {
     display: grid;
     grid-template-columns: repeat(4, 1fr);
     gap: 16px;
-    margin-bottom: 0;
-  }
-
-  .cards-grid-3 {
-    display: grid;
-    grid-template-columns: 2fr 1fr 1fr;
-    gap: 16px;
-  }
-
-  .card-title {
-    font-family: var(--font-heading);
-    font-weight: 600;
-    font-size: 20px;
-    letter-spacing: 1px;
-    color: var(--black);
-    margin-bottom: 10px;
-  }
-
-  .card-body {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 15px;
-    color: var(--charcoal);
-    line-height: 1.6;
-    margin-bottom: 16px;
-  }
-
-  .card-link {
-    color: var(--cyan);
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 13px;
-    text-decoration: none;
-    letter-spacing: 0.5px;
-  }
-
-  .card-link:hover {
-    text-decoration: underline;
-  }
-
-  .card-sport-title {
-    font-family: var(--font-heading);
-    font-weight: 600;
-    font-size: 16px;
-    letter-spacing: 1px;
-    color: var(--black);
-    margin-bottom: 6px;
-  }
-
-  .card-sport-count {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 13px;
-    color: var(--charcoal);
-  }
-
-  .card-stat-label {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 1.5px;
-    color: var(--charcoal);
-    margin-bottom: 8px;
-    display: block;
-  }
-
-  .card-stat-number {
-    font-family: var(--font-heading);
-    font-weight: 600;
-    font-size: 30px;
-    letter-spacing: 1px;
-    color: var(--black);
-    line-height: 1;
-  }
-
-  .card-img-placeholder {
-    height: 120px;
-    background: var(--stone);
-    opacity: 0.3;
-    border-radius: 4px;
-    margin-bottom: 16px;
-  }
-
-  .card-img-title {
-    font-family: var(--font-heading);
-    font-weight: 600;
-    font-size: 16px;
-    letter-spacing: 1px;
-    color: var(--black);
-    margin-bottom: 8px;
-  }
-
-  .card-img-desc {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 13px;
-    color: var(--charcoal);
-    line-height: 1.5;
-  }
-
-  /* ==================== NAVIGATION ==================== */
-  .mockup-frame {
-    border: 1px solid var(--stone);
-    border-radius: 6px;
-    overflow: hidden;
-    margin-bottom: 24px;
-  }
-
-  .nav-desktop {
-    height: 64px;
-    background: var(--cream);
-    border-bottom: 2px solid var(--black);
-    display: flex;
-    align-items: center;
-    padding: 0 32px;
-    gap: 0;
-  }
-
-  .nav-desktop-left {
-    display: flex;
-    align-items: center;
-    flex: 0 0 auto;
-  }
-
-  .nav-desktop-center {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 24px;
-    flex: 1 1 auto;
-  }
-
-  .nav-link {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    color: var(--charcoal);
-    text-decoration: none;
-    cursor: default;
-  }
-
-  .nav-link.active {
-    color: var(--black);
-    border-bottom: 2px solid var(--black);
-    padding-bottom: 2px;
-  }
-
-  .nav-desktop-right {
-    display: flex;
-    align-items: center;
-    flex: 0 0 auto;
-  }
-
-  .nav-specs {
-    font-family: var(--font-body);
-    font-weight: 400;
-    font-size: 11px;
-    color: var(--charcoal);
-    letter-spacing: 0.5px;
-    margin-bottom: 24px;
-  }
-
-  .nav-mobile-header {
-    height: 56px;
-    background: var(--cream);
-    border-bottom: 2px solid var(--black);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    padding: 0 20px;
-  }
-
-  .nav-mobile-panel {
-    background: var(--cream);
-    padding: 32px 20px;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 24px;
-  }
-
-  /* ==================== FOOTER ==================== */
-  .footer-mockup {
-    border-top: 2px solid var(--black);
-    background: var(--cream);
-    padding: 48px 32px 0;
-  }
-
-  .footer-grid {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 40px;
-  }
-
-  .footer-col-tagline {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 13px;
-    color: var(--charcoal);
-    line-height: 1.6;
-    margin-top: 12px;
-  }
-
-  .footer-col-heading {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    color: var(--black);
-    margin-bottom: 12px;
-  }
-
-  .footer-col-link {
-    display: block;
-    font-family: var(--font-body);
-    font-weight: 400;
-    font-size: 14px;
-    color: var(--charcoal);
-    line-height: 2;
-    text-decoration: none;
-    cursor: default;
-  }
-
-  .footer-copyright {
-    border-top: 1px solid var(--stone);
-    padding: 16px 0;
-    margin-top: 40px;
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 12px;
-    color: var(--charcoal);
-  }
-
-  /* ==================== PAGE TREATMENTS (SECTION 12) ==================== */
-  .treatment-tabs {
-    display: flex;
-    gap: 0;
-    border-bottom: 1px solid var(--stone);
     margin-bottom: 32px;
-    overflow-x: auto;
   }
-
-  .treatment-tab {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 1px;
-    padding: 8px 16px;
-    cursor: pointer;
-    background: transparent;
-    border: none;
-    border-bottom: 2px solid transparent;
-    color: var(--charcoal);
-    white-space: nowrap;
-    transition: color 0.15s, border-color 0.15s;
-    margin-bottom: -1px;
-  }
-
-  .treatment-tab.active {
-    color: var(--black);
-    border-bottom: 2px solid var(--black);
-  }
-
-  .treatment-tab:hover:not(.active) {
-    color: var(--black);
-  }
-
-  /* 12a Landing */
-  .pt-hero {
-    background: var(--cream);
-    text-align: center;
-    padding: 48px 32px;
-    border-bottom: 1px solid var(--stone);
-  }
-
-  .pt-hero-headline {
-    font-family: var(--font-heading);
-    font-weight: 300;
-    font-size: 36px;
-    letter-spacing: 3px;
-    color: var(--black);
-    margin-bottom: 12px;
-  }
-
-  .pt-hero-subtitle {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 15px;
-    color: var(--charcoal);
-    margin-bottom: 24px;
-  }
-
-  .pt-hero-btns {
-    display: flex;
-    gap: 12px;
-    justify-content: center;
-  }
-
-  .pt-sport-grid {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 16px;
-    padding: 32px;
-    border-bottom: 1px solid var(--stone);
-  }
-
-  .pt-sport-card {
-    border-radius: 6px;
-    padding: 20px;
-    border: 1px solid transparent;
-  }
-
-  .pt-sport-name {
-    font-family: var(--font-heading);
-    font-weight: 600;
-    font-size: 18px;
-    letter-spacing: 1px;
-    color: var(--black);
-    margin-bottom: 6px;
-  }
-
-  .pt-sport-count {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 13px;
-    color: var(--charcoal);
-    margin-bottom: 12px;
-  }
-
-  .pt-sport-link {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 13px;
-    color: var(--cyan);
-    text-decoration: none;
-    cursor: default;
-  }
-
-  .pt-testimonial {
-    text-align: center;
-    padding: 40px 64px;
-    border-bottom: 1px solid var(--stone);
-  }
-
-  .pt-testimonial-quote {
-    font-family: var(--font-heading);
-    font-weight: 400;
-    font-size: 20px;
-    font-style: italic;
-    color: var(--black);
-    margin-bottom: 12px;
-    line-height: 1.5;
-  }
-
-  .pt-testimonial-attr {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 13px;
-    color: var(--charcoal);
-  }
-
-  .pt-cta {
-    text-align: center;
-    padding: 40px 32px;
-    background: var(--cream);
-  }
-
-  .pt-cta-heading {
-    font-family: var(--font-heading);
-    font-weight: 600;
-    font-size: 24px;
-    letter-spacing: 1px;
-    color: var(--black);
-    margin-bottom: 20px;
-  }
-
-  /* 12b Dashboard */
-  .pt-dash-inner {
-    padding: 24px;
-    background: var(--cream);
-  }
-
-  .pt-kpi-grid {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 16px;
-    margin-bottom: 24px;
-  }
-
-  .pt-kpi-card {
-    background: var(--white);
-    border: 1px solid var(--stone);
-    border-radius: 6px;
-    padding: 20px;
-  }
-
-  .pt-kpi-label {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 10px;
-    text-transform: uppercase;
-    letter-spacing: 2px;
-    color: var(--charcoal);
-    margin-bottom: 8px;
-    display: block;
-  }
-
-  .pt-kpi-value {
-    font-family: var(--font-heading);
-    font-weight: 600;
-    font-size: 28px;
-    letter-spacing: 1px;
-    color: var(--black);
-  }
-
-  .pt-activity-feed {
-    background: var(--white);
-    border: 1px solid var(--stone);
-    border-radius: 6px;
-    margin-bottom: 20px;
+  .color-card {
+    border-radius: 8px;
     overflow: hidden;
+    background: var(--gray-900);
   }
-
-  .pt-activity-row {
+  .color-swatch {
+    height: 120px;
     display: flex;
-    align-items: center;
-    gap: 12px;
+    align-items: flex-end;
     padding: 12px 16px;
-    border-bottom: 1px solid var(--stone);
   }
-
-  .pt-activity-row:last-child {
-    border-bottom: none;
-  }
-
-  .pt-activity-time {
-    font-family: var(--font-body);
-    font-weight: 300;
+  .color-swatch span {
     font-size: 12px;
-    color: var(--charcoal);
-    flex-shrink: 0;
-    width: 72px;
-  }
-
-  .pt-activity-desc {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 14px;
-    color: var(--black);
-    flex: 1;
-  }
-
-  .pt-quick-actions {
-    display: flex;
-    gap: 12px;
-  }
-
-  /* 12c Content */
-  .pt-content-inner {
-    padding: 40px;
-    background: var(--white);
-    max-width: 780px;
-    margin: 0 auto;
-  }
-
-  .pt-content-title {
-    font-family: var(--font-heading);
     font-weight: 600;
-    font-size: 28px;
-    letter-spacing: 2px;
-    color: var(--black);
-    margin-bottom: 12px;
-    line-height: 1.3;
-  }
-
-  .pt-content-meta {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 13px;
-    color: var(--charcoal);
-    margin-bottom: 24px;
-    padding-bottom: 24px;
-    border-bottom: 1px solid var(--stone);
-  }
-
-  .pt-content-body {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 15px;
-    color: var(--charcoal);
-    line-height: 1.6;
-    margin-bottom: 20px;
-  }
-
-  .pt-content-blockquote {
-    border-left: 3px solid var(--black);
-    padding-left: 20px;
-    font-style: italic;
-    margin: 24px 0;
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 15px;
-    color: var(--charcoal);
-    line-height: 1.6;
-  }
-
-  .pt-related-heading {
-    font-family: var(--font-heading);
-    font-weight: 600;
-    font-size: 20px;
     letter-spacing: 1px;
-    color: var(--black);
-    margin-top: 40px;
-    margin-bottom: 20px;
   }
-
-  .pt-related-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 1fr);
-    gap: 16px;
+  .color-info {
+    padding: 16px;
   }
-
-  .pt-related-card {
-    background: var(--white);
-    border: 1px solid var(--stone);
-    border-radius: 6px;
-    padding: 20px;
-  }
-
-  .pt-related-card-title {
-    font-family: var(--font-heading);
-    font-weight: 600;
-    font-size: 14px;
-    letter-spacing: 0.5px;
-    color: var(--black);
-    margin-bottom: 8px;
-    line-height: 1.4;
-  }
-
-  .pt-related-card-date {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 12px;
-    color: var(--charcoal);
-    margin-top: 8px;
-  }
-
-  /* 12d CRUD */
-  .pt-crud-inner {
-    padding: 24px;
-    background: var(--white);
-  }
-
-  .pt-crud-topbar {
-    display: flex;
-    gap: 12px;
-    margin-bottom: 20px;
-    align-items: center;
-  }
-
-  .pt-crud-search {
-    flex: 1;
-    max-width: 300px;
-  }
-
-  .pt-table {
-    width: 100%;
-    border-collapse: collapse;
-    border: 1px solid var(--stone);
-    border-radius: 6px;
-    overflow: hidden;
-    margin-bottom: 16px;
-  }
-
-  .pt-table th {
-    background: var(--black);
-    color: var(--cream);
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 11px;
-    text-transform: uppercase;
+  .color-name {
+    font-size: 16px;
+    font-weight: 700;
     letter-spacing: 1px;
-    padding: 12px 16px;
-    text-align: left;
-  }
-
-  .pt-table td {
-    padding: 12px 16px;
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 14px;
-    color: var(--black);
-    border-bottom: 1px solid var(--stone);
-    background: var(--white);
-  }
-
-  .pt-table tr:last-child td {
-    border-bottom: none;
-  }
-
-  .pt-table-actions {
-    display: flex;
-    gap: 8px;
-    align-items: center;
-  }
-
-  .pt-icon-btn {
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--charcoal);
-    display: flex;
-    align-items: center;
-    padding: 2px;
-  }
-
-  .pt-pagination {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-  }
-
-  .pt-pagination-info {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 13px;
-    color: var(--charcoal);
-  }
-
-  .pt-pagination-btns {
-    display: flex;
-    gap: 8px;
-  }
-
-  .btn-sm {
-    padding: 6px 16px;
-    font-size: 11px;
-  }
-
-  /* 12e ERP */
-  .pt-erp-layout {
-    display: flex;
-    background: var(--cream);
-  }
-
-  .pt-erp-sidebar {
-    width: 56px;
-    background: var(--black);
-    padding: 12px 8px;
-    flex-shrink: 0;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: 20px;
-  }
-
-  .pt-erp-sidebar-icon {
-    color: var(--cream);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    cursor: default;
-  }
-
-  .pt-erp-sidebar-icon.active-icon {
-    color: var(--cyan);
-  }
-
-  .pt-erp-main {
-    flex: 1;
-    padding: 24px;
-    overflow: hidden;
-  }
-
-  .pt-chart-row {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 16px;
-    margin-bottom: 24px;
-  }
-
-  .pt-chart-placeholder {
-    border: 2px dashed var(--stone);
-    border-radius: 6px;
-    height: 160px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 13px;
-    color: var(--charcoal);
-  }
-
-  /* 12f Schedule */
-  .pt-schedule-inner {
-    padding: 24px;
-    background: var(--white);
-  }
-
-  .pt-toggle-bar {
-    display: flex;
-    gap: 0;
-    margin-bottom: 20px;
-  }
-
-  .pt-calendar-grid {
-    width: 100%;
-    border-collapse: collapse;
-    border: 1px solid var(--stone);
-    border-radius: 6px;
-    overflow: hidden;
-    margin-bottom: 0;
-    table-layout: fixed;
-  }
-
-  .pt-calendar-grid th {
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 11px;
-    text-transform: uppercase;
-    color: var(--charcoal);
-    padding: 8px;
-    border-bottom: 1px solid var(--stone);
-    text-align: center;
-    background: var(--cream);
-  }
-
-  .pt-calendar-grid td {
-    border: 1px solid var(--stone);
-    padding: 4px;
-    vertical-align: top;
-    height: 60px;
-  }
-
-  .pt-time-cell {
-    font-family: var(--font-body);
-    font-weight: 300;
-    font-size: 11px;
-    color: var(--charcoal);
-    padding: 8px 4px;
-    text-align: right;
-    white-space: nowrap;
-    background: var(--cream);
-    width: 56px;
-  }
-
-  .pt-event-card {
-    padding: 6px 8px;
-    border-radius: 4px;
-    font-family: var(--font-body);
-    font-weight: 400;
-    font-size: 11px;
-    color: var(--black);
-    line-height: 1.4;
-  }
-
-  .pt-modal-backdrop {
-    position: relative;
-    background: rgba(26,26,26,0.4);
-    border-radius: 6px;
-    padding: 40px;
-    margin-top: 24px;
-    display: flex;
-    justify-content: center;
-  }
-
-  .pt-modal-card {
-    background: var(--white);
-    border-radius: 6px;
-    padding: 32px;
-    max-width: 480px;
-    width: 100%;
-  }
-
-  .pt-modal-title {
-    font-family: var(--font-heading);
-    font-weight: 600;
-    font-size: 20px;
-    letter-spacing: 1px;
-    color: var(--black);
-    margin-bottom: 24px;
-  }
-
-  .pt-form-field {
-    margin-bottom: 16px;
-  }
-
-  .pt-form-label {
-    display: block;
-    font-family: var(--font-body);
-    font-weight: 500;
-    font-size: 12px;
-    color: var(--charcoal);
     margin-bottom: 4px;
   }
+  .color-hex {
+    font-size: 13px;
+    color: var(--gray-500);
+    font-family: monospace;
+    margin-bottom: 8px;
+  }
+  .color-usage {
+    font-size: 12px;
+    color: var(--gray-500);
+    line-height: 1.5;
+  }
 
-  .pt-modal-btns {
+  /* ==================== 4. TYPOGRAPHY ==================== */
+  .type-scale { margin-bottom: 40px; }
+  .type-row {
+    display: grid;
+    grid-template-columns: 160px 1fr;
+    align-items: baseline;
+    padding: 16px 0;
+    border-bottom: 1px solid var(--gray-800);
+  }
+  .type-meta {
+    font-size: 11px;
+    color: var(--gray-500);
+    font-family: monospace;
+    line-height: 1.8;
+  }
+
+  /* ==================== 5. SPACING ==================== */
+  .spacing-row {
     display: flex;
-    gap: 12px;
-    margin-top: 20px;
+    align-items: center;
+    gap: 20px;
+    margin-bottom: 16px;
+  }
+  .spacing-label {
+    width: 80px;
+    font-size: 13px;
+    color: var(--gray-500);
+    font-family: monospace;
+    text-align: right;
+  }
+  .spacing-bar {
+    height: 24px;
+    background: var(--plum);
+    border-radius: 4px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    padding-right: 8px;
+  }
+  .spacing-bar span {
+    font-size: 11px;
+    color: var(--gold);
+    font-family: monospace;
   }
 
-  /* ==================== RESPONSIVE ==================== */
-  @media (max-width: 768px) {
-    /* TOC nav: already has overflow-x:auto from base style; ensure no wrap */
-    .toc-nav { white-space: nowrap; }
-
-    /* Stack multi-column grids to single column */
-    .pillars-grid,
-    .sport-tints-row,
-    .donts-grid,
-    .logo-row,
-    .cards-grid,
-    .cards-grid-3,
-    .footer-grid,
-    .pt-sport-grid,
-    .pt-kpi-grid,
-    .pt-related-grid,
-    .pt-chart-row,
-    .sport-cards-grid,
-    [style*="grid-template-columns"] {
-      grid-template-columns: 1fr !important;
-    }
-
-    /* Button showcase grid: 2 cols on mobile */
-    .btn-grid { grid-template-columns: repeat(2, 1fr) !important; }
-
-    /* Form inputs grid: stack */
-    .form-grid { grid-template-columns: 1fr !important; }
-
-    /* Type scale rows: collapse to single col */
-    .type-scale-row {
-      grid-template-columns: 1fr !important;
-      gap: 8px;
-    }
-
-    /* Reduce hero text sizes */
-    .sample-hero h2 { font-size: 32px !important; }
-    .pt-hero-headline { font-size: 24px !important; }
-
-    /* Container padding */
-    .container { padding: 0 16px; }
-
-    /* Section padding */
-    .section { padding: 40px 0; }
-
-    /* Palette row: 2 cols */
-    .palette-row { flex-wrap: wrap; }
-    .swatch-card { min-width: 140px; }
-
-    /* ERP layout: stack sidebar */
-    .pt-erp-layout { flex-direction: column; }
-    .pt-erp-sidebar { width: 100%; flex-direction: row; height: auto; padding: 8px 16px; }
+  /* ==================== 6. BUTTONS ==================== */
+  .btn-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    align-items: center;
+    margin-bottom: 32px;
+  }
+  .btn {
+    font-family: var(--font);
+    font-weight: 700;
+    font-size: 14px;
+    letter-spacing: 3px;
+    text-transform: uppercase;
+    padding: 14px 32px;
+    border: 2px solid transparent;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: all 0.2s;
+  }
+  .btn-primary {
+    background: var(--plum);
+    color: var(--gold);
+    border-color: var(--plum);
+  }
+  .btn-primary:hover { background: var(--plum-light); }
+  .btn-secondary {
+    background: transparent;
+    color: var(--gold);
+    border-color: var(--gold);
+  }
+  .btn-secondary:hover { background: rgba(240,223,160,0.1); }
+  .btn-ghost {
+    background: transparent;
+    color: var(--gray-300);
+    border-color: var(--gray-700);
+  }
+  .btn-ghost:hover { border-color: var(--gray-500); color: var(--white); }
+  .btn-accent {
+    background: var(--gold);
+    color: var(--black);
+    border-color: var(--gold);
+  }
+  .btn-peri {
+    background: var(--peri);
+    color: var(--black);
+    border-color: var(--peri);
   }
 
-  /* Logo images */
-  .logo-img { object-fit: contain; }
-  .logo-img-logotype { height: auto; }
-  .logo-img-icon { height: auto; }
-  .logo-img--on-cream { /* transparent bg, no blend needed */ }
-  .logo-img--on-dark { filter: brightness(0) invert(1); }
-  .logo-img--monochrome { filter: grayscale(1); }
-  .logo-img--cyan { /* default icon is already cyan */ }
-  .logo-img--recolor-red { filter: hue-rotate(140deg) saturate(2); }
-  .logo-img--rotated { transform: rotate(25deg); }
-  .logo-img--stretched { transform: scaleX(1.5); }
-  .logo-img--gradient { opacity: 0.7; }
+  .btn-label {
+    font-size: 11px;
+    color: var(--gray-500);
+    font-family: monospace;
+    text-align: center;
+    margin-top: 8px;
+  }
+  .btn-col { display: flex; flex-direction: column; align-items: center; }
+
+  /* ==================== 7. TAGS & BADGES ==================== */
+  .tag-grid { display: flex; flex-wrap: wrap; gap: 12px; margin-bottom: 24px; }
+  .tag {
+    display: inline-block;
+    padding: 8px 16px;
+    border-radius: 4px;
+    font-size: 13px;
+    font-weight: 700;
+    letter-spacing: 2px;
+    text-transform: uppercase;
+  }
+  .tag.compact { padding: 4px 10px; font-size: 11px; }
+  .tag-row-label {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 2px;
+    color: var(--gray-500);
+    margin-bottom: 12px;
+    text-transform: uppercase;
+  }
+
+  /* ==================== 8. FORM INPUTS ==================== */
+  .form-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; margin-bottom: 32px; }
+  .form-cell label {
+    display: block;
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 2px;
+    color: var(--gray-500);
+    margin-bottom: 8px;
+    text-transform: uppercase;
+  }
+  .form-cell input[type="text"],
+  .form-cell input[type="date"],
+  .form-cell textarea,
+  .form-cell select {
+    width: 100%;
+    padding: 10px 14px;
+    background: var(--gray-900);
+    border: 1px solid var(--gray-700);
+    border-radius: 4px;
+    color: var(--white);
+    font-family: var(--font);
+    font-size: 14px;
+    outline: none;
+  }
+  .form-cell input.focus-demo { border-color: var(--gold); box-shadow: 0 0 0 2px rgba(240,223,160,0.15); }
+  .form-cell input.error-demo, .form-cell textarea.error-demo, .form-cell select.error-demo { border-color: #E53E3E; }
+  .form-cell .error-msg { font-size: 11px; color: #E53E3E; margin-top: 4px; letter-spacing: 0.5px; }
+  .form-cell input:disabled, .form-cell textarea:disabled, .form-cell select:disabled { opacity: 0.5; cursor: not-allowed; }
+  .form-row-label {
+    font-size: 12px;
+    font-weight: 600;
+    letter-spacing: 2px;
+    color: var(--gray-300);
+    margin-bottom: 12px;
+    text-transform: uppercase;
+  }
+  .toggle-track {
+    width: 44px; height: 24px;
+    background: var(--gray-700);
+    border-radius: 12px;
+    position: relative;
+    display: inline-block;
+    cursor: pointer;
+  }
+  .toggle-track.on { background: var(--plum); }
+  .toggle-thumb {
+    width: 20px; height: 20px;
+    background: var(--white);
+    border-radius: 50%;
+    position: absolute;
+    top: 2px; left: 2px;
+    transition: left 0.2s;
+  }
+  .toggle-track.on .toggle-thumb { left: 22px; background: var(--gold); }
+  .checkbox-custom {
+    width: 18px; height: 18px;
+    border: 2px solid var(--gray-700);
+    border-radius: 3px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .checkbox-custom.checked { background: var(--plum); border-color: var(--plum); }
+  .radio-custom {
+    width: 18px; height: 18px;
+    border: 2px solid var(--gray-700);
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .radio-custom.checked { border-color: var(--gold); }
+  .radio-custom.checked::after { content: ''; width: 8px; height: 8px; background: var(--gold); border-radius: 50%; }
+  .search-wrap { position: relative; }
+  .search-wrap svg { position: absolute; left: 12px; top: 50%; transform: translateY(-50%); }
+  .search-wrap input { padding-left: 36px; }
+
+  /* ==================== 9. CARDS ==================== */
+  .card-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+    margin-bottom: 32px;
+  }
+  .demo-card {
+    background: var(--gray-900);
+    border: 1px solid var(--gray-800);
+    border-radius: 8px;
+    overflow: hidden;
+    transition: border-color 0.2s;
+  }
+  .demo-card:hover { border-color: var(--plum-light); }
+  .demo-card-img {
+    height: 140px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .demo-card-img span {
+    font-size: 12px;
+    letter-spacing: 3px;
+    font-weight: 700;
+  }
+  .demo-card-body { padding: 20px; }
+  .demo-card-body h4 {
+    font-size: 18px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    margin-bottom: 8px;
+  }
+  .demo-card-body p {
+    font-size: 14px;
+    color: var(--gray-500);
+    line-height: 1.5;
+  }
+
+  /* ==================== 13. SAMPLE LAYOUT ==================== */
+  .sample-frame {
+    background: var(--black);
+    border: 1px solid var(--gray-800);
+    border-radius: 12px;
+    overflow: hidden;
+  }
+  .sample-nav {
+    display: flex;
+    align-items: center;
+    padding: 16px 24px;
+    background: var(--gray-900);
+    border-bottom: 1px solid var(--gray-800);
+    gap: 32px;
+  }
+  .sample-nav img { height: 36px; filter: invert(1); }
+  .sample-nav-links { display: flex; gap: 24px; margin-left: auto; }
+  .sample-nav-links span {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 2px;
+    color: var(--gray-500);
+    cursor: pointer;
+  }
+  .sample-nav-links span:first-child { color: var(--gold); }
+
+  .sample-hero-section {
+    background: linear-gradient(135deg, var(--plum) 0%, #2A0E28 100%);
+    padding: 64px 40px;
+    text-align: center;
+  }
+  .sample-hero-section h2 {
+    font-size: 48px;
+    font-weight: 700;
+    letter-spacing: 6px;
+    color: var(--gold);
+    margin-bottom: 12px;
+  }
+  .sample-hero-section p {
+    font-size: 16px;
+    color: rgba(255,255,255,0.6);
+    letter-spacing: 1px;
+    margin-bottom: 28px;
+  }
+
+  .sample-content {
+    padding: 40px;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+  }
+  .sample-content-card {
+    background: var(--gray-900);
+    border: 1px solid var(--gray-800);
+    border-radius: 8px;
+    padding: 24px;
+  }
+  .sample-content-card h4 {
+    font-size: 16px;
+    font-weight: 700;
+    letter-spacing: 1px;
+    margin-bottom: 8px;
+    color: var(--gold);
+  }
+  .sample-content-card p {
+    font-size: 14px;
+    color: var(--gray-500);
+    line-height: 1.5;
+  }
+  .sample-footer {
+    padding: 20px 40px;
+    border-top: 1px solid var(--gray-800);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .sample-footer span {
+    font-size: 12px;
+    color: var(--gray-500);
+    letter-spacing: 2px;
+  }
+
+  .toc-link {
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 2px;
+    color: var(--gray-500);
+    text-decoration: none;
+    white-space: nowrap;
+    transition: color 0.2s;
+  }
+  .toc-link:hover { color: var(--gray-300); }
+  .toc-link.active { color: var(--gold); }
+
+  /* ==================== UTILITIES ==================== */
+  .token {
+    display: inline-block;
+    background: var(--gray-900);
+    border: 1px solid var(--gray-800);
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    font-family: monospace;
+    color: var(--peri);
+  }
+
+.pillar-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 24px; margin-top: 24px; }
+.pillar-card {
+  background: var(--gray-900);
+  border: 1px solid var(--gray-800);
+  border-radius: 8px;
+  padding: 32px 24px;
+  border-top: 3px solid var(--plum);
+}
+.pillar-card:nth-child(2) { border-top-color: var(--gold); }
+.pillar-card:nth-child(3) { border-top-color: var(--peri); }
+.pillar-card h3 {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: 3px;
+  text-transform: uppercase;
+  margin-bottom: 12px;
+}
+.pillar-card:nth-child(1) h3 { color: var(--plum-light); }
+.pillar-card:nth-child(2) h3 { color: var(--gold); }
+.pillar-card:nth-child(3) h3 { color: var(--peri); }
+.pillar-card p { font-size: 15px; color: var(--gray-300); line-height: 1.7; }
+
+  /* ==================== 10. NAVIGATION ==================== */
+  .nav-mockup { background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;overflow:hidden;margin-bottom:24px; }
+  .nav-mockup-bar {
+    height:64px;display:flex;align-items:center;padding:0 24px;border-bottom:1px solid var(--gray-800);
+  }
+  .nav-mockup-links { display:flex;gap:24px;margin:0 auto; }
+  .nav-mockup-links a {
+    font-size:13px;font-weight:600;letter-spacing:2px;color:var(--gray-500);text-decoration:none;
+    padding-bottom:4px;
+  }
+  .nav-mockup-links a.active { color:var(--gold);border-bottom:2px solid var(--gold); }
+  .mobile-mockup { max-width:375px; }
+  .mobile-mockup-bar { height:56px;display:flex;align-items:center;justify-content:space-between;padding:0 16px;border-bottom:1px solid var(--gray-800); }
+  .mobile-overlay {
+    background:rgba(17,17,17,0.95);padding:48px 24px;display:flex;flex-direction:column;align-items:center;gap:24px;
+  }
+  .mobile-overlay a {
+    font-size:18px;font-weight:600;letter-spacing:3px;color:var(--gray-300);text-decoration:none;text-transform:uppercase;
+  }
+  .mobile-overlay a.active { color:var(--gold); }
+
+  /* ==================== 11. FOOTER ==================== */
+  .footer-mockup {
+    background:var(--black-deep);border:1px solid var(--gray-800);border-radius:8px;overflow:hidden;
+  }
+  .footer-inner { padding:48px 32px;display:grid;grid-template-columns:1.5fr 1fr 1fr 1fr;gap:32px; }
+  .footer-col h4 {
+    font-size:13px;font-weight:700;letter-spacing:2px;text-transform:uppercase;color:var(--gray-300);margin-bottom:16px;
+  }
+  .footer-col a {
+    display:block;font-size:14px;color:var(--gray-500);text-decoration:none;margin-bottom:8px;
+  }
+  .footer-col a:hover { color:var(--gray-300); }
+  .footer-col p { font-size:14px;color:var(--gray-500);line-height:1.6; }
+  .footer-bar {
+    border-top:1px solid var(--gray-800);padding:16px 32px;display:flex;justify-content:space-between;align-items:center;
+  }
+  .footer-bar span { font-size:12px;color:var(--gray-500);letter-spacing:1px; }
+  .footer-social { display:flex;gap:16px; }
+  .footer-social a { color:var(--gray-500);text-decoration:none;font-size:13px;letter-spacing:1px; }
+  .footer-social a:hover { color:var(--gold); }
+  .page-tabs { display:flex;gap:8px;margin:24px 0 16px;flex-wrap:wrap; }
+  .page-tab {
+    padding:8px 16px;font-size:12px;font-weight:600;letter-spacing:2px;
+    background:var(--gray-900);border:1px solid var(--gray-800);border-radius:4px;
+    color:var(--gray-500);cursor:pointer;text-transform:uppercase;transition:all 0.2s;
+  }
+  .page-tab.active { background:var(--plum);border-color:var(--plum);color:var(--gold); }
+  .page-tab:hover:not(.active) { border-color:var(--gray-700);color:var(--gray-300); }
+  .page-panel { display:none; }
+  .page-panel.active { display:block; }
+  .page-frame {
+    background:var(--black-deep);border:1px solid var(--gray-800);border-radius:8px;
+    overflow:hidden;margin-top:16px;
+  }
+  .page-frame-label {
+    font-size:11px;font-weight:600;letter-spacing:2px;color:var(--gray-500);
+    padding:12px 24px;border-bottom:1px solid var(--gray-800);text-transform:uppercase;
+  }
+  .page-frame-body { padding:0; }
+  .mock-hero { padding:48px 32px;text-align:center; }
+  .mock-grid { display:grid;gap:16px;padding:24px 32px; }
+  .mock-stat { background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;padding:20px;text-align:center; }
+  .mock-stat .stat-value { font-size:28px;font-weight:700;color:var(--gold); }
+  .mock-stat .stat-label { font-size:11px;font-weight:600;letter-spacing:2px;color:var(--gray-500);margin-top:4px;text-transform:uppercase; }
+  .mock-table { width:100%;border-collapse:collapse; }
+  .mock-table th {
+    text-align:left;padding:10px 16px;font-size:11px;font-weight:600;letter-spacing:2px;
+    color:var(--gray-500);border-bottom:1px solid var(--gray-800);text-transform:uppercase;
+  }
+  .mock-table td { padding:12px 16px;font-size:14px;color:var(--gray-300);border-bottom:1px solid var(--gray-800); }
+  .mock-table tr:hover td { background:rgba(74,25,66,0.1); }
+.sched-grid { display:grid;grid-template-columns:60px repeat(5,1fr);border:1px solid var(--gray-800);border-radius:8px;overflow:hidden; }
+.sched-header { background:var(--gray-900);padding:10px 8px;font-size:11px;font-weight:600;letter-spacing:1px;color:var(--gray-500);text-align:center;border-bottom:1px solid var(--gray-800);text-transform:uppercase; }
+.sched-time { padding:8px;font-size:11px;color:var(--gray-500);text-align:right;border-right:1px solid var(--gray-800);border-bottom:1px solid var(--gray-800); }
+.sched-cell { border-right:1px solid var(--gray-800);border-bottom:1px solid var(--gray-800);padding:4px;min-height:48px;position:relative; }
+.sched-event { border-radius:4px;padding:4px 8px;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;margin-bottom:2px; }
+.sched-toggle { display:flex;gap:4px;margin-bottom:16px; }
+.sched-toggle button {
+  padding:6px 16px;font-size:12px;font-weight:600;letter-spacing:2px;text-transform:uppercase;
+  background:var(--gray-900);border:1px solid var(--gray-800);border-radius:4px;
+  color:var(--gray-500);font-family:var(--font);cursor:pointer;
+}
+.sched-toggle button.active { background:var(--plum);border-color:var(--plum);color:var(--gold); }
 </style>
 </head>
 <body>
 
-
 <!-- ==================== HERO ==================== -->
 <div class="hero">
-  <div class="container">
-    <img data-logo="logotype" alt="Kosmas Athletic Ventures" class="logo-img logo-img-logotype logo-img--on-cream" style="height: 260px;">
-    <p class="hero-tagline">Premium athletic ventures management across Southeast Asia</p>
-  </div>
+  <img class="logo" id="main-logo" alt="Kosmas Athletic Ventures Co.">
+  <div class="brand-statement">Premium sports experiences across Southeast Asia. Bold, defined, confident.</div>
 </div>
 
-<!-- ==================== STICKY TOC NAV ==================== -->
-<nav class="toc-nav" id="toc-nav">
-  <div class="container">
-    <a href="#section-01" class="toc-link">PHILOSOPHY</a>
-    <a href="#section-02" class="toc-link">LOGO</a>
-    <a href="#section-03" class="toc-link">COLORS</a>
-    <a href="#section-04" class="toc-link">TYPE</a>
-    <a href="#section-05" class="toc-link">SPACING</a>
-    <a href="#section-06" class="toc-link">BUTTONS</a>
-    <a href="#section-07" class="toc-link">TAGS</a>
-    <a href="#section-08" class="toc-link">FORMS</a>
-    <a href="#section-09" class="toc-link">CARDS</a>
-    <a href="#section-10" class="toc-link">NAV</a>
-    <a href="#section-11" class="toc-link">FOOTER</a>
-    <a href="#section-12" class="toc-link">PAGES</a>
-    <a href="#section-13" class="toc-link">SAMPLE</a>
+<nav id="toc-nav" style="background:var(--gray-900);border-bottom:1px solid var(--gray-800);padding:12px 0;position:sticky;top:0;z-index:100;">
+  <div style="max-width:1080px;margin:0 auto;padding:0 32px;display:flex;gap:20px;overflow-x:auto;">
+    <a href="#philosophy" class="toc-link">PHILOSOPHY</a>
+    <a href="#logo" class="toc-link">LOGO</a>
+    <a href="#colors" class="toc-link">COLORS</a>
+    <a href="#typography" class="toc-link">TYPE</a>
+    <a href="#spacing" class="toc-link">SPACING</a>
+    <a href="#buttons" class="toc-link">BUTTONS</a>
+    <a href="#tags" class="toc-link">TAGS</a>
+    <a href="#forms" class="toc-link">FORMS</a>
+    <a href="#cards" class="toc-link">CARDS</a>
+    <a href="#nav" class="toc-link">NAV</a>
+    <a href="#footer" class="toc-link">FOOTER</a>
+    <a href="#pages" class="toc-link">PAGES</a>
+    <a href="#sample" class="toc-link">SAMPLE</a>
   </div>
 </nav>
 
-<!-- ==================== SECTION 01: DESIGN PHILOSOPHY ==================== -->
-<section class="section" id="section-01">
-  <div class="container">
-    <p class="section-number">01</p>
-    <h2 class="section-title">DESIGN PHILOSOPHY</h2>
+<div class="container">
 
-    <div class="pillars-grid">
+<!-- ==================== 1. DESIGN PHILOSOPHY ==================== -->
+<div class="section" id="philosophy">
+  <div class="section-number">01</div>
+  <div class="section-title">Design Philosophy</div>
+  <div class="section-desc">Three pillars define every Kosmas interface. Together they create a visual language that is athletic, premium, and distinctly Southeast Asian.</div>
 
-      <div class="pillar-card">
-        <div class="pillar-motif pillar-motif--precision"></div>
-        <h3 class="pillar-name">ATHLETIC PRECISION</h3>
-        <p class="pillar-desc">Clean lines, geometric structure, the star's sharp angles. Sports demand exactness — our design reflects that discipline in every pixel.</p>
-      </div>
-
-      <div class="pillar-card">
-        <div class="pillar-motif pillar-motif--premium"></div>
-        <h3 class="pillar-name">PREMIUM CONFIDENCE</h3>
-        <p class="pillar-desc">Warm editorial palette, generous whitespace, restrained color. This is not budget athletics — it's a premium experience from first glance.</p>
-      </div>
-
-      <div class="pillar-card">
-        <div class="pillar-motif pillar-motif--energy"></div>
-        <h3 class="pillar-name">SOUTHEAST ASIAN ENERGY</h3>
-        <p class="pillar-desc">Warm cream undertones, bold black contrasts, movement implied through typography and spacing. Reflecting the energy and culture of our market.</p>
-      </div>
-
+  <div class="pillar-grid">
+    <div class="pillar-card">
+      <h3>Athletic Precision</h3>
+      <p>Sharp geometry, tight letter-spacing, structured grids. Every pixel earns its place. The sports world demands exactness — our interfaces deliver it.</p>
+    </div>
+    <div class="pillar-card">
+      <h3>Premium Confidence</h3>
+      <p>Plum and gold palette, bold weight typography, generous whitespace. This is not budget athletics. Every element communicates quality without saying it.</p>
+    </div>
+    <div class="pillar-card">
+      <h3>Southeast Asian Energy</h3>
+      <p>Warm undertones, dynamic contrast, movement in layout. Our market is vibrant — Manila, Cebu, Davao. The design reflects that energy.</p>
     </div>
   </div>
-</section>
+</div>
 
-<!-- ==================== SECTION 02: LOGO SYSTEM ==================== -->
-<section class="section" id="section-02">
-  <div class="container">
-    <p class="section-number">02</p>
-    <h2 class="section-title">LOGO SYSTEM</h2>
+<!-- ==================== 2. LOGO SYSTEM ==================== -->
+<div class="section" id="logo">
+  <div class="section-number">02</div>
+  <div class="section-title">Logo System</div>
+  <div class="section-desc">Two marks: the full logotype and the icon mark. Use the full logotype for hero sections and brand-forward contexts. Use the icon mark for nav, favicons, and compact spaces.</div>
 
-    <!-- Full logotype row -->
-    <p class="subsection-label">Full Logotype</p>
-    <div class="logo-row">
-
-      <div class="logo-card">
-        <div class="logo-card-display logo-card-display--cream">
-          <img data-logo="logotype" alt="Kosmas logotype" class="logo-img logo-img-logotype logo-img--on-cream" style="height: 210px;">
-        </div>
-        <div class="logo-card-label">Default — on cream</div>
+  <div class="logo-subsection">
+    <div class="logo-subsection-title">Full Logotype</div>
+    <div class="logo-grid">
+      <div class="logo-variant">
+        <img class="logo-sys-full" alt="Kosmas logotype on dark" style="filter:invert(1);">
       </div>
-
-      <div class="logo-card">
-        <div class="logo-card-display logo-card-display--dark">
-          <img data-logo="logotype" alt="Kosmas logotype on dark" class="logo-img logo-img-logotype logo-img--on-dark" style="height: 210px;">
-        </div>
-        <div class="logo-card-label">
-          On dark
-          <span class="caption">Production: use transparent PNG</span>
-        </div>
+      <div class="logo-variant light-bg">
+        <img class="logo-sys-full" alt="Kosmas logotype on light" style="max-height:60px;">
       </div>
-
-      <div class="logo-card">
-        <div class="logo-card-display logo-card-display--cream">
-          <img data-logo="logotype" alt="Kosmas logotype monochrome" class="logo-img logo-img-logotype logo-img--monochrome" style="height: 210px;">
-        </div>
-        <div class="logo-card-label">Monochrome</div>
-      </div>
-
-    </div>
-
-    <!-- Icon mark row -->
-    <p class="subsection-label">Icon Mark</p>
-    <div class="logo-row">
-
-      <div class="logo-card">
-        <div class="logo-card-display logo-card-display--cream">
-          <img data-logo="icon" alt="Kosmas star icon" class="logo-img logo-img-icon logo-img--on-cream" style="height: 64px;">
-        </div>
-        <div class="logo-card-label">Default — on cream</div>
-      </div>
-
-      <div class="logo-card">
-        <div class="logo-card-display logo-card-display--dark">
-          <img data-logo="icon" alt="Kosmas star icon on dark" class="logo-img logo-img-icon logo-img--on-dark" style="height: 64px;">
-        </div>
-        <div class="logo-card-label">On dark</div>
-      </div>
-
-      <div class="logo-card">
-        <div class="logo-card-display logo-card-display--cream">
-          <img data-logo="icon" alt="Kosmas star icon monochrome" class="logo-img logo-img-icon logo-img--monochrome" style="height: 64px;">
-        </div>
-        <div class="logo-card-label">Monochrome</div>
-      </div>
-
-    </div>
-
-    <!-- Safe zone diagram -->
-    <div class="safe-zone-section">
-      <p class="subsection-label">Clear Space</p>
-      <div class="safe-zone-demo">
-        <div class="safe-zone-box" style="padding: 64px;">
-          <img data-logo="icon" alt="Kosmas star" class="logo-img logo-img-icon logo-img--on-cream" style="height: 64px;">
-        </div>
-        <span class="safe-zone-caption">Minimum clear space = 1× mark width on all sides</span>
+      <div class="logo-variant">
+        <img class="logo-sys-full" alt="Kosmas logotype monochrome" style="filter:invert(1) grayscale(1);">
       </div>
     </div>
-
-    <!-- Minimum sizes -->
-    <div class="min-sizes-section">
-      <p class="subsection-label">Minimum Sizes</p>
-      <div class="min-sizes-row">
-        <div class="min-size-item">
-          <img data-logo="logotype" alt="Kosmas logotype min size" class="logo-img logo-img-logotype logo-img--on-cream" style="height: 156px;">
-          <span class="min-size-label">Min: 120px</span>
-        </div>
-        <div class="min-size-item">
-          <img data-logo="icon" alt="Kosmas star min size" class="logo-img logo-img-icon logo-img--on-cream" style="height: 32px;">
-          <span class="min-size-label">Min: 32px</span>
-        </div>
-      </div>
+    <div style="display:flex;gap:16px;margin-top:8px;">
+      <span style="flex:1;text-align:center;font-size:12px;color:var(--gray-500);letter-spacing:1px;">LIGHT ON DARK</span>
+      <span style="flex:1;text-align:center;font-size:12px;color:var(--gray-500);letter-spacing:1px;">DARK ON LIGHT</span>
+      <span style="flex:1;text-align:center;font-size:12px;color:var(--gray-500);letter-spacing:1px;">MONOCHROME</span>
     </div>
-
-    <!-- Don't do this -->
-    <div>
-      <p class="subsection-label">Don'ts</p>
-      <div class="donts-grid">
-
-        <div class="dont-card">
-          <div class="dont-display">
-            <img data-logo="logotype" alt="Don't rotate" class="logo-img logo-img-logotype logo-img--on-cream" style="height: 104px; transform: rotate(25deg);">
-            <svg class="dont-x" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <circle cx="12" cy="12" r="10" stroke="var(--error)" stroke-width="2"/>
-              <line x1="8" y1="8" x2="16" y2="16" stroke="var(--error)" stroke-width="2" stroke-linecap="round"/>
-              <line x1="16" y1="8" x2="8" y2="16" stroke="var(--error)" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-          </div>
-          <div class="dont-caption">Don't rotate</div>
-        </div>
-
-        <div class="dont-card">
-          <div class="dont-display">
-            <div class="dont-logo-gradient-wrap">
-              <img data-logo="logotype" alt="Don't add gradients" class="logo-img logo-img-logotype logo-img--gradient" style="height: 104px;">
-            </div>
-            <svg class="dont-x" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <circle cx="12" cy="12" r="10" stroke="var(--error)" stroke-width="2"/>
-              <line x1="8" y1="8" x2="16" y2="16" stroke="var(--error)" stroke-width="2" stroke-linecap="round"/>
-              <line x1="16" y1="8" x2="8" y2="16" stroke="var(--error)" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-          </div>
-          <div class="dont-caption">Don't add gradients</div>
-        </div>
-
-        <div class="dont-card">
-          <div class="dont-display">
-            <img data-logo="logotype" alt="Don't stretch" class="logo-img logo-img-logotype logo-img--on-cream" style="height: 104px; transform: scaleX(1.5);">
-            <svg class="dont-x" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <circle cx="12" cy="12" r="10" stroke="var(--error)" stroke-width="2"/>
-              <line x1="8" y1="8" x2="16" y2="16" stroke="var(--error)" stroke-width="2" stroke-linecap="round"/>
-              <line x1="16" y1="8" x2="8" y2="16" stroke="var(--error)" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-          </div>
-          <div class="dont-caption">Don't stretch</div>
-        </div>
-
-        <div class="dont-card">
-          <div class="dont-display">
-            <img data-logo="logotype" alt="Don't recolor" class="logo-img logo-img-logotype logo-img--recolor-red" style="height: 104px;">
-            <svg class="dont-x" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <circle cx="12" cy="12" r="10" stroke="var(--error)" stroke-width="2"/>
-              <line x1="8" y1="8" x2="16" y2="16" stroke="var(--error)" stroke-width="2" stroke-linecap="round"/>
-              <line x1="16" y1="8" x2="8" y2="16" stroke="var(--error)" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-          </div>
-          <div class="dont-caption">Don't recolor</div>
-        </div>
-
-      </div>
-    </div>
-
   </div>
-</section>
 
-<!-- ==================== SECTION 03: COLOR PALETTE ==================== -->
-<section class="section" id="section-03">
-  <div class="container">
-    <p class="section-number">03</p>
-    <h2 class="section-title">COLOR PALETTE</h2>
-
-    <!-- Main palette swatches -->
-    <p class="subsection-label">Core Palette</p>
-    <div class="palette-row">
-      <div class="swatch-card">
-        <div class="swatch-block" style="background:#1A1A1A;"></div>
-        <span class="swatch-name">Black</span>
-        <span class="swatch-hex">#1A1A1A</span>
-        <span class="swatch-rgb">RGB 26, 26, 26</span>
+  <div class="logo-subsection">
+    <div class="logo-subsection-title">Icon Mark</div>
+    <div class="logo-grid">
+      <div class="logo-variant">
+        <img class="logo-sys-icon" alt="Icon mark on dark" style="height:48px;filter:invert(1);">
       </div>
-      <div class="swatch-card">
-        <div class="swatch-block" style="background:#F5F0E8; border:1px solid #D4CFC4;"></div>
-        <span class="swatch-name">Cream</span>
-        <span class="swatch-hex">#F5F0E8</span>
-        <span class="swatch-rgb">RGB 245, 240, 232</span>
+      <div class="logo-variant light-bg">
+        <img class="logo-sys-icon" alt="Icon mark on light" style="height:48px;">
       </div>
-      <div class="swatch-card">
-        <div class="swatch-block" style="background:#0CB4CE;"></div>
-        <span class="swatch-name">Cyan</span>
-        <span class="swatch-hex">#0CB4CE</span>
-        <span class="swatch-rgb">RGB 12, 180, 206</span>
-      </div>
-      <div class="swatch-card">
-        <div class="swatch-block" style="background:#D4CFC4;"></div>
-        <span class="swatch-name">Stone</span>
-        <span class="swatch-hex">#D4CFC4</span>
-        <span class="swatch-rgb">RGB 212, 207, 196</span>
-      </div>
-      <div class="swatch-card">
-        <div class="swatch-block" style="background:#3D3D3D;"></div>
-        <span class="swatch-name">Charcoal</span>
-        <span class="swatch-hex">#3D3D3D</span>
-        <span class="swatch-rgb">RGB 61, 61, 61</span>
-      </div>
-      <div class="swatch-card">
-        <div class="swatch-block" style="background:#FFFFFF; border:1px solid #D4CFC4;"></div>
-        <span class="swatch-name">White</span>
-        <span class="swatch-hex">#FFFFFF</span>
-        <span class="swatch-rgb">RGB 255, 255, 255</span>
-      </div>
-      <div class="swatch-card">
-        <div class="swatch-block" style="background:#B33A3A;"></div>
-        <span class="swatch-name">Error</span>
-        <span class="swatch-hex">#B33A3A</span>
-        <span class="swatch-rgb">RGB 179, 58, 58</span>
+      <div class="logo-variant">
+        <img class="logo-sys-icon" alt="Icon mark mono" style="height:48px;filter:invert(1) grayscale(1);">
       </div>
     </div>
-
-    <!-- Usage ratio bar -->
-    <div class="usage-bar-wrap">
-      <p class="usage-bar-label">Typical Usage Ratio</p>
-      <div class="usage-bar">
-        <div class="usage-bar-segment" style="width:65%; background:#F5F0E8; color:#3D3D3D;">65% Cream</div>
-        <div class="usage-bar-segment" style="width:30%; background:#1A1A1A; color:#F5F0E8;">30% Dark</div>
-        <div class="usage-bar-segment" style="width:5%; background:#0CB4CE; color:#1A1A1A;">5%</div>
-      </div>
-      <div class="usage-bar-legend">
-        <div class="usage-bar-legend-item">
-          <div class="usage-bar-legend-dot" style="background:#F5F0E8; border-color:#D4CFC4;"></div>
-          <span>65% — Cream (backgrounds, surfaces)</span>
-        </div>
-        <div class="usage-bar-legend-item">
-          <div class="usage-bar-legend-dot" style="background:#1A1A1A;"></div>
-          <span>30% — Black / Charcoal (text, UI structure)</span>
-        </div>
-        <div class="usage-bar-legend-item">
-          <div class="usage-bar-legend-dot" style="background:#0CB4CE;"></div>
-          <span>5% — Cyan (accent only)</span>
-        </div>
-      </div>
+    <div style="display:flex;gap:16px;margin-top:8px;">
+      <span style="flex:1;text-align:center;font-size:12px;color:var(--gray-500);letter-spacing:1px;">LIGHT ON DARK</span>
+      <span style="flex:1;text-align:center;font-size:12px;color:var(--gray-500);letter-spacing:1px;">DARK ON LIGHT</span>
+      <span style="flex:1;text-align:center;font-size:12px;color:var(--gray-500);letter-spacing:1px;">MONOCHROME</span>
     </div>
+  </div>
 
-    <!-- Cyan usage rules -->
-    <div class="cyan-callout">
-      <p class="cyan-callout-rule"><strong>Cyan is an accent only.</strong> Never use for backgrounds, large surfaces, or primary buttons.</p>
-      <p class="cyan-callout-rule"><strong>Use for:</strong> logo mark, text links, focus rings, hover highlights, metric callouts.</p>
-    </div>
-
-    <!-- Sport tints -->
-    <p class="subsection-label">Sport Tints</p>
-    <div class="sport-tints-row">
-      <div class="sport-tint-card">
-        <div class="sport-tint-swatch" style="background:#FDF8F0; border-bottom:2px solid #E8DFD0;"></div>
-        <div class="sport-tint-info">
-          <p class="sport-tint-name">Pickleball</p>
-          <span class="sport-tint-hex">BG: #FDF8F0</span>
-          <span class="sport-tint-hex">Border: #E8DFD0</span>
+  <div class="logo-subsection">
+    <div class="logo-subsection-title">Safe Zone &amp; Minimum Size</div>
+    <div style="display:flex;gap:48px;align-items:center;">
+      <div>
+        <div class="safe-zone">
+          <img class="logo-sys-safe" alt="Safe zone" style="height:50px;filter:invert(1);">
         </div>
+        <p style="font-size:12px;color:var(--gray-500);margin-top:8px;letter-spacing:1px;">1× PADDING ON ALL SIDES</p>
       </div>
-      <div class="sport-tint-card">
-        <div class="sport-tint-swatch" style="background:#F5F8F4; border-bottom:2px solid #D8E0D5;"></div>
-        <div class="sport-tint-info">
-          <p class="sport-tint-name">Volleyball</p>
-          <span class="sport-tint-hex">BG: #F5F8F4</span>
-          <span class="sport-tint-hex">Border: #D8E0D5</span>
-        </div>
-      </div>
-      <div class="sport-tint-card">
-        <div class="sport-tint-swatch" style="background:#F6F4F8; border-bottom:2px solid #DDD8E2;"></div>
-        <div class="sport-tint-info">
-          <p class="sport-tint-name">Football</p>
-          <span class="sport-tint-hex">BG: #F6F4F8</span>
-          <span class="sport-tint-hex">Border: #DDD8E2</span>
-        </div>
-      </div>
-      <div class="sport-tint-card">
-        <div class="sport-tint-swatch" style="background:#F2F5F8; border-bottom:2px solid #D5DCE3;"></div>
-        <div class="sport-tint-info">
-          <p class="sport-tint-name">Golf</p>
-          <span class="sport-tint-hex">BG: #F2F5F8</span>
-          <span class="sport-tint-hex">Border: #D5DCE3</span>
-        </div>
+      <div>
+        <p style="font-size:14px;color:var(--gray-300);line-height:1.8;">
+          Full logotype: min <strong style="color:var(--gold);">120px</strong> wide<br>
+          Icon mark: min <strong style="color:var(--gold);">32px</strong>
+        </p>
       </div>
     </div>
   </div>
-</section>
 
-<!-- ==================== SECTION 04: TYPOGRAPHY ==================== -->
-<section class="section" id="section-04">
-  <div class="container">
-    <p class="section-number">04</p>
-    <h2 class="section-title">TYPOGRAPHY</h2>
-
-    <!-- Type scale -->
-    <p class="subsection-label">Type Scale</p>
-    <div style="margin-bottom:48px;">
-      <div class="type-scale-row">
-        <div class="type-level-label">Display</div>
-        <div class="type-sample-display">
-          <span style="font-family:'Josefin Sans',sans-serif; font-weight:300; font-size:48px; letter-spacing:3px; line-height:1.1; color:var(--black);">Kosmas Athletic</span>
+  <div class="logo-subsection">
+    <div class="logo-subsection-title">Don't Do This</div>
+    <div class="dont-grid">
+      <div class="dont-card">
+        <svg class="dont-x" width="20" height="20" viewBox="0 0 20 20"><line x1="4" y1="4" x2="16" y2="16" stroke="#E53E3E" stroke-width="2.5" stroke-linecap="round"/><line x1="16" y1="4" x2="4" y2="16" stroke="#E53E3E" stroke-width="2.5" stroke-linecap="round"/></svg>
+        <img class="logo-sys-dont" alt="" style="filter:invert(1);transform:rotate(15deg);max-height:40px;">
+        <p>No rotation</p>
+      </div>
+      <div class="dont-card">
+        <svg class="dont-x" width="20" height="20" viewBox="0 0 20 20"><line x1="4" y1="4" x2="16" y2="16" stroke="#E53E3E" stroke-width="2.5" stroke-linecap="round"/><line x1="16" y1="4" x2="4" y2="16" stroke="#E53E3E" stroke-width="2.5" stroke-linecap="round"/></svg>
+        <div style="position:relative;display:inline-block;">
+          <img class="logo-sys-dont" alt="" style="filter:invert(1);max-height:40px;">
+          <div style="position:absolute;inset:0;background:linear-gradient(135deg,rgba(74,25,66,0.7),rgba(240,223,160,0.7));mix-blend-mode:overlay;"></div>
         </div>
-        <div class="type-specs">48px / Josefin Sans<br>Weight 300 / LS 3px / LH 1.1</div>
+        <p>No gradients</p>
       </div>
-      <div class="type-scale-row">
-        <div class="type-level-label">H1</div>
-        <div class="type-sample-display">
-          <span style="font-family:'Josefin Sans',sans-serif; font-weight:600; font-size:36px; letter-spacing:2px; line-height:1.2; color:var(--black);">Kosmas Athletic</span>
-        </div>
-        <div class="type-specs">36px / Josefin Sans<br>Weight 600 / LS 2px / LH 1.2</div>
+      <div class="dont-card">
+        <svg class="dont-x" width="20" height="20" viewBox="0 0 20 20"><line x1="4" y1="4" x2="16" y2="16" stroke="#E53E3E" stroke-width="2.5" stroke-linecap="round"/><line x1="16" y1="4" x2="4" y2="16" stroke="#E53E3E" stroke-width="2.5" stroke-linecap="round"/></svg>
+        <img class="logo-sys-dont" alt="" style="filter:invert(1);transform:scaleX(1.5);max-height:40px;">
+        <p>No stretching</p>
       </div>
-      <div class="type-scale-row">
-        <div class="type-level-label">H2</div>
-        <div class="type-sample-display">
-          <span style="font-family:'Josefin Sans',sans-serif; font-weight:600; font-size:28px; letter-spacing:2px; line-height:1.2; color:var(--black);">Kosmas Athletic</span>
-        </div>
-        <div class="type-specs">28px / Josefin Sans<br>Weight 600 / LS 2px / LH 1.2</div>
-      </div>
-      <div class="type-scale-row">
-        <div class="type-level-label">H3</div>
-        <div class="type-sample-display">
-          <span style="font-family:'Josefin Sans',sans-serif; font-weight:600; font-size:20px; letter-spacing:1px; line-height:1.3; color:var(--black);">Kosmas Athletic Ventures</span>
-        </div>
-        <div class="type-specs">20px / Josefin Sans<br>Weight 600 / LS 1px / LH 1.3</div>
-      </div>
-      <div class="type-scale-row">
-        <div class="type-level-label">H4</div>
-        <div class="type-sample-display">
-          <span style="font-family:'Josefin Sans',sans-serif; font-weight:600; font-size:16px; letter-spacing:1px; line-height:1.3; color:var(--black);">Kosmas Athletic Ventures</span>
-        </div>
-        <div class="type-specs">16px / Josefin Sans<br>Weight 600 / LS 1px / LH 1.3</div>
-      </div>
-      <div class="type-scale-row">
-        <div class="type-level-label">Body</div>
-        <div class="type-sample-display">
-          <span style="font-family:'Outfit',sans-serif; font-weight:300; font-size:15px; letter-spacing:0; line-height:1.6; color:var(--black);">Premium sports management for pickleball, volleyball, football and golf.</span>
-        </div>
-        <div class="type-specs">15px / Outfit<br>Weight 300 / LS 0 / LH 1.6</div>
-      </div>
-      <div class="type-scale-row">
-        <div class="type-level-label">Label</div>
-        <div class="type-sample-display">
-          <span style="font-family:'Outfit',sans-serif; font-weight:500; font-size:10px; letter-spacing:2px; line-height:1.0; text-transform:uppercase; color:var(--charcoal);">Section Label — Metadata</span>
-        </div>
-        <div class="type-specs">10px / Outfit<br>Weight 500 / LS 2px / LH 1.0</div>
-      </div>
-      <div class="type-scale-row">
-        <div class="type-level-label">Caption</div>
-        <div class="type-sample-display">
-          <span style="font-family:'Outfit',sans-serif; font-weight:300; font-size:12px; letter-spacing:0; line-height:1.4; color:var(--charcoal);">Supporting detail, image captions, helper text</span>
-        </div>
-        <div class="type-specs">12px / Outfit<br>Weight 300 / LS 0 / LH 1.4</div>
-      </div>
-    </div>
-
-    <!-- Weight showcase -->
-    <p class="subsection-label">Weight Showcase</p>
-    <div class="weight-showcase">
-      <div class="weight-row">
-        <div class="weight-item">
-          <span class="weight-label">300</span>
-          <span style="font-family:'Josefin Sans',sans-serif; font-weight:300; font-size:24px; letter-spacing:1px; color:var(--black);">Kosmas Athletic</span>
-        </div>
-        <div class="weight-item">
-          <span class="weight-label">400</span>
-          <span style="font-family:'Josefin Sans',sans-serif; font-weight:400; font-size:24px; letter-spacing:1px; color:var(--black);">Kosmas Athletic</span>
-        </div>
-        <div class="weight-item">
-          <span class="weight-label">600</span>
-          <span style="font-family:'Josefin Sans',sans-serif; font-weight:600; font-size:24px; letter-spacing:1px; color:var(--black);">Kosmas Athletic</span>
-        </div>
-        <div class="weight-item">
-          <span class="weight-label">700</span>
-          <span style="font-family:'Josefin Sans',sans-serif; font-weight:700; font-size:24px; letter-spacing:1px; color:var(--black);">Kosmas Athletic</span>
-        </div>
-      </div>
-      <div class="weight-row">
-        <div class="weight-item">
-          <span class="weight-label">300</span>
-          <span style="font-family:'Outfit',sans-serif; font-weight:300; font-size:20px; color:var(--black);">Premium Sports Management</span>
-        </div>
-        <div class="weight-item">
-          <span class="weight-label">400</span>
-          <span style="font-family:'Outfit',sans-serif; font-weight:400; font-size:20px; color:var(--black);">Premium Sports Management</span>
-        </div>
-        <div class="weight-item">
-          <span class="weight-label">500</span>
-          <span style="font-family:'Outfit',sans-serif; font-weight:500; font-size:20px; color:var(--black);">Premium Sports Management</span>
-        </div>
-        <div class="weight-item">
-          <span class="weight-label">600</span>
-          <span style="font-family:'Outfit',sans-serif; font-weight:600; font-size:20px; color:var(--black);">Premium Sports Management</span>
-        </div>
-      </div>
-    </div>
-
-    <!-- Pairing guidance -->
-    <div class="pairing-guidance">
-      <strong>Josefin Sans</strong> — Headlines, section titles, display numbers, brand moments.<br>
-      <strong>Outfit</strong> — Body text, labels, buttons, navigation, captions, and all UI copy.
-    </div>
-
-    <!-- Body text sample -->
-    <p class="subsection-label">Body Text Sample</p>
-    <div class="body-text-sample">
-      <p style="font-family:'Outfit',sans-serif; font-weight:300; font-size:15px; line-height:1.6; color:var(--black);">Kosmas Athletic Ventures manages elite athletes and sports organizations across pickleball, volleyball, football, and golf. Our approach combines data-driven insights with personalized coaching to maximize performance and career longevity. Every decision is made with precision, every relationship built with integrity.</p>
-    </div>
-  </div>
-</section>
-
-<!-- ==================== SECTION 05: SPACING & GRID ==================== -->
-<section class="section" id="section-05">
-  <div class="container">
-    <p class="section-number">05</p>
-    <h2 class="section-title">SPACING &amp; GRID</h2>
-
-    <!-- Spacing scale -->
-    <p class="subsection-label">Spacing Scale (base unit: 8px)</p>
-    <div class="spacing-scale">
-      <div class="spacing-row">
-        <div class="spacing-bar-label">4px — 0.5×</div>
-        <div class="spacing-bar-track"><div class="spacing-bar-fill" style="width:4px;"></div></div>
-      </div>
-      <div class="spacing-row">
-        <div class="spacing-bar-label">8px — 1×</div>
-        <div class="spacing-bar-track"><div class="spacing-bar-fill" style="width:8px;"></div></div>
-      </div>
-      <div class="spacing-row">
-        <div class="spacing-bar-label">12px — 1.5×</div>
-        <div class="spacing-bar-track"><div class="spacing-bar-fill" style="width:12px;"></div></div>
-      </div>
-      <div class="spacing-row">
-        <div class="spacing-bar-label">16px — 2×</div>
-        <div class="spacing-bar-track"><div class="spacing-bar-fill" style="width:16px;"></div></div>
-      </div>
-      <div class="spacing-row">
-        <div class="spacing-bar-label">24px — 3×</div>
-        <div class="spacing-bar-track"><div class="spacing-bar-fill" style="width:24px;"></div></div>
-      </div>
-      <div class="spacing-row">
-        <div class="spacing-bar-label">32px — 4×</div>
-        <div class="spacing-bar-track"><div class="spacing-bar-fill" style="width:32px;"></div></div>
-      </div>
-      <div class="spacing-row">
-        <div class="spacing-bar-label">48px — 6×</div>
-        <div class="spacing-bar-track"><div class="spacing-bar-fill" style="width:48px;"></div></div>
-      </div>
-      <div class="spacing-row">
-        <div class="spacing-bar-label">64px — 8×</div>
-        <div class="spacing-bar-track"><div class="spacing-bar-fill" style="width:64px;"></div></div>
-      </div>
-      <div class="spacing-row">
-        <div class="spacing-bar-label">80px — 10×</div>
-        <div class="spacing-bar-track"><div class="spacing-bar-fill" style="width:80px;"></div></div>
-      </div>
-    </div>
-
-    <!-- Grid example -->
-    <p class="subsection-label">Layout Grid</p>
-    <div class="grid-demo">
-      <div style="font-family:var(--font-body); font-size:11px; font-weight:500; color:var(--charcoal); text-transform:uppercase; letter-spacing:1.5px; margin-bottom:16px; text-align:center;">Max-width 1080px container with 32px side padding</div>
-      <div style="position:relative;">
-        <div class="grid-demo-inner">
-          <div class="grid-padding-indicator" style="left:0;">
-            <span>32px</span>
-          </div>
-          <span style="font-family:var(--font-body); font-weight:500; font-size:12px; color:var(--charcoal); letter-spacing:1px;">Content Area — max-width 1080px</span>
-          <div class="grid-padding-indicator" style="right:0;">
-            <span>32px</span>
-          </div>
-        </div>
-      </div>
-      <p class="grid-annotation">
-        <strong>Container:</strong> max-width 1080px — centered — 32px padding each side<br>
-        Mobile: 16px padding · Tablet: 24px padding · Desktop: 32px padding
-      </p>
-    </div>
-  </div>
-</section>
-
-<!-- ==================== SECTION 06: BUTTONS ==================== -->
-<section class="section" id="section-06">
-  <div class="container">
-    <p class="section-number">06</p>
-    <h2 class="section-title">BUTTONS</h2>
-
-    <!-- Button grid: 5 variants × 2 states -->
-    <div class="btn-grid">
-      <!-- Header row -->
-      <div class="btn-grid-header">State</div>
-      <div class="btn-grid-header" style="border-left:1px solid rgba(255,255,255,0.15);">Primary</div>
-      <div class="btn-grid-header" style="border-left:1px solid rgba(255,255,255,0.15);">Secondary</div>
-      <div class="btn-grid-header" style="border-left:1px solid rgba(255,255,255,0.15);">Ghost</div>
-      <div class="btn-grid-header" style="border-left:1px solid rgba(255,255,255,0.15);">Accent</div>
-      <div class="btn-grid-header" style="border-left:1px solid rgba(255,255,255,0.15);">Disabled</div>
-
-      <!-- Default row -->
-      <div class="btn-grid-row-label">Default</div>
-      <div class="btn-grid-cell" style="background:var(--white);">
-        <button class="btn btn-primary">Action</button>
-      </div>
-      <div class="btn-grid-cell" style="background:var(--white);">
-        <button class="btn btn-secondary">Action</button>
-      </div>
-      <div class="btn-grid-cell" style="background:var(--white);">
-        <button class="btn btn-ghost">Action</button>
-      </div>
-      <div class="btn-grid-cell" style="background:var(--white);">
-        <button class="btn btn-accent">Action</button>
-      </div>
-      <div class="btn-grid-cell" style="background:var(--white);">
-        <button class="btn btn-primary btn-disabled" disabled>Action</button>
-      </div>
-
-      <!-- Hover row (static simulation) -->
-      <div class="btn-grid-row-label last">Hover</div>
-      <div class="btn-grid-cell last" style="background:var(--white);">
-        <!-- Primary hover: charcoal bg -->
-        <button class="btn" style="background:var(--charcoal); color:var(--cream); pointer-events:none;">Action</button>
-      </div>
-      <div class="btn-grid-cell last" style="background:var(--white);">
-        <!-- Secondary hover: black bg, cream text -->
-        <button class="btn" style="background:var(--black); color:var(--cream); border:2px solid var(--black); pointer-events:none;">Action</button>
-      </div>
-      <div class="btn-grid-cell last" style="background:var(--white);">
-        <!-- Ghost hover: stone bg -->
-        <button class="btn" style="background:var(--stone); color:var(--charcoal); pointer-events:none;">Action</button>
-      </div>
-      <div class="btn-grid-cell last" style="background:var(--white);">
-        <!-- Accent hover: darker cyan -->
-        <button class="btn" style="background:#0A9AB3; color:var(--black); pointer-events:none;">Action</button>
-      </div>
-      <div class="btn-grid-cell last" style="background:var(--white);">
-        <!-- Disabled hover: same as default, no-op -->
-        <button class="btn btn-primary btn-disabled" style="pointer-events:none;" disabled>Action</button>
-      </div>
-    </div>
-
-    <!-- Spec notes -->
-    <div style="margin-top:24px; display:grid; grid-template-columns:repeat(2,1fr); gap:16px;">
-      <div style="background:var(--white); border:1px solid var(--stone); border-radius:6px; padding:18px 20px;">
-        <p style="font-family:var(--font-body); font-weight:500; font-size:11px; text-transform:uppercase; letter-spacing:1.5px; color:var(--charcoal); margin-bottom:10px;">Button Anatomy</p>
-        <p style="font-family:var(--font-body); font-weight:300; font-size:13px; color:var(--charcoal); line-height:1.6;">Padding: 10px top/bottom · 28px left/right<br>Font: Outfit 600 · 12px · 1.5px letter-spacing<br>Border-radius: 4px · Transition: 150ms ease</p>
-      </div>
-      <div style="background:var(--white); border:1px solid var(--stone); border-radius:6px; padding:18px 20px;">
-        <p style="font-family:var(--font-body); font-weight:500; font-size:11px; text-transform:uppercase; letter-spacing:1.5px; color:var(--charcoal); margin-bottom:10px;">Usage Guidance</p>
-        <p style="font-family:var(--font-body); font-weight:300; font-size:13px; color:var(--charcoal); line-height:1.6;">One primary per view. Accent (Cyan) for promotional or metric actions only. Ghost for low-priority or tertiary actions.</p>
+      <div class="dont-card">
+        <svg class="dont-x" width="20" height="20" viewBox="0 0 20 20"><line x1="4" y1="4" x2="16" y2="16" stroke="#E53E3E" stroke-width="2.5" stroke-linecap="round"/><line x1="16" y1="4" x2="4" y2="16" stroke="#E53E3E" stroke-width="2.5" stroke-linecap="round"/></svg>
+        <img class="logo-sys-dont" alt="" style="filter:invert(1) hue-rotate(90deg);max-height:40px;">
+        <p>No recoloring</p>
       </div>
     </div>
   </div>
-</section>
+</div>
 
-<!-- ==================== SECTION 07: TAGS & BADGES ==================== -->
-<section class="section" id="section-07">
-  <div class="container">
-    <p class="section-number">07</p>
-    <h2 class="section-title">TAGS &amp; BADGES</h2>
+<!-- ==================== 3. COLOR PALETTE ==================== -->
+<div class="section" id="colors">
+  <div class="section-number">03</div>
+  <div class="section-title">Color Palette</div>
+  <div class="section-desc">Four core colors. Dark plum leads, gold accents, periwinkle softens, near-black grounds.</div>
 
-    <!-- Row 1: Sport Tags -->
-    <div class="tag-row">
-      <div class="tag-row-label">Sport Tags</div>
-      <div class="tag-row-examples">
-        <div class="tag-example-group">
-          <span class="tag-size-label">Default</span>
-          <div class="tag-items">
-            <span class="tag-sport">Pickleball</span>
-            <span class="tag-sport">Volleyball</span>
-            <span class="tag-sport">Football</span>
-            <span class="tag-sport">Golf</span>
-          </div>
-        </div>
-        <div class="tag-example-group">
-          <span class="tag-size-label">Compact</span>
-          <div class="tag-items">
-            <span class="tag-sport tag-sport--compact">Pickleball</span>
-            <span class="tag-sport tag-sport--compact">Volleyball</span>
-            <span class="tag-sport tag-sport--compact">Football</span>
-            <span class="tag-sport tag-sport--compact">Golf</span>
-          </div>
-        </div>
+  <div class="color-grid">
+    <div class="color-card">
+      <div class="color-swatch" style="background:var(--plum);">
+        <span style="color:var(--gold);">PRIMARY</span>
+      </div>
+      <div class="color-info">
+        <div class="color-name">Dark Plum</div>
+        <div class="color-hex">#4A1942</div>
+        <div class="color-usage">Hero backgrounds, primary buttons, brand sections, emphasis blocks</div>
       </div>
     </div>
-
-    <!-- Row 2: Status Badges -->
-    <div class="tag-row">
-      <div class="tag-row-label">Status Badges</div>
-      <div class="tag-row-examples">
-        <div class="tag-example-group">
-          <span class="tag-size-label">Default</span>
-          <div class="tag-items">
-            <span class="badge-active">Active</span>
-            <span class="badge-soldout">Sold Out</span>
-            <span class="badge-upcoming">Upcoming</span>
-          </div>
-        </div>
-        <div class="tag-example-group">
-          <span class="tag-size-label">Compact</span>
-          <div class="tag-items">
-            <span class="badge-active badge-active--compact">Active</span>
-            <span class="badge-soldout badge-soldout--compact">Sold Out</span>
-            <span class="badge-upcoming badge-upcoming--compact">Upcoming</span>
-          </div>
-        </div>
+    <div class="color-card">
+      <div class="color-swatch" style="background:var(--gold);">
+        <span style="color:var(--plum);">ACCENT</span>
+      </div>
+      <div class="color-info">
+        <div class="color-name">Soft Gold</div>
+        <div class="color-hex">#F0DFA0</div>
+        <div class="color-usage">Headlines on dark, CTAs, active nav, hover states, key text</div>
       </div>
     </div>
-
-    <!-- Row 3: Location Tags -->
-    <div class="tag-row">
-      <div class="tag-row-label">Location Tags</div>
-      <div class="tag-row-examples">
-        <div class="tag-example-group">
-          <span class="tag-size-label">Default</span>
-          <div class="tag-items">
-            <span class="tag-location">Manila</span>
-            <span class="tag-location">Cebu</span>
-            <span class="tag-location">Davao</span>
-          </div>
-        </div>
-        <div class="tag-example-group">
-          <span class="tag-size-label">Compact</span>
-          <div class="tag-items">
-            <span class="tag-location tag-location--compact">Manila</span>
-            <span class="tag-location tag-location--compact">Cebu</span>
-            <span class="tag-location tag-location--compact">Davao</span>
-          </div>
-        </div>
+    <div class="color-card">
+      <div class="color-swatch" style="background:var(--peri);">
+        <span style="color:var(--black);">SECONDARY</span>
+      </div>
+      <div class="color-info">
+        <div class="color-name">Periwinkle</div>
+        <div class="color-hex">#B8C8E8</div>
+        <div class="color-usage">Secondary elements, tags, info states, subtle highlights</div>
       </div>
     </div>
-
-    <!-- Row 4: Category Labels -->
-    <div class="tag-row">
-      <div class="tag-row-label">Category Labels</div>
-      <div class="tag-row-examples">
-        <div class="tag-example-group">
-          <span class="tag-size-label">Default</span>
-          <div class="tag-items">
-            <span class="tag-category">Premium</span>
-            <span class="tag-category">Group</span>
-            <span class="tag-category">Private</span>
-          </div>
-        </div>
-        <div class="tag-example-group">
-          <span class="tag-size-label">Compact</span>
-          <div class="tag-items">
-            <span class="tag-category tag-category--compact">Premium</span>
-            <span class="tag-category tag-category--compact">Group</span>
-            <span class="tag-category tag-category--compact">Private</span>
-          </div>
-        </div>
+    <div class="color-card">
+      <div class="color-swatch" style="background:var(--black);">
+        <span style="color:var(--gray-500);">FOUNDATION</span>
+      </div>
+      <div class="color-info">
+        <div class="color-name">Near Black</div>
+        <div class="color-hex">#1E1E1E</div>
+        <div class="color-usage">Page background, body text on light, grounding layer</div>
       </div>
     </div>
-
-    <!-- Row 5: Metric Badges -->
-    <div class="tag-row">
-      <div class="tag-row-label">Metric Badges</div>
-      <div class="tag-row-examples">
-        <div class="tag-example-group">
-          <span class="tag-size-label">Default</span>
-          <div class="tag-items">
-            <span class="badge-metric">4.8★</span>
-            <span class="badge-metric">12 Spots Left</span>
-          </div>
-        </div>
-        <div class="tag-example-group">
-          <span class="tag-size-label">Compact</span>
-          <div class="tag-items">
-            <span class="badge-metric badge-metric--compact">4.8★</span>
-            <span class="badge-metric badge-metric--compact">12 Spots Left</span>
-          </div>
-        </div>
-      </div>
-    </div>
-
   </div>
-</section>
 
-<!-- ==================== SECTION 08: FORM INPUTS ==================== -->
-<section class="section" id="section-08">
-  <div class="container">
-    <p class="section-number">08</p>
-    <h2 class="section-title">FORM INPUTS</h2>
+  <!-- Extended neutrals -->
+  <div style="margin-top:24px;">
+    <div style="font-size:14px;font-weight:600;letter-spacing:2px;color:var(--gray-300);margin-bottom:16px;">NEUTRALS</div>
+    <div style="display:flex;gap:8px;height:48px;">
+      <div style="flex:1;background:#111111;border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:11px;font-family:monospace;color:#666;">#111</div>
+      <div style="flex:1;background:#1E1E1E;border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:11px;font-family:monospace;color:#666;">#1E1E1E</div>
+      <div style="flex:1;background:#252525;border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:11px;font-family:monospace;color:#666;">#252525</div>
+      <div style="flex:1;background:#333;border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:11px;font-family:monospace;color:#999;">#333</div>
+      <div style="flex:1;background:#444;border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:11px;font-family:monospace;color:#999;">#444</div>
+      <div style="flex:1;background:#888;border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:11px;font-family:monospace;color:#ddd;">#888</div>
+      <div style="flex:1;background:#BBB;border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:11px;font-family:monospace;color:#333;">#BBB</div>
+      <div style="flex:1;background:#EEE;border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:11px;font-family:monospace;color:#333;">#EEE</div>
+      <div style="flex:1;background:#FAFAFA;border-radius:4px;display:flex;align-items:center;justify-content:center;font-size:11px;font-family:monospace;color:#333;">#FAFAFA</div>
+    </div>
+  </div>
 
+  <!-- Usage Ratios -->
+  <div style="margin-top:32px;">
+    <div style="font-size:14px;font-weight:600;letter-spacing:2px;color:var(--gray-300);margin-bottom:16px;">USAGE RATIOS</div>
+    <div style="display:flex;height:40px;border-radius:4px;overflow:hidden;margin-bottom:12px;">
+      <div style="flex:7;background:var(--black);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:600;letter-spacing:1px;color:var(--gray-500);">60–70% DARK</div>
+      <div style="flex:2.5;background:var(--plum);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:600;letter-spacing:1px;color:var(--gold-dim);">20–30% PLUM</div>
+      <div style="flex:0.5;background:var(--gold);display:flex;align-items:center;justify-content:center;font-size:11px;font-weight:600;letter-spacing:1px;color:var(--black);">5–10%</div>
+    </div>
+  </div>
+
+  <!-- Sport Color Mapping -->
+  <div style="margin-top:32px;">
+    <div style="font-size:14px;font-weight:600;letter-spacing:2px;color:var(--gray-300);margin-bottom:16px;">SPORT COLOR ASSIGNMENTS</div>
+    <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:12px;">
+      <div style="background:var(--gold);border-radius:4px;padding:16px;text-align:center;">
+        <div style="font-size:13px;font-weight:700;letter-spacing:2px;color:var(--black);">PICKLEBALL</div>
+        <div style="font-size:11px;color:var(--black);opacity:0.6;margin-top:4px;">--gold</div>
+      </div>
+      <div style="background:var(--peri);border-radius:4px;padding:16px;text-align:center;">
+        <div style="font-size:13px;font-weight:700;letter-spacing:2px;color:var(--black);">VOLLEYBALL</div>
+        <div style="font-size:11px;color:var(--black);opacity:0.6;margin-top:4px;">--peri</div>
+      </div>
+      <div style="background:var(--plum);border-radius:4px;padding:16px;text-align:center;">
+        <div style="font-size:13px;font-weight:700;letter-spacing:2px;color:var(--gold);">FOOTBALL</div>
+        <div style="font-size:11px;color:var(--gold);opacity:0.6;margin-top:4px;">--plum</div>
+      </div>
+      <div style="background:var(--gray-300);border-radius:4px;padding:16px;text-align:center;">
+        <div style="font-size:13px;font-weight:700;letter-spacing:2px;color:var(--black);">GOLF</div>
+        <div style="font-size:11px;color:var(--black);opacity:0.6;margin-top:4px;">--gray-300</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ==================== 4. TYPOGRAPHY ==================== -->
+<div class="section" id="typography">
+  <div class="section-number">04</div>
+  <div class="section-title">Typography</div>
+  <div class="section-desc">Rajdhani across all weights. Angular, geometric, sporty. Wide letter-spacing for headlines, tighter for body.</div>
+
+  <div class="type-scale">
+    <div class="type-row">
+      <div class="type-meta">H1 — 48px<br>Weight 700<br>Spacing 6px</div>
+      <div style="font-size:48px;font-weight:700;letter-spacing:6px;text-transform:uppercase;color:var(--gold);">PLAY BOLD</div>
+    </div>
+    <div class="type-row">
+      <div class="type-meta">H2 — 36px<br>Weight 700<br>Spacing 4px</div>
+      <div style="font-size:36px;font-weight:700;letter-spacing:4px;text-transform:uppercase;">OUR VENUES</div>
+    </div>
+    <div class="type-row">
+      <div class="type-meta">H3 — 24px<br>Weight 600<br>Spacing 2px</div>
+      <div style="font-size:24px;font-weight:600;letter-spacing:2px;text-transform:uppercase;">Helios Sports Center</div>
+    </div>
+    <div class="type-row">
+      <div class="type-meta">H4 — 18px<br>Weight 600<br>Spacing 1px</div>
+      <div style="font-size:18px;font-weight:600;letter-spacing:1px;">Court Booking Details</div>
+    </div>
+    <div class="type-row">
+      <div class="type-meta">Body — 16px<br>Weight 400<br>Spacing 0.5px</div>
+      <div style="font-size:16px;font-weight:400;letter-spacing:0.5px;color:var(--gray-300);max-width:600px;">Kosmas Athletic Ventures brings world-class sports experiences to Southeast Asia. Our venues combine cutting-edge technology with premium facilities for athletes of all levels.</div>
+    </div>
+    <div class="type-row">
+      <div class="type-meta">Caption — 13px<br>Weight 500<br>Spacing 2px</div>
+      <div style="font-size:13px;font-weight:500;letter-spacing:2px;text-transform:uppercase;color:var(--gray-500);">ATHLETIC VENTURES CO.</div>
+    </div>
+    <div class="type-row">
+      <div class="type-meta">Label — 11px<br>Weight:700<br>Spacing 3px</div>
+      <div style="font-size:11px;font-weight:700;letter-spacing:3px;text-transform:uppercase;color:var(--gold-dim);">SECTION LABEL</div>
+    </div>
+  </div>
+
+  <!-- Weight Showcase -->
+  <div style="margin-top:32px;">
+    <div style="font-size:14px;font-weight:600;letter-spacing:2px;color:var(--gray-300);margin-bottom:16px;">WEIGHT RANGE</div>
+    <div style="display:flex;gap:24px;flex-wrap:wrap;">
+      <div style="text-align:center;">
+        <div style="font-size:36px;font-weight:300;color:var(--white);">Aa</div>
+        <div style="font-size:11px;color:var(--gray-500);letter-spacing:1px;">300 LIGHT</div>
+      </div>
+      <div style="text-align:center;">
+        <div style="font-size:36px;font-weight:400;color:var(--white);">Aa</div>
+        <div style="font-size:11px;color:var(--gray-500);letter-spacing:1px;">400 REGULAR</div>
+      </div>
+      <div style="text-align:center;">
+        <div style="font-size:36px;font-weight:500;color:var(--white);">Aa</div>
+        <div style="font-size:11px;color:var(--gray-500);letter-spacing:1px;">500 MEDIUM</div>
+      </div>
+      <div style="text-align:center;">
+        <div style="font-size:36px;font-weight:600;color:var(--white);">Aa</div>
+        <div style="font-size:11px;color:var(--gray-500);letter-spacing:1px;">600 SEMIBOLD</div>
+      </div>
+      <div style="text-align:center;">
+        <div style="font-size:36px;font-weight:700;color:var(--white);">Aa</div>
+        <div style="font-size:11px;color:var(--gray-500);letter-spacing:1px;">700 BOLD</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Pairing Guidance -->
+  <div style="margin-top:32px;">
+    <div style="font-size:14px;font-weight:600;letter-spacing:2px;color:var(--gray-300);margin-bottom:16px;">PAIRING GUIDANCE</div>
+    <div style="display:grid;grid-template-columns:repeat(3,1fr);gap:16px;">
+      <div style="background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;padding:20px;">
+        <div style="font-size:11px;font-weight:700;letter-spacing:2px;color:var(--gold-dim);margin-bottom:8px;">HEADLINES</div>
+        <p style="font-size:14px;color:var(--gray-300);">700 weight, 4-6px letter-spacing, uppercase. Use for H1-H2 and hero text.</p>
+      </div>
+      <div style="background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;padding:20px;">
+        <div style="font-size:11px;font-weight:700;letter-spacing:2px;color:var(--gold-dim);margin-bottom:8px;">SUBHEADS &amp; UI</div>
+        <p style="font-size:14px;color:var(--gray-300);">600 weight, 1-2px spacing. Use for H3-H4, nav links, button labels, card titles.</p>
+      </div>
+      <div style="background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;padding:20px;">
+        <div style="font-size:11px;font-weight:700;letter-spacing:2px;color:var(--gold-dim);margin-bottom:8px;">BODY TEXT</div>
+        <p style="font-size:14px;color:var(--gray-300);">400 weight, 0.5px spacing. Use for paragraphs, descriptions, form labels.</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Body Text Sample -->
+  <div style="margin-top:32px;">
+    <div style="font-size:14px;font-weight:600;letter-spacing:2px;color:var(--gray-300);margin-bottom:16px;">BODY TEXT SAMPLE</div>
+    <div style="background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;padding:32px;max-width:680px;">
+      <p style="font-size:16px;font-weight:400;letter-spacing:0.5px;color:var(--gray-300);line-height:1.8;">Kosmas Athletic Ventures brings world-class sports experiences to Southeast Asia. From pickleball courts in Manila to golf ranges in Cebu, our facilities combine cutting-edge technology with premium design. Every venue is built for athletes who demand precision, comfort, and style — whether you're booking a casual weekend match or training for competition.</p>
+    </div>
+  </div>
+</div>
+
+<!-- ==================== 5. SPACING ==================== -->
+<div class="section" id="spacing">
+  <div class="section-number">05</div>
+  <div class="section-title">Spacing & Grid</div>
+  <div class="section-desc">8px base unit. All spacing is a multiple of the base. Max content width: 1080px.</div>
+
+  <div style="margin-bottom:32px;">
+    <div class="spacing-row">
+      <div class="spacing-label">4px</div>
+      <div class="spacing-bar" style="width:4px;"><span></span></div>
+      <span class="token">0.5x</span>
+    </div>
+    <div class="spacing-row">
+      <div class="spacing-label">8px</div>
+      <div class="spacing-bar" style="width:32px;"><span></span></div>
+      <span class="token">1x — base</span>
+    </div>
+    <div class="spacing-row">
+      <div class="spacing-label">16px</div>
+      <div class="spacing-bar" style="width:64px;"><span></span></div>
+      <span class="token">2x</span>
+    </div>
+    <div class="spacing-row">
+      <div class="spacing-label">24px</div>
+      <div class="spacing-bar" style="width:96px;"><span></span></div>
+      <span class="token">3x</span>
+    </div>
+    <div class="spacing-row">
+      <div class="spacing-label">32px</div>
+      <div class="spacing-bar" style="width:128px;"><span></span></div>
+      <span class="token">4x</span>
+    </div>
+    <div class="spacing-row">
+      <div class="spacing-label">48px</div>
+      <div class="spacing-bar" style="width:192px;"><span></span></div>
+      <span class="token">6x</span>
+    </div>
+    <div class="spacing-row">
+      <div class="spacing-label">64px</div>
+      <div class="spacing-bar" style="width:256px;"><span></span></div>
+      <span class="token">8x — section</span>
+    </div>
+    <div class="spacing-row">
+      <div class="spacing-label">80px</div>
+      <div class="spacing-bar" style="width:320px;"><span></span></div>
+      <span class="token">10x — hero</span>
+    </div>
+  </div>
+</div>
+
+<!-- ==================== 6. BUTTONS ==================== -->
+<div class="section" id="buttons">
+  <div class="section-number">06</div>
+  <div class="section-title">Buttons</div>
+  <div class="section-desc">Five variants. Radius 4px. Padding 14px 32px. All caps, 700 weight, 3px letter-spacing.</div>
+
+  <div class="btn-grid">
+    <div class="btn-col">
+      <button class="btn btn-primary">BOOK NOW</button>
+      <div class="btn-label">Primary<br>plum bg / gold text</div>
+    </div>
+    <div class="btn-col">
+      <button class="btn btn-secondary">LEARN MORE</button>
+      <div class="btn-label">Secondary<br>gold outline</div>
+    </div>
+    <div class="btn-col">
+      <button class="btn btn-ghost">CANCEL</button>
+      <div class="btn-label">Ghost<br>gray outline</div>
+    </div>
+    <div class="btn-col">
+      <button class="btn btn-accent">GET STARTED</button>
+      <div class="btn-label">Accent<br>gold bg / black text</div>
+    </div>
+    <div class="btn-col">
+      <button class="btn btn-peri">INFO</button>
+      <div class="btn-label">Info<br>periwinkle bg</div>
+    </div>
+  </div>
+</div>
+
+<!-- ==================== 7. TAGS & BADGES ==================== -->
+<div class="section" id="tags">
+  <div class="section-number">07</div>
+  <div class="section-title">Tags & Badges</div>
+  <div class="section-desc">Five variants for categorization, status, location, category, and metrics. Each available in default and compact sizes.</div>
+
+  <div style="margin-bottom:32px;">
+    <div class="tag-row-label">Sport Tags</div>
+    <div class="tag-grid">
+      <span class="tag" style="background:var(--gold);color:var(--black);">PICKLEBALL</span>
+      <span class="tag" style="background:var(--peri);color:var(--black);">VOLLEYBALL</span>
+      <span class="tag" style="background:var(--plum);color:var(--gold);">FOOTBALL</span>
+      <span class="tag" style="background:var(--gray-300);color:var(--black);">GOLF</span>
+    </div>
+    <div class="tag-grid">
+      <span class="tag compact" style="background:var(--gold);color:var(--black);">PICKLEBALL</span>
+      <span class="tag compact" style="background:var(--peri);color:var(--black);">VOLLEYBALL</span>
+      <span class="tag compact" style="background:var(--plum);color:var(--gold);">FOOTBALL</span>
+      <span class="tag compact" style="background:var(--gray-300);color:var(--black);">GOLF</span>
+    </div>
+  </div>
+
+  <div style="margin-bottom:32px;">
+    <div class="tag-row-label">Status Badges</div>
+    <div class="tag-grid">
+      <span class="tag" style="background:var(--gold);color:var(--black);">ACTIVE</span>
+      <span class="tag" style="background:#E53E3E;color:var(--white);">SOLD OUT</span>
+      <span class="tag" style="background:var(--peri);color:var(--black);">UPCOMING</span>
+      <span class="tag" style="background:var(--gray-700);color:var(--gray-300);">CLOSED</span>
+    </div>
+    <div class="tag-grid">
+      <span class="tag compact" style="background:var(--gold);color:var(--black);">ACTIVE</span>
+      <span class="tag compact" style="background:#E53E3E;color:var(--white);">SOLD OUT</span>
+      <span class="tag compact" style="background:var(--peri);color:var(--black);">UPCOMING</span>
+      <span class="tag compact" style="background:var(--gray-700);color:var(--gray-300);">CLOSED</span>
+    </div>
+  </div>
+
+  <div style="margin-bottom:32px;">
+    <div class="tag-row-label">Location Tags</div>
+    <div class="tag-grid">
+      <span class="tag" style="background:transparent;color:var(--gray-300);border:1px solid var(--gray-700);">MANILA</span>
+      <span class="tag" style="background:transparent;color:var(--gray-300);border:1px solid var(--gray-700);">CEBU</span>
+      <span class="tag" style="background:transparent;color:var(--gray-300);border:1px solid var(--gray-700);">DAVAO</span>
+    </div>
+    <div class="tag-grid">
+      <span class="tag compact" style="background:transparent;color:var(--gray-300);border:1px solid var(--gray-700);">MANILA</span>
+      <span class="tag compact" style="background:transparent;color:var(--gray-300);border:1px solid var(--gray-700);">CEBU</span>
+      <span class="tag compact" style="background:transparent;color:var(--gray-300);border:1px solid var(--gray-700);">DAVAO</span>
+    </div>
+  </div>
+
+  <div style="margin-bottom:32px;">
+    <div class="tag-row-label">Category Labels</div>
+    <div class="tag-grid">
+      <span class="tag" style="background:var(--gray-900);color:var(--gray-300);border:1px solid var(--gray-800);">PREMIUM</span>
+      <span class="tag" style="background:var(--gray-900);color:var(--gray-300);border:1px solid var(--gray-800);">GROUP</span>
+      <span class="tag" style="background:var(--gray-900);color:var(--gray-300);border:1px solid var(--gray-800);">PRIVATE</span>
+    </div>
+    <div class="tag-grid">
+      <span class="tag compact" style="background:var(--gray-900);color:var(--gray-300);border:1px solid var(--gray-800);">PREMIUM</span>
+      <span class="tag compact" style="background:var(--gray-900);color:var(--gray-300);border:1px solid var(--gray-800);">GROUP</span>
+      <span class="tag compact" style="background:var(--gray-900);color:var(--gray-300);border:1px solid var(--gray-800);">PRIVATE</span>
+    </div>
+  </div>
+
+  <div>
+    <div class="tag-row-label">Metric Badges</div>
+    <div class="tag-grid">
+      <span class="tag" style="background:var(--gray-900);color:var(--gold);border:1px solid var(--gray-800);font-family:monospace;">4.8★</span>
+      <span class="tag" style="background:var(--gray-900);color:var(--peri);border:1px solid var(--gray-800);font-family:monospace;">12 SPOTS LEFT</span>
+      <span class="tag" style="background:var(--gray-900);color:var(--gold);border:1px solid var(--gray-800);font-family:monospace;">₱2,500/HR</span>
+    </div>
+    <div class="tag-grid">
+      <span class="tag compact" style="background:var(--gray-900);color:var(--gold);border:1px solid var(--gray-800);font-family:monospace;">4.8★</span>
+      <span class="tag compact" style="background:var(--gray-900);color:var(--peri);border:1px solid var(--gray-800);font-family:monospace;">12 SPOTS LEFT</span>
+      <span class="tag compact" style="background:var(--gray-900);color:var(--gold);border:1px solid var(--gray-800);font-family:monospace;">₱2,500/HR</span>
+    </div>
+  </div>
+</div>
+
+<!-- ==================== 8. FORM INPUTS ==================== -->
+<div class="section" id="forms">
+  <div class="section-number">08</div>
+  <div class="section-title">Form Inputs</div>
+  <div class="section-desc">Styled form elements on the dark theme. Each shown in four states: default, focus, error, disabled.</div>
+
+  <div style="margin-bottom:32px;">
+    <div class="form-row-label">Text Input</div>
     <div class="form-grid">
-      <!-- Header row -->
-      <div class="form-grid-header">Input Type</div>
-      <div class="form-grid-header">Default</div>
-      <div class="form-grid-header">Focus</div>
-      <div class="form-grid-header">Error</div>
-      <div class="form-grid-header">Disabled</div>
-
-      <!-- Row 1: Text Input -->
-      <div class="form-grid-row-label">Text</div>
-      <div class="form-grid-cell">
-        <input class="form-input" type="text" placeholder="Full name">
-      </div>
-      <div class="form-grid-cell">
-        <input class="form-input focus" type="text" placeholder="Full name" value="Carlos Santos">
-      </div>
-      <div class="form-grid-cell">
-        <input class="form-input error" type="text" placeholder="Full name" value="Car">
-        <p class="input-error-msg">Name is too short</p>
-      </div>
-      <div class="form-grid-cell">
-        <input class="form-input" type="text" placeholder="Full name" disabled>
-      </div>
-
-      <!-- Row 2: Textarea -->
-      <div class="form-grid-row-label">Textarea</div>
-      <div class="form-grid-cell">
-        <textarea class="form-input" placeholder="Message..." rows="3" style="resize:none;"></textarea>
-      </div>
-      <div class="form-grid-cell">
-        <textarea class="form-input focus" rows="3" style="resize:none;">Looking to join the Monday pickleball group...</textarea>
-      </div>
-      <div class="form-grid-cell">
-        <textarea class="form-input error" rows="3" style="resize:none;">Hi</textarea>
-        <p class="input-error-msg">Message is too short</p>
-      </div>
-      <div class="form-grid-cell">
-        <textarea class="form-input" placeholder="Message..." rows="3" style="resize:none;" disabled></textarea>
-      </div>
-
-      <!-- Row 3: Select -->
-      <div class="form-grid-row-label">Select</div>
-      <div class="form-grid-cell">
-        <select class="form-input">
-          <option value="">Select sport</option>
-          <option>Pickleball</option>
-          <option>Volleyball</option>
-          <option>Football</option>
-          <option>Golf</option>
-        </select>
-      </div>
-      <div class="form-grid-cell">
-        <select class="form-input focus">
-          <option>Pickleball</option>
-          <option>Volleyball</option>
-          <option>Football</option>
-          <option>Golf</option>
-        </select>
-      </div>
-      <div class="form-grid-cell">
-        <select class="form-input error">
-          <option value="">Select sport</option>
-          <option>Pickleball</option>
-        </select>
-        <p class="input-error-msg">Please select a sport</p>
-      </div>
-      <div class="form-grid-cell">
-        <select class="form-input" disabled>
-          <option>Pickleball</option>
-        </select>
-      </div>
-
-      <!-- Row 4: Toggle -->
-      <div class="form-grid-row-label">Toggle</div>
-      <div class="form-grid-cell">
-        <div class="toggle-wrap">
-          <label class="toggle">
-            <input type="checkbox">
-            <span class="toggle-track"></span>
-          </label>
-          <span class="toggle-label">Off</span>
-        </div>
-      </div>
-      <div class="form-grid-cell">
-        <div class="toggle-wrap">
-          <label class="toggle">
-            <input type="checkbox" checked>
-            <span class="toggle-track"></span>
-          </label>
-          <span class="toggle-label">On</span>
-        </div>
-      </div>
-      <div class="form-grid-cell">
-        <div class="toggle-wrap">
-          <label class="toggle">
-            <input type="checkbox">
-            <span class="toggle-track" style="border: 1px solid var(--error);"></span>
-          </label>
-          <span class="toggle-label" style="color: var(--error);">Required</span>
-        </div>
-        <p class="input-error-msg">Must accept terms</p>
-      </div>
-      <div class="form-grid-cell">
-        <div class="toggle-wrap">
-          <label class="toggle disabled">
-            <input type="checkbox" disabled>
-            <span class="toggle-track"></span>
-          </label>
-          <span class="toggle-label" style="opacity:0.5;">Disabled</span>
-        </div>
-      </div>
-
-      <!-- Row 5: Checkbox & Radio -->
-      <div class="form-grid-row-label">Check / Radio</div>
-      <div class="form-grid-cell">
-        <div class="check-wrap">
-          <label class="custom-checkbox">
-            <input type="checkbox">
-            <span class="checkbox-box"></span>
-          </label>
-          <span class="check-radio-label">Unchecked</span>
-        </div>
-        <div class="radio-wrap">
-          <label class="custom-radio">
-            <input type="radio" name="r-default">
-            <span class="radio-circle"></span>
-          </label>
-          <span class="check-radio-label">Unselected</span>
-        </div>
-      </div>
-      <div class="form-grid-cell">
-        <div class="check-wrap focus">
-          <label class="custom-checkbox">
-            <input type="checkbox" checked>
-            <span class="checkbox-box"></span>
-          </label>
-          <span class="check-radio-label">Checked</span>
-        </div>
-        <div class="radio-wrap focus">
-          <label class="custom-radio">
-            <input type="radio" name="r-focus" checked>
-            <span class="radio-circle"></span>
-          </label>
-          <span class="check-radio-label">Selected</span>
-        </div>
-      </div>
-      <div class="form-grid-cell">
-        <div class="check-wrap error">
-          <label class="custom-checkbox">
-            <input type="checkbox">
-            <span class="checkbox-box"></span>
-          </label>
-          <span class="check-radio-label">Required</span>
-        </div>
-        <p class="input-error-msg">Must check to proceed</p>
-      </div>
-      <div class="form-grid-cell">
-        <div class="check-wrap disabled">
-          <label class="custom-checkbox">
-            <input type="checkbox" disabled>
-            <span class="checkbox-box" style="opacity:0.5;cursor:not-allowed;"></span>
-          </label>
-          <span class="check-radio-label" style="opacity:0.5;">Disabled</span>
-        </div>
-        <div class="radio-wrap disabled">
-          <label class="custom-radio">
-            <input type="radio" disabled>
-            <span class="radio-circle" style="opacity:0.5;cursor:not-allowed;"></span>
-          </label>
-          <span class="check-radio-label" style="opacity:0.5;">Disabled</span>
-        </div>
-      </div>
-
-      <!-- Row 6: Search -->
-      <div class="form-grid-row-label">Search</div>
-      <div class="form-grid-cell">
-        <div class="search-wrap">
-          <span class="search-icon">
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <circle cx="6" cy="6" r="4.5" stroke="currentColor" stroke-width="1.5"/>
-              <line x1="9.5" y1="9.5" x2="13" y2="13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-            </svg>
-          </span>
-          <input class="form-input" type="text" placeholder="Search sessions...">
-        </div>
-      </div>
-      <div class="form-grid-cell">
-        <div class="search-wrap">
-          <span class="search-icon">
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <circle cx="6" cy="6" r="4.5" stroke="currentColor" stroke-width="1.5"/>
-              <line x1="9.5" y1="9.5" x2="13" y2="13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-            </svg>
-          </span>
-          <input class="form-input focus" type="text" value="Pickleball Monday">
-        </div>
-      </div>
-      <div class="form-grid-cell">
-        <div class="search-wrap">
-          <span class="search-icon">
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <circle cx="6" cy="6" r="4.5" stroke="currentColor" stroke-width="1.5"/>
-              <line x1="9.5" y1="9.5" x2="13" y2="13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-            </svg>
-          </span>
-          <input class="form-input error" type="text" value="???">
-        </div>
-        <p class="input-error-msg">No results found</p>
-      </div>
-      <div class="form-grid-cell">
-        <div class="search-wrap">
-          <span class="search-icon">
-            <svg width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-              <circle cx="6" cy="6" r="4.5" stroke="currentColor" stroke-width="1.5"/>
-              <line x1="9.5" y1="9.5" x2="13" y2="13" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
-            </svg>
-          </span>
-          <input class="form-input" type="text" placeholder="Search sessions..." disabled>
-        </div>
-      </div>
-
-      <!-- Row 7: Date Picker -->
-      <div class="form-grid-row-label last">Date</div>
-      <div class="form-grid-cell last">
-        <input class="form-input" type="date">
-      </div>
-      <div class="form-grid-cell last">
-        <input class="form-input focus" type="date" value="2026-03-15">
-      </div>
-      <div class="form-grid-cell last">
-        <input class="form-input error" type="date">
-        <p class="input-error-msg">Please select a date</p>
-      </div>
-      <div class="form-grid-cell last">
-        <input class="form-input" type="date" disabled>
-      </div>
+      <div class="form-cell"><label>Default</label><input type="text" placeholder="Enter name" readonly></div>
+      <div class="form-cell"><label>Focus</label><input type="text" value="Carlos Sandoval" class="focus-demo" readonly></div>
+      <div class="form-cell"><label>Error</label><input type="text" value="" class="error-demo" readonly><div class="error-msg">Name is required</div></div>
+      <div class="form-cell"><label>Disabled</label><input type="text" placeholder="Enter name" disabled></div>
     </div>
-
   </div>
-</section>
 
-<!-- ==================== SECTION 09: CARDS & CONTAINERS ==================== -->
-<section class="section" id="section-09">
-  <div class="container">
-    <p class="section-number">09</p>
-    <h2 class="section-title">CARDS &amp; CONTAINERS</h2>
-
-    <!-- Basic card + Stat card + Image card -->
-    <p class="cards-section-label">Basic · Stat · Image</p>
-    <div class="cards-grid-3">
-
-      <!-- 1. Basic card -->
-      <div class="card">
-        <h3 class="card-title">Session Overview</h3>
-        <p class="card-body">Monday morning pickleball group — open to all skill levels. Meet at Court 3, Ayala Sports Hub. Equipment provided for new members.</p>
-        <a href="#" class="card-link">View Details</a>
-      </div>
-
-      <!-- 3. Stat card -->
-      <div class="card" style="display:flex;flex-direction:column;justify-content:center;">
-        <span class="card-stat-label">Active Members</span>
-        <span class="card-stat-number">186</span>
-      </div>
-
-      <!-- 4. Image placeholder card -->
-      <div class="card" style="padding:0;overflow:hidden;">
-        <div class="card-img-placeholder" style="border-radius:4px 4px 0 0;margin:0;opacity:0.3;"></div>
-        <div style="padding:20px 20px 20px;">
-          <h4 class="card-img-title">Volleyball Clinic</h4>
-          <p class="card-img-desc">Intermediate-level clinic covering serve, receive, and blocking fundamentals.</p>
-        </div>
-      </div>
-
+  <div style="margin-bottom:32px;">
+    <div class="form-row-label">Textarea</div>
+    <div class="form-grid">
+      <div class="form-cell"><label>Default</label><textarea rows="3" placeholder="Add notes..." readonly></textarea></div>
+      <div class="form-cell"><label>Focus</label><textarea rows="3" class="focus-demo" readonly>Looking forward to the match!</textarea></div>
+      <div class="form-cell"><label>Error</label><textarea rows="3" class="error-demo" readonly></textarea><div class="error-msg">Notes required</div></div>
+      <div class="form-cell"><label>Disabled</label><textarea rows="3" placeholder="Add notes..." disabled></textarea></div>
     </div>
-
-    <!-- Sport tint cards -->
-    <p class="cards-section-label" style="margin-top:32px;">Sport Tint Cards</p>
-    <div class="cards-grid">
-
-      <!-- Pickleball -->
-      <div class="card" style="background:var(--tint-pickleball);border-color:var(--border-pickleball);">
-        <h3 class="card-sport-title">Pickleball</h3>
-        <p class="card-sport-count">12 active sessions</p>
-      </div>
-
-      <!-- Volleyball -->
-      <div class="card" style="background:var(--tint-volleyball);border-color:var(--border-volleyball);">
-        <h3 class="card-sport-title">Volleyball</h3>
-        <p class="card-sport-count">8 active sessions</p>
-      </div>
-
-      <!-- Football -->
-      <div class="card" style="background:var(--tint-football);border-color:var(--border-football);">
-        <h3 class="card-sport-title">Football</h3>
-        <p class="card-sport-count">6 active sessions</p>
-      </div>
-
-      <!-- Golf -->
-      <div class="card" style="background:var(--tint-golf);border-color:var(--border-golf);">
-        <h3 class="card-sport-title">Golf</h3>
-        <p class="card-sport-count">4 active sessions</p>
-      </div>
-
-    </div>
-
   </div>
-</section>
 
-<!-- ==================== SECTION 10: NAVIGATION ==================== -->
-<section class="section" id="section-10">
-  <div class="container">
-    <p class="section-number">10</p>
-    <h2 class="section-title">NAVIGATION</h2>
-
-    <!-- Desktop nav mockup -->
-    <div class="mockup-frame">
-      <div class="nav-desktop">
-        <div class="nav-desktop-left">
-          <img data-logo="icon" alt="Kosmas" class="logo-img logo-img-icon logo-img--on-cream" style="height: 32px;">
-        </div>
-        <nav class="nav-desktop-center">
-          <a class="nav-link" href="#">HOME</a>
-          <a class="nav-link" href="#">EXPERIENCES</a>
-          <a class="nav-link active" href="#">SCHEDULE</a>
-          <a class="nav-link" href="#">ABOUT</a>
-          <a class="nav-link" href="#">CONTACT</a>
-        </nav>
-        <div class="nav-desktop-right">
-          <button class="btn btn-primary" style="padding: 8px 20px; font-size: 11px;">BOOK NOW</button>
-        </div>
-      </div>
+  <div style="margin-bottom:32px;">
+    <div class="form-row-label">Select</div>
+    <div class="form-grid">
+      <div class="form-cell"><label>Default</label><select><option>Select sport...</option></select></div>
+      <div class="form-cell"><label>Focus</label><select class="focus-demo"><option>Pickleball</option></select></div>
+      <div class="form-cell"><label>Error</label><select class="error-demo"><option>Select sport...</option></select><div class="error-msg">Selection required</div></div>
+      <div class="form-cell"><label>Disabled</label><select disabled><option>Select sport...</option></select></div>
     </div>
-
-    <!-- Specs annotation -->
-    <p class="nav-specs">Height: 64px | Link gap: 24px | Font: Outfit 500 / 11px | Letter-spacing: 1px</p>
-
-    <!-- Mobile nav mockup -->
-    <div class="mockup-frame" style="max-width: 375px;">
-      <div class="nav-mobile-header">
-        <img data-logo="icon" alt="Kosmas" class="logo-img logo-img-icon logo-img--on-cream" style="height: 24px;">
-        <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <line x1="3" y1="6" x2="21" y2="6" stroke="var(--black)" stroke-width="2" stroke-linecap="round"/>
-          <line x1="3" y1="12" x2="21" y2="12" stroke="var(--black)" stroke-width="2" stroke-linecap="round"/>
-          <line x1="3" y1="18" x2="21" y2="18" stroke="var(--black)" stroke-width="2" stroke-linecap="round"/>
-        </svg>
-      </div>
-      <div class="nav-mobile-panel">
-        <a class="nav-link" href="#">HOME</a>
-        <a class="nav-link" href="#">EXPERIENCES</a>
-        <a class="nav-link active" href="#">SCHEDULE</a>
-        <a class="nav-link" href="#">ABOUT</a>
-        <a class="nav-link" href="#">CONTACT</a>
-        <button class="btn btn-primary" style="width: 100%; margin-top: 8px;">BOOK NOW</button>
-      </div>
-    </div>
-
   </div>
-</section>
 
-<!-- ==================== SECTION 11: FOOTER ==================== -->
-<section class="section" id="section-11">
-  <div class="container">
-    <p class="section-number">11</p>
-    <h2 class="section-title">FOOTER</h2>
-
-    <div class="mockup-frame">
-      <div class="footer-mockup">
-        <div class="footer-grid">
-          <!-- Col 1: Brand -->
-          <div>
-            <img data-logo="icon" alt="Kosmas" class="logo-img logo-img-icon logo-img--on-cream" style="height: 40px;">
-            <p class="footer-col-tagline">Kosmas Athletic Ventures — Premium sports management across Southeast Asia.</p>
-          </div>
-          <!-- Col 2: Experiences -->
-          <div>
-            <p class="footer-col-heading">EXPERIENCES</p>
-            <a class="footer-col-link" href="#">Pickleball</a>
-            <a class="footer-col-link" href="#">Volleyball</a>
-            <a class="footer-col-link" href="#">Football</a>
-            <a class="footer-col-link" href="#">Golf</a>
-          </div>
-          <!-- Col 3: Locations -->
-          <div>
-            <p class="footer-col-heading">LOCATIONS</p>
-            <a class="footer-col-link" href="#">Manila</a>
-            <a class="footer-col-link" href="#">Cebu</a>
-            <a class="footer-col-link" href="#">Davao</a>
-            <a class="footer-col-link" href="#">Boracay</a>
-          </div>
-          <!-- Col 4: Company -->
-          <div>
-            <p class="footer-col-heading">COMPANY</p>
-            <a class="footer-col-link" href="#">About</a>
-            <a class="footer-col-link" href="#">Careers</a>
-            <a class="footer-col-link" href="#">Press</a>
-            <a class="footer-col-link" href="#">Contact</a>
-          </div>
-        </div>
-        <div class="footer-copyright">
-          &copy; 2026 Kosmas Athletic Ventures Corporation
-        </div>
-      </div>
+  <div style="margin-bottom:32px;">
+    <div class="form-row-label">Search Input</div>
+    <div class="form-grid">
+      <div class="form-cell"><label>Default</label><div class="search-wrap"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2"><circle cx="11" cy="11" r="7"/><line x1="16.5" y1="16.5" x2="21" y2="21"/></svg><input type="text" placeholder="Search bookings..." readonly></div></div>
+      <div class="form-cell"><label>Focus</label><div class="search-wrap"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#F0DFA0" stroke-width="2"><circle cx="11" cy="11" r="7"/><line x1="16.5" y1="16.5" x2="21" y2="21"/></svg><input type="text" value="Manila courts" class="focus-demo" readonly></div></div>
+      <div class="form-cell"><label>Error</label><div class="search-wrap"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#E53E3E" stroke-width="2"><circle cx="11" cy="11" r="7"/><line x1="16.5" y1="16.5" x2="21" y2="21"/></svg><input type="text" class="error-demo" readonly></div><div class="error-msg">No results found</div></div>
+      <div class="form-cell"><label>Disabled</label><div class="search-wrap"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2" opacity="0.5"><circle cx="11" cy="11" r="7"/><line x1="16.5" y1="16.5" x2="21" y2="21"/></svg><input type="text" placeholder="Search bookings..." disabled></div></div>
     </div>
-
   </div>
-</section>
 
-<!-- ==================== SECTION 12: PAGE TREATMENTS ==================== -->
-<section class="section" id="section-12">
-  <div class="container">
-    <p class="section-number">12</p>
-    <h2 class="section-title">PAGE TREATMENTS</h2>
-
-    <!-- Tab bar -->
-    <div class="treatment-tabs">
-      <button class="treatment-tab active" onclick="showTreatment('treatment-12a', this)">12A: LANDING</button>
-      <button class="treatment-tab" onclick="showTreatment('treatment-12b', this)">12B: DASHBOARD</button>
-      <button class="treatment-tab" onclick="showTreatment('treatment-12c', this)">12C: CONTENT</button>
-      <button class="treatment-tab" onclick="showTreatment('treatment-12d', this)">12D: CRUD</button>
-      <button class="treatment-tab" onclick="showTreatment('treatment-12e', this)">12E: ERP</button>
-      <button class="treatment-tab" onclick="showTreatment('treatment-12f', this)">12F: SCHEDULE</button>
-    </div>
-
-    <!-- 12a: Marketing Landing Page -->
-    <div class="page-treatment" id="treatment-12a" style="display:block">
-      <div class="mockup-frame">
-        <!-- Hero band -->
-        <div class="pt-hero">
-          <p class="pt-hero-headline">PREMIER ATHLETIC EXPERIENCES</p>
-          <p class="pt-hero-subtitle">World-class sports management for athletes and coaches</p>
-          <div class="pt-hero-btns">
-            <button class="btn btn-primary">Get Started</button>
-            <button class="btn btn-secondary">Learn More</button>
-          </div>
+  <div style="margin-bottom:32px;">
+    <div class="form-row-label">Toggle / Checkbox / Radio</div>
+    <div style="display:flex;gap:48px;align-items:flex-start;">
+      <div>
+        <label style="font-size:11px;font-weight:600;letter-spacing:2px;color:var(--gray-500);display:block;margin-bottom:12px;">TOGGLES</label>
+        <div style="display:flex;gap:16px;align-items:center;">
+          <div class="toggle-track"><div class="toggle-thumb"></div></div>
+          <div class="toggle-track on"><div class="toggle-thumb"></div></div>
+          <div class="toggle-track" style="opacity:0.5;cursor:not-allowed;"><div class="toggle-thumb"></div></div>
         </div>
-        <!-- Sport cards grid -->
-        <div class="pt-sport-grid">
-          <div class="pt-sport-card" style="background: var(--tint-pickleball); border-color: var(--border-pickleball);">
-            <p class="pt-sport-name">PICKLEBALL</p>
-            <p class="pt-sport-count">14 active sessions</p>
-            <a class="pt-sport-link">Explore →</a>
-          </div>
-          <div class="pt-sport-card" style="background: var(--tint-volleyball); border-color: var(--border-volleyball);">
-            <p class="pt-sport-name">VOLLEYBALL</p>
-            <p class="pt-sport-count">8 active sessions</p>
-            <a class="pt-sport-link">Explore →</a>
-          </div>
-          <div class="pt-sport-card" style="background: var(--tint-football); border-color: var(--border-football);">
-            <p class="pt-sport-name">FOOTBALL</p>
-            <p class="pt-sport-count">11 active sessions</p>
-            <a class="pt-sport-link">Explore →</a>
-          </div>
-          <div class="pt-sport-card" style="background: var(--tint-golf); border-color: var(--border-golf);">
-            <p class="pt-sport-name">GOLF</p>
-            <p class="pt-sport-count">6 active sessions</p>
-            <a class="pt-sport-link">Explore →</a>
-          </div>
+        <div style="display:flex;gap:16px;margin-top:4px;font-size:11px;color:var(--gray-500);letter-spacing:1px;">
+          <span style="width:44px;text-align:center;">OFF</span>
+          <span style="width:44px;text-align:center;">ON</span>
+          <span style="width:44px;text-align:center;">OFF</span>
         </div>
-        <!-- Testimonial -->
-        <div class="pt-testimonial">
-          <p class="pt-testimonial-quote">"The best athletic management platform in Southeast Asia."</p>
-          <p class="pt-testimonial-attr">— Marco Reyes, Head Coach, Manila Athletics Club</p>
+      </div>
+      <div>
+        <label style="font-size:11px;font-weight:600;letter-spacing:2px;color:var(--gray-500);display:block;margin-bottom:12px;">CHECKBOXES</label>
+        <div style="display:flex;gap:16px;align-items:center;">
+          <div class="checkbox-custom"></div>
+          <div class="checkbox-custom checked"><svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#F0DFA0" stroke-width="3" stroke-linecap="round"><polyline points="20 6 9 17 4 12"/></svg></div>
+          <div class="checkbox-custom" style="opacity:0.5;"></div>
         </div>
-        <!-- CTA section -->
-        <div class="pt-cta">
-          <p class="pt-cta-heading">Ready to Play?</p>
-          <button class="btn btn-primary">Book a Session</button>
+      </div>
+      <div>
+        <label style="font-size:11px;font-weight:600;letter-spacing:2px;color:var(--gray-500);display:block;margin-bottom:12px;">RADIO BUTTONS</label>
+        <div style="display:flex;gap:16px;align-items:center;">
+          <div class="radio-custom"></div>
+          <div class="radio-custom checked"></div>
+          <div class="radio-custom" style="opacity:0.5;"></div>
         </div>
       </div>
     </div>
+  </div>
 
-    <!-- 12b: App Dashboard -->
-    <div class="page-treatment" id="treatment-12b" style="display:none">
-      <div class="mockup-frame">
-        <div class="pt-dash-inner">
-          <!-- KPI cards -->
-          <div class="pt-kpi-grid">
-            <div class="pt-kpi-card">
-              <span class="pt-kpi-label">Active Members</span>
-              <span class="pt-kpi-value">186</span>
-            </div>
-            <div class="pt-kpi-card">
-              <span class="pt-kpi-label">Upcoming Sessions</span>
-              <span class="pt-kpi-value">24</span>
-            </div>
-            <div class="pt-kpi-card">
-              <span class="pt-kpi-label">Revenue</span>
-              <span class="pt-kpi-value">$12,400</span>
-            </div>
-            <div class="pt-kpi-card">
-              <span class="pt-kpi-label">Utilization</span>
-              <span class="pt-kpi-value">78%</span>
-            </div>
+  <div>
+    <div class="form-row-label">Date Input</div>
+    <div class="form-grid">
+      <div class="form-cell"><label>Default</label><input type="text" placeholder="YYYY-MM-DD" readonly></div>
+      <div class="form-cell"><label>Focus</label><input type="text" value="2026-03-15" class="focus-demo" readonly></div>
+      <div class="form-cell"><label>Error</label><input type="text" value="invalid" class="error-demo" readonly><div class="error-msg">Invalid date</div></div>
+      <div class="form-cell"><label>Disabled</label><input type="text" placeholder="YYYY-MM-DD" disabled></div>
+    </div>
+  </div>
+</div>
+
+<!-- ==================== 9. CARDS ==================== -->
+<div class="section" id="cards">
+  <div class="section-number">09</div>
+  <div class="section-title">Cards & Containers</div>
+  <div class="section-desc">Background #252525, border 1px #333, radius 8px. Hover: border shifts to plum-light.</div>
+
+  <div class="card-grid">
+    <div class="demo-card">
+      <div class="demo-card-img" style="background:linear-gradient(135deg, var(--plum), #2A0E28);">
+        <span style="color:var(--gold);letter-spacing:3px;">PICKLEBALL</span>
+      </div>
+      <div class="demo-card-body">
+        <h4>Court Booking</h4>
+        <p>Reserve your court in seconds. Available 24/7 at autonomous venues.</p>
+      </div>
+    </div>
+    <div class="demo-card">
+      <div class="demo-card-img" style="background:linear-gradient(135deg, var(--peri-dim), #5A6A8A);">
+        <span style="color:var(--white);letter-spacing:3px;">PING PONG</span>
+      </div>
+      <div class="demo-card-body">
+        <h4>Instant Replay</h4>
+        <p>Every rally captured. Review your game with AI-powered highlights.</p>
+      </div>
+    </div>
+    <div class="demo-card">
+      <div class="demo-card-img" style="background:linear-gradient(135deg, var(--gold-dim), #8A7A50);">
+        <span style="color:var(--black);letter-spacing:3px;">PADEL</span>
+      </div>
+      <div class="demo-card-body">
+        <h4>Premium Venues</h4>
+        <p>World-class facilities with cutting-edge technology across Asia.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ==================== 10. NAVIGATION ==================== -->
+<div class="section" id="nav">
+  <div class="section-number">10</div>
+  <div class="section-title">Navigation</div>
+  <div class="section-desc">Shared nav component. Desktop: 64px, logo left, links center, CTA right. Mobile: 56px header with full-screen overlay.</div>
+
+  <div style="margin-bottom:16px;font-size:12px;font-weight:600;letter-spacing:2px;color:var(--gray-500);">DESKTOP — 64PX</div>
+  <div class="nav-mockup">
+    <div class="nav-mockup-bar">
+      <img class="logo-nav-desktop" alt="Kosmas" style="height:32px;margin-right:16px;filter:invert(1);">
+      <div class="nav-mockup-links">
+        <a href="#" class="active">HOME</a>
+        <a href="#">EXPERIENCES</a>
+        <a href="#">SCHEDULE</a>
+        <a href="#">ABOUT</a>
+        <a href="#">CONTACT</a>
+      </div>
+      <button class="btn btn-primary" style="padding:8px 20px;font-size:12px;margin-left:auto;">BOOK NOW</button>
+    </div>
+  </div>
+  <div style="font-size:12px;color:var(--gray-500);letter-spacing:1px;margin-bottom:32px;">Active link: gold + 2px underline · Hover: color → gray-300 · Sticky · z-index: 100</div>
+
+  <div style="margin-bottom:16px;font-size:12px;font-weight:600;letter-spacing:2px;color:var(--gray-500);">MOBILE — 56PX + OVERLAY</div>
+  <div class="nav-mockup mobile-mockup">
+    <div class="mobile-mockup-bar">
+      <img class="logo-nav-mobile" alt="Kosmas" style="height:28px;filter:invert(1);">
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2" stroke-linecap="round"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+    </div>
+    <div class="mobile-overlay">
+      <a href="#" class="active">HOME</a>
+      <a href="#">EXPERIENCES</a>
+      <a href="#">SCHEDULE</a>
+      <a href="#">ABOUT</a>
+      <a href="#">CONTACT</a>
+      <button class="btn btn-primary" style="margin-top:16px;width:100%;max-width:280px;">BOOK NOW</button>
+    </div>
+  </div>
+</div>
+
+<!-- ==================== 11. FOOTER ==================== -->
+<div class="section" id="footer">
+  <div class="section-number">11</div>
+  <div class="section-title">Footer</div>
+  <div class="section-desc">Multi-column footer. Icon mark + brand statement left, three link columns right, social + copyright bar at bottom.</div>
+
+  <div class="footer-mockup">
+    <div class="footer-inner">
+      <div class="footer-col">
+        <img class="logo-footer" alt="Kosmas" style="height:40px;margin-bottom:16px;filter:invert(1);">
+        <p>Premium athletic experiences across Southeast Asia. Bold, defined, confident.</p>
+      </div>
+      <div class="footer-col">
+        <h4>Experiences</h4>
+        <a href="#">Pickleball</a>
+        <a href="#">Volleyball</a>
+        <a href="#">Football</a>
+        <a href="#">Golf</a>
+      </div>
+      <div class="footer-col">
+        <h4>Locations</h4>
+        <a href="#">Manila</a>
+        <a href="#">Cebu</a>
+        <a href="#">Davao</a>
+      </div>
+      <div class="footer-col">
+        <h4>Company</h4>
+        <a href="#">About</a>
+        <a href="#">Careers</a>
+        <a href="#">Press</a>
+        <a href="#">Contact</a>
+      </div>
+    </div>
+    <div class="footer-bar">
+      <span>© 2026 KOSMAS ATHLETIC VENTURES CO.</span>
+      <div class="footer-social">
+        <a href="#">X</a>
+        <a href="#">IG</a>
+        <a href="#">LI</a>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ==================== 12. PAGE TREATMENTS ==================== -->
+<div class="section" id="pages">
+  <div class="section-number">12</div>
+  <div class="section-title">Page Treatments</div>
+  <div class="section-desc">Six page mockups showing the brand applied to real contexts. Click tabs to switch.</div>
+
+  <div class="page-tabs">
+    <div class="page-tab active" onclick="switchPageTab('landing')">12A LANDING</div>
+    <div class="page-tab" onclick="switchPageTab('dashboard')">12B DASHBOARD</div>
+    <div class="page-tab" onclick="switchPageTab('content')">12C CONTENT</div>
+    <div class="page-tab" onclick="switchPageTab('crud')">12D CRUD</div>
+    <div class="page-tab" onclick="switchPageTab('erp')">12E ERP</div>
+    <div class="page-tab" onclick="switchPageTab('schedule')">12F SCHEDULE</div>
+  </div>
+
+  <!-- 12a: Marketing Landing Page -->
+  <div class="page-panel active" id="panel-landing">
+    <div class="page-frame">
+      <div class="page-frame-label">12A — Marketing Landing Page</div>
+      <div class="page-frame-body">
+        <div class="mock-hero" style="background:linear-gradient(135deg,var(--plum),var(--black-deep));padding:64px 32px;">
+          <div style="font-size:11px;font-weight:700;letter-spacing:4px;color:var(--gold-dim);margin-bottom:16px;">KOSMAS ATHLETIC VENTURES</div>
+          <div style="font-size:36px;font-weight:700;letter-spacing:6px;color:var(--gold);text-transform:uppercase;">PREMIER ATHLETIC<br>EXPERIENCES</div>
+          <p style="font-size:15px;color:rgba(255,255,255,0.6);margin-top:16px;max-width:500px;margin-left:auto;margin-right:auto;">World-class sports facilities across Southeast Asia. Pickleball, volleyball, football, and golf.</p>
+          <div style="margin-top:24px;display:flex;gap:12px;justify-content:center;">
+            <button class="btn btn-primary">BOOK NOW</button>
+            <button class="btn btn-secondary">EXPLORE</button>
           </div>
-          <!-- Activity feed -->
-          <div class="pt-activity-feed">
-            <div class="pt-activity-row">
-              <span class="pt-activity-time">9:15 AM</span>
-              <span class="pt-activity-desc">Court 3 booked for Mixed Doubles</span>
-              <span class="tag-sport">Pickleball</span>
-            </div>
-            <div class="pt-activity-row">
-              <span class="pt-activity-time">10:00 AM</span>
-              <span class="pt-activity-desc">New member registration: Maria Santos</span>
-              <span class="tag-sport">Volleyball</span>
-            </div>
-            <div class="pt-activity-row">
-              <span class="pt-activity-time">11:30 AM</span>
-              <span class="pt-activity-desc">Group session cancelled</span>
-              <span class="tag-sport">Football</span>
-            </div>
-            <div class="pt-activity-row">
-              <span class="pt-activity-time">1:00 PM</span>
-              <span class="pt-activity-desc">Payment received: ₱2,400</span>
-              <span class="tag-sport">Golf</span>
-            </div>
-            <div class="pt-activity-row">
-              <span class="pt-activity-time">2:45 PM</span>
-              <span class="pt-activity-desc">Court maintenance scheduled</span>
-              <span class="tag-sport">Pickleball</span>
-            </div>
+        </div>
+        <div class="mock-grid" style="grid-template-columns:repeat(4,1fr);padding:32px;">
+          <div style="background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;overflow:hidden;">
+            <div style="height:80px;background:linear-gradient(135deg,var(--gold),#C4B580);display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;letter-spacing:3px;color:var(--black);">PICKLEBALL</div>
+            <div style="padding:16px;"><p style="font-size:13px;color:var(--gray-300);">Courts in Manila, Cebu & Davao. Book by the hour.</p></div>
           </div>
-          <!-- Quick actions -->
-          <div class="pt-quick-actions">
-            <button class="btn btn-primary">Book Session</button>
-            <button class="btn btn-secondary">Add Member</button>
-            <button class="btn btn-ghost">View Reports</button>
+          <div style="background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;overflow:hidden;">
+            <div style="height:80px;background:linear-gradient(135deg,var(--peri),#8A9ABB);display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;letter-spacing:3px;color:var(--black);">VOLLEYBALL</div>
+            <div style="padding:16px;"><p style="font-size:13px;color:var(--gray-300);">Indoor & beach courts. Team leagues available.</p></div>
+          </div>
+          <div style="background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;overflow:hidden;">
+            <div style="height:80px;background:linear-gradient(135deg,var(--plum),var(--plum-light));display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;letter-spacing:3px;color:var(--gold);">FOOTBALL</div>
+            <div style="padding:16px;"><p style="font-size:13px;color:var(--gray-300);">5-a-side & full pitch. Premium turf facilities.</p></div>
+          </div>
+          <div style="background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;overflow:hidden;">
+            <div style="height:80px;background:linear-gradient(135deg,var(--gray-300),var(--gray-500));display:flex;align-items:center;justify-content:center;font-size:13px;font-weight:700;letter-spacing:3px;color:var(--black);">GOLF</div>
+            <div style="padding:16px;"><p style="font-size:13px;color:var(--gray-300);">Driving ranges & simulator bays. All skill levels.</p></div>
+          </div>
+        </div>
+        <div style="background:var(--plum);padding:32px;text-align:center;">
+          <p style="font-size:18px;font-weight:400;color:var(--white);font-style:italic;max-width:600px;margin:0 auto;">"The best sports facilities I've experienced in Southeast Asia. Kosmas sets a new standard."</p>
+          <p style="font-size:13px;font-weight:600;letter-spacing:2px;color:var(--gold);margin-top:16px;">— MARCO REYES, ATHLETE</p>
+        </div>
+        <div style="padding:32px;text-align:center;">
+          <div style="font-size:24px;font-weight:700;letter-spacing:4px;color:var(--white);text-transform:uppercase;">READY TO PLAY?</div>
+          <div style="margin-top:16px;display:flex;gap:12px;justify-content:center;">
+            <button class="btn btn-accent">GET STARTED</button>
+            <button class="btn btn-ghost">CONTACT US</button>
           </div>
         </div>
       </div>
     </div>
+  </div>
 
-    <!-- 12c: Content Page -->
-    <div class="page-treatment" id="treatment-12c" style="display:none">
-      <div class="mockup-frame">
-        <div class="pt-content-inner">
-          <h1 class="pt-content-title">Pickleball Courts: Our Top 5 in Manila</h1>
-          <p class="pt-content-meta">By Sarah Chen · March 10, 2026 · 5 min read</p>
-          <p class="pt-content-body">Manila's sporting scene has transformed dramatically over the past few years, and nowhere is that more evident than on the pickleball courts. From Bonifacio Global City to Quezon City, dedicated facilities are springing up across the metro, catering to players of all skill levels—from beginners picking up a paddle for the first time to seasoned competitors chasing regional titles.</p>
-          <p class="pt-content-body">Whether you're looking for a casual weekend game with friends or serious training sessions with a certified coach, Manila now offers court options that rival those found in major sporting capitals. Here are the five venues we consider essential playing grounds for anyone serious about the sport.</p>
-          <blockquote class="pt-content-blockquote">Manila's pickleball scene has exploded in the last two years, with court bookings up over 300% and a growing community of dedicated players pushing the sport into the mainstream.</blockquote>
-          <p class="pt-content-body">Each of these venues has been evaluated on court quality, coaching availability, equipment rental, booking ease, and overall atmosphere. We visited every location multiple times across different times of day to give you an honest, well-rounded assessment of what to expect.</p>
-          <!-- Related articles -->
-          <h2 class="pt-related-heading">Related Articles</h2>
-          <div class="pt-related-grid">
-            <div class="pt-related-card">
-              <p class="pt-related-card-title">Volleyball Beach Courts in Cebu</p>
-              <span class="tag-sport">Volleyball</span>
-              <p class="pt-related-card-date">Mar 8, 2026</p>
+  <!-- Remaining panels: 12b-12f will be added in subsequent tasks -->
+
+  <!-- 12b: App Dashboard -->
+  <div class="page-panel" id="panel-dashboard">
+    <div class="page-frame">
+      <div class="page-frame-label">12B — App Dashboard</div>
+      <div class="page-frame-body">
+        <div class="mock-grid" style="grid-template-columns:repeat(4,1fr);padding:24px 32px;">
+          <div class="mock-stat"><div class="stat-value">2,847</div><div class="stat-label">Active Members</div></div>
+          <div class="mock-stat"><div class="stat-value">156</div><div class="stat-label">Upcoming Sessions</div></div>
+          <div class="mock-stat"><div class="stat-value" style="color:var(--peri);">₱1.2M</div><div class="stat-label">Monthly Revenue</div></div>
+          <div class="mock-stat"><div class="stat-value" style="color:var(--gold);">87%</div><div class="stat-label">Utilization</div></div>
+        </div>
+        <div style="padding:0 32px 24px;">
+          <div style="font-size:13px;font-weight:600;letter-spacing:2px;color:var(--gray-500);margin-bottom:12px;">RECENT ACTIVITY</div>
+          <div style="background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;">
+            <div style="padding:12px 16px;border-bottom:1px solid var(--gray-800);display:flex;justify-content:space-between;align-items:center;">
+              <span style="font-size:14px;color:var(--gray-300);">Carlos booked Pickleball Court 3</span>
+              <span class="tag compact" style="background:var(--gold);color:var(--black);">PICKLEBALL</span>
             </div>
-            <div class="pt-related-card">
-              <p class="pt-related-card-title">Golf Driving Ranges: A Guide</p>
-              <span class="tag-sport">Golf</span>
-              <p class="pt-related-card-date">Mar 5, 2026</p>
+            <div style="padding:12px 16px;border-bottom:1px solid var(--gray-800);display:flex;justify-content:space-between;align-items:center;">
+              <span style="font-size:14px;color:var(--gray-300);">Team Bravo reserved Football Pitch A</span>
+              <span class="tag compact" style="background:var(--plum);color:var(--gold);">FOOTBALL</span>
             </div>
-            <div class="pt-related-card">
-              <p class="pt-related-card-title">Football Youth Leagues 2026</p>
-              <span class="tag-sport">Football</span>
-              <p class="pt-related-card-date">Mar 1, 2026</p>
+            <div style="padding:12px 16px;border-bottom:1px solid var(--gray-800);display:flex;justify-content:space-between;align-items:center;">
+              <span style="font-size:14px;color:var(--gray-300);">Maria joined Volleyball League — Season 3</span>
+              <span class="tag compact" style="background:var(--peri);color:var(--black);">VOLLEYBALL</span>
+            </div>
+            <div style="padding:12px 16px;display:flex;justify-content:space-between;align-items:center;">
+              <span style="font-size:14px;color:var(--gray-300);">Golf Range Bay 7 — maintenance complete</span>
+              <span class="tag compact" style="background:var(--gray-300);color:var(--black);">GOLF</span>
+            </div>
+          </div>
+        </div>
+        <div style="padding:0 32px 32px;display:flex;gap:12px;">
+          <button class="btn btn-primary">NEW BOOKING</button>
+          <button class="btn btn-secondary">VIEW SCHEDULE</button>
+          <button class="btn btn-ghost">EXPORT REPORT</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 12c: Content Page -->
+  <div class="page-panel" id="panel-content">
+    <div class="page-frame">
+      <div class="page-frame-label">12C — Content Page (Blog Article)</div>
+      <div class="page-frame-body">
+        <div style="max-width:680px;margin:0 auto;padding:48px 32px;">
+          <span class="tag compact" style="background:var(--gold);color:var(--black);margin-bottom:16px;display:inline-block;">PICKLEBALL</span>
+          <h2 style="font-size:32px;font-weight:700;letter-spacing:4px;color:var(--white);text-transform:uppercase;margin-bottom:8px;">PICKLEBALL COURTS:<br>OUR TOP 5 IN MANILA</h2>
+          <div style="font-size:13px;color:var(--gray-500);letter-spacing:1px;margin-bottom:32px;">By <span style="color:var(--gold);">KOSMAS EDITORIAL</span> · March 12, 2026 · 5 min read</div>
+          <p style="font-size:16px;color:var(--gray-300);line-height:1.8;margin-bottom:24px;">Manila's pickleball scene has exploded in the last two years. From converted warehouses to purpose-built facilities, the metro now offers world-class courts for players of every level.</p>
+          <h3 style="font-size:20px;font-weight:600;letter-spacing:2px;color:var(--white);text-transform:uppercase;margin-bottom:12px;">1. Kosmas BGC</h3>
+          <p style="font-size:16px;color:var(--gray-300);line-height:1.8;margin-bottom:24px;">Our flagship facility features 8 indoor courts with competition-grade surfaces, LED lighting calibrated for zero-glare play, and a pro shop stocked with the latest paddles.</p>
+          <div style="border-left:3px solid var(--gold);padding:16px 24px;margin:24px 0;background:rgba(74,25,66,0.15);border-radius:0 8px 8px 0;">
+            <p style="font-size:16px;color:var(--white);font-style:italic;line-height:1.7;">"The court quality at Kosmas BGC rivals anything I've played on in the US. The surface response is exceptional."</p>
+            <p style="font-size:13px;color:var(--gold);margin-top:8px;letter-spacing:1px;">— PRO PLAYER, APPT TOURNAMENT</p>
+          </div>
+          <h3 style="font-size:20px;font-weight:600;letter-spacing:2px;color:var(--white);text-transform:uppercase;margin-bottom:12px;">2. Kosmas Makati</h3>
+          <p style="font-size:16px;color:var(--gray-300);line-height:1.8;margin-bottom:32px;">Located in the heart of the business district, this venue caters to the after-work crowd with extended evening hours and a lounge overlooking the courts.</p>
+          <div style="border-top:1px solid var(--gray-800);padding-top:32px;">
+            <div style="font-size:13px;font-weight:600;letter-spacing:2px;color:var(--gray-500);margin-bottom:16px;">RELATED ARTICLES</div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
+              <div style="background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;padding:16px;">
+                <span class="tag compact" style="background:var(--peri);color:var(--black);margin-bottom:8px;display:inline-block;">VOLLEYBALL</span>
+                <h4 style="font-size:15px;font-weight:600;color:var(--white);margin-bottom:4px;">Beach Volleyball Season Opens</h4>
+                <p style="font-size:13px;color:var(--gray-500);">March 2026 · 3 min</p>
+              </div>
+              <div style="background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;padding:16px;">
+                <span class="tag compact" style="background:var(--gray-300);color:var(--black);margin-bottom:8px;display:inline-block;">GOLF</span>
+                <h4 style="font-size:15px;font-weight:600;color:var(--white);margin-bottom:4px;">New Simulator Bays at Cebu</h4>
+                <p style="font-size:13px;color:var(--gray-500);">February 2026 · 4 min</p>
+              </div>
             </div>
           </div>
         </div>
       </div>
     </div>
+  </div>
 
-    <!-- 12d: CRUD Interface -->
-    <div class="page-treatment" id="treatment-12d" style="display:none">
-      <div class="mockup-frame">
-        <div class="pt-crud-inner">
-          <!-- Top bar -->
-          <div class="pt-crud-topbar">
-            <div class="pt-crud-search search-wrap" style="flex:1;max-width:300px;">
-              <span class="search-icon">
-                <svg width="14" height="14" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="6.5" cy="6.5" r="5.5" stroke="currentColor" stroke-width="1.5"/><line x1="10.5" y1="10.5" x2="14.5" y2="14.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
-              </span>
-              <input type="text" class="form-input" placeholder="Search bookings..." style="padding-left:32px;">
-            </div>
-            <select class="form-input" style="width:auto;">
-              <option>All Sports</option>
-              <option>Pickleball</option>
-              <option>Volleyball</option>
-              <option>Football</option>
-              <option>Golf</option>
-            </select>
-            <select class="form-input" style="width:auto;">
-              <option>All Statuses</option>
-              <option>Active</option>
-              <option>Upcoming</option>
-              <option>Sold Out</option>
-            </select>
-            <button class="btn btn-primary" style="margin-left:auto;white-space:nowrap;">Create Booking</button>
-          </div>
-          <!-- Data table -->
-          <table class="pt-table">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Sport</th>
-                <th>Date</th>
-                <th>Status</th>
-                <th>Actions</th>
-              </tr>
-            </thead>
+  <!-- 12d: CRUD Interface -->
+  <div class="page-panel" id="panel-crud">
+    <div class="page-frame">
+      <div class="page-frame-label">12D — CRUD Interface (Manage Bookings)</div>
+      <div class="page-frame-body">
+        <div style="padding:24px 32px;display:flex;justify-content:space-between;align-items:center;">
+          <div style="font-size:20px;font-weight:700;letter-spacing:3px;color:var(--white);text-transform:uppercase;">MANAGE BOOKINGS</div>
+          <button class="btn btn-primary">+ NEW BOOKING</button>
+        </div>
+        <div style="padding:0 32px 16px;display:flex;gap:12px;">
+          <div class="search-wrap" style="flex:1;"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2"><circle cx="11" cy="11" r="7"/><line x1="16.5" y1="16.5" x2="21" y2="21"/></svg><input type="text" placeholder="Search bookings..." readonly style="width:100%;padding:10px 14px 10px 36px;background:var(--gray-900);border:1px solid var(--gray-700);border-radius:4px;color:var(--white);font-family:var(--font);font-size:14px;"></div>
+          <select style="padding:10px 14px;background:var(--gray-900);border:1px solid var(--gray-700);border-radius:4px;color:var(--white);font-family:var(--font);font-size:14px;"><option>All Sports</option></select>
+          <select style="padding:10px 14px;background:var(--gray-900);border:1px solid var(--gray-700);border-radius:4px;color:var(--white);font-family:var(--font);font-size:14px;"><option>All Status</option></select>
+        </div>
+        <div style="padding:0 32px;">
+          <table class="mock-table">
+            <thead><tr><th>Name</th><th>Sport</th><th>Date</th><th>Status</th><th>Actions</th></tr></thead>
             <tbody>
+              <tr>
+                <td>Carlos Sandoval</td>
+                <td><span class="tag compact" style="background:var(--gold);color:var(--black);">PICKLEBALL</span></td>
+                <td>Mar 15, 2026</td>
+                <td><span class="tag compact" style="background:var(--gold);color:var(--black);">ACTIVE</span></td>
+                <td><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2" style="cursor:pointer;margin-right:8px;"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#E53E3E" stroke-width="2" style="cursor:pointer;"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14H7L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg></td>
+              </tr>
               <tr>
                 <td>Maria Santos</td>
-                <td><span class="tag-sport">Pickleball</span></td>
-                <td>Mar 15, 2026</td>
-                <td><span class="badge-active">Active</span></td>
-                <td>
-                  <div class="pt-table-actions">
-                    <button class="pt-icon-btn" title="Edit">
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.5 2.5L13.5 4.5L5.5 12.5H3.5V10.5L11.5 2.5Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><line x1="9.5" y1="4.5" x2="11.5" y2="6.5" stroke="currentColor" stroke-width="1.5"/></svg>
-                    </button>
-                    <button class="pt-icon-btn" title="Delete">
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><polyline points="3,5 13,5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M6 5V3h4v2" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><path d="M4 5l1 9h6l1-9" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <td>Juan Cruz</td>
-                <td><span class="tag-sport">Volleyball</span></td>
+                <td><span class="tag compact" style="background:var(--peri);color:var(--black);">VOLLEYBALL</span></td>
                 <td>Mar 16, 2026</td>
-                <td><span class="badge-upcoming">Upcoming</span></td>
-                <td>
-                  <div class="pt-table-actions">
-                    <button class="pt-icon-btn" title="Edit">
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.5 2.5L13.5 4.5L5.5 12.5H3.5V10.5L11.5 2.5Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><line x1="9.5" y1="4.5" x2="11.5" y2="6.5" stroke="currentColor" stroke-width="1.5"/></svg>
-                    </button>
-                    <button class="pt-icon-btn" title="Delete">
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><polyline points="3,5 13,5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M6 5V3h4v2" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><path d="M4 5l1 9h6l1-9" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg>
-                    </button>
-                  </div>
-                </td>
+                <td><span class="tag compact" style="background:var(--peri);color:var(--black);">UPCOMING</span></td>
+                <td><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2" style="cursor:pointer;margin-right:8px;"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#E53E3E" stroke-width="2" style="cursor:pointer;"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14H7L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg></td>
               </tr>
               <tr>
-                <td>Ana Reyes</td>
-                <td><span class="tag-sport">Football</span></td>
-                <td>Mar 14, 2026</td>
-                <td><span class="badge-active">Active</span></td>
-                <td>
-                  <div class="pt-table-actions">
-                    <button class="pt-icon-btn" title="Edit">
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.5 2.5L13.5 4.5L5.5 12.5H3.5V10.5L11.5 2.5Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><line x1="9.5" y1="4.5" x2="11.5" y2="6.5" stroke="currentColor" stroke-width="1.5"/></svg>
-                    </button>
-                    <button class="pt-icon-btn" title="Delete">
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><polyline points="3,5 13,5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M6 5V3h4v2" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><path d="M4 5l1 9h6l1-9" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg>
-                    </button>
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <td>Carlos Tan</td>
-                <td><span class="tag-sport">Golf</span></td>
+                <td>Team Bravo</td>
+                <td><span class="tag compact" style="background:var(--plum);color:var(--gold);">FOOTBALL</span></td>
                 <td>Mar 17, 2026</td>
-                <td><span class="badge-upcoming">Upcoming</span></td>
-                <td>
-                  <div class="pt-table-actions">
-                    <button class="pt-icon-btn" title="Edit">
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.5 2.5L13.5 4.5L5.5 12.5H3.5V10.5L11.5 2.5Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><line x1="9.5" y1="4.5" x2="11.5" y2="6.5" stroke="currentColor" stroke-width="1.5"/></svg>
-                    </button>
-                    <button class="pt-icon-btn" title="Delete">
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><polyline points="3,5 13,5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M6 5V3h4v2" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><path d="M4 5l1 9h6l1-9" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg>
-                    </button>
-                  </div>
-                </td>
+                <td><span class="tag compact" style="background:var(--gold);color:var(--black);">ACTIVE</span></td>
+                <td><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2" style="cursor:pointer;margin-right:8px;"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#E53E3E" stroke-width="2" style="cursor:pointer;"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14H7L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg></td>
               </tr>
               <tr>
-                <td>Lisa Park</td>
-                <td><span class="tag-sport">Pickleball</span></td>
-                <td>Mar 13, 2026</td>
-                <td><span class="badge-soldout">Sold Out</span></td>
-                <td>
-                  <div class="pt-table-actions">
-                    <button class="pt-icon-btn" title="Edit">
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M11.5 2.5L13.5 4.5L5.5 12.5H3.5V10.5L11.5 2.5Z" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><line x1="9.5" y1="4.5" x2="11.5" y2="6.5" stroke="currentColor" stroke-width="1.5"/></svg>
-                    </button>
-                    <button class="pt-icon-btn" title="Delete">
-                      <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg"><polyline points="3,5 13,5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><path d="M6 5V3h4v2" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><path d="M4 5l1 9h6l1-9" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/></svg>
-                    </button>
-                  </div>
-                </td>
+                <td>Jun Reyes</td>
+                <td><span class="tag compact" style="background:var(--gray-300);color:var(--black);">GOLF</span></td>
+                <td>Mar 18, 2026</td>
+                <td><span class="tag compact" style="background:var(--gray-700);color:var(--gray-300);">CLOSED</span></td>
+                <td><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2" style="cursor:pointer;margin-right:8px;"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.121 2.121 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#E53E3E" stroke-width="2" style="cursor:pointer;"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-2 14H7L5 6"/><path d="M10 11v6"/><path d="M14 11v6"/></svg></td>
               </tr>
             </tbody>
           </table>
-          <!-- Pagination -->
-          <div class="pt-pagination">
-            <span class="pt-pagination-info">Showing 1–5 of 24</span>
-            <div class="pt-pagination-btns">
-              <button class="btn btn-secondary btn-sm">Previous</button>
-              <button class="btn btn-secondary btn-sm">Next</button>
-            </div>
+        </div>
+        <div style="padding:16px 32px 24px;display:flex;justify-content:space-between;align-items:center;">
+          <span style="font-size:13px;color:var(--gray-500);">Showing 1-4 of 128 bookings</span>
+          <div style="display:flex;gap:4px;">
+            <button style="padding:6px 12px;background:var(--gray-900);border:1px solid var(--gray-800);border-radius:4px;color:var(--gray-500);font-family:var(--font);font-size:13px;cursor:pointer;">←</button>
+            <button style="padding:6px 12px;background:var(--plum);border:1px solid var(--plum);border-radius:4px;color:var(--gold);font-family:var(--font);font-size:13px;cursor:pointer;">1</button>
+            <button style="padding:6px 12px;background:var(--gray-900);border:1px solid var(--gray-800);border-radius:4px;color:var(--gray-500);font-family:var(--font);font-size:13px;cursor:pointer;">2</button>
+            <button style="padding:6px 12px;background:var(--gray-900);border:1px solid var(--gray-800);border-radius:4px;color:var(--gray-500);font-family:var(--font);font-size:13px;cursor:pointer;">3</button>
+            <button style="padding:6px 12px;background:var(--gray-900);border:1px solid var(--gray-800);border-radius:4px;color:var(--gray-500);font-family:var(--font);font-size:13px;cursor:pointer;">→</button>
           </div>
         </div>
       </div>
     </div>
+  </div>
 
-    <!-- 12e: ERP Dashboard -->
-    <div class="page-treatment" id="treatment-12e" style="display:none">
-      <div class="mockup-frame">
-        <div class="pt-erp-layout">
-          <!-- Sidebar -->
-          <div class="pt-erp-sidebar">
-            <!-- Grid / Home icon (active) -->
-            <span class="pt-erp-sidebar-icon active-icon">
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="2" y="2" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.5"/><rect x="11" y="2" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.5"/><rect x="2" y="11" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.5"/><rect x="11" y="11" width="7" height="7" rx="1" stroke="currentColor" stroke-width="1.5"/></svg>
-            </span>
-            <!-- Calendar icon -->
-            <span class="pt-erp-sidebar-icon">
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="2" y="4" width="16" height="14" rx="2" stroke="currentColor" stroke-width="1.5"/><line x1="2" y1="8" x2="18" y2="8" stroke="currentColor" stroke-width="1.5"/><line x1="6" y1="2" x2="6" y2="6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><line x1="14" y1="2" x2="14" y2="6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
-            </span>
-            <!-- People icon -->
-            <span class="pt-erp-sidebar-icon">
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="7" cy="7" r="3" stroke="currentColor" stroke-width="1.5"/><path d="M1 17c0-3.314 2.686-6 6-6s6 2.686 6 6" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/><circle cx="14" cy="6" r="2.5" stroke="currentColor" stroke-width="1.5"/><path d="M17 16c0-2.761-1.343-5-3-5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
-            </span>
-            <!-- Chart icon -->
-            <span class="pt-erp-sidebar-icon">
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><rect x="3" y="10" width="3" height="7" rx="1" stroke="currentColor" stroke-width="1.5"/><rect x="8.5" y="6" width="3" height="11" rx="1" stroke="currentColor" stroke-width="1.5"/><rect x="14" y="3" width="3" height="14" rx="1" stroke="currentColor" stroke-width="1.5"/></svg>
-            </span>
-            <!-- Gear icon -->
-            <span class="pt-erp-sidebar-icon">
-              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg"><circle cx="10" cy="10" r="3" stroke="currentColor" stroke-width="1.5"/><path d="M10 2v2M10 16v2M2 10h2M16 10h2M4.222 4.222l1.414 1.414M14.364 14.364l1.414 1.414M4.222 15.778l1.414-1.414M14.364 5.636l1.414-1.414" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></svg>
-            </span>
-          </div>
-          <!-- Main content -->
-          <div class="pt-erp-main">
-            <!-- KPI cards -->
-            <div class="pt-kpi-grid" style="margin-bottom:20px;">
-              <div class="pt-kpi-card">
-                <span class="pt-kpi-label">Revenue</span>
-                <span class="pt-kpi-value">$48.2K</span>
-              </div>
-              <div class="pt-kpi-card">
-                <span class="pt-kpi-label">Bookings</span>
-                <span class="pt-kpi-value">312</span>
-              </div>
-              <div class="pt-kpi-card">
-                <span class="pt-kpi-label">Utilization</span>
-                <span class="pt-kpi-value">82%</span>
-              </div>
-              <div class="pt-kpi-card">
-                <span class="pt-kpi-label">NPS</span>
-                <span class="pt-kpi-value">4.6</span>
-              </div>
-            </div>
-            <!-- Chart placeholders -->
-            <div class="pt-chart-row">
-              <div class="pt-chart-placeholder">Revenue Chart</div>
-              <div class="pt-chart-placeholder">Booking Trends</div>
-            </div>
-            <!-- Recent transactions table -->
-            <table class="pt-table">
-              <thead>
-                <tr>
-                  <th>Date</th>
-                  <th>Description</th>
-                  <th>Amount</th>
-                  <th>Status</th>
-                </tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>Mar 12, 2026</td>
-                  <td>Pickleball Court Booking — Mixed Doubles</td>
-                  <td>₱2,400</td>
-                  <td><span class="badge-active">Active</span></td>
-                </tr>
-                <tr>
-                  <td>Mar 12, 2026</td>
-                  <td>Volleyball Open Practice — Group Session</td>
-                  <td>₱1,800</td>
-                  <td><span class="badge-upcoming">Upcoming</span></td>
-                </tr>
-                <tr>
-                  <td>Mar 11, 2026</td>
-                  <td>Golf Private Lesson — 1 Hour</td>
-                  <td>₱3,200</td>
-                  <td><span class="badge-active">Active</span></td>
-                </tr>
-                <tr>
-                  <td>Mar 11, 2026</td>
-                  <td>Football Youth League Registration</td>
-                  <td>₱5,000</td>
-                  <td><span class="badge-active">Active</span></td>
-                </tr>
-                <tr>
-                  <td>Mar 10, 2026</td>
-                  <td>Pickleball Tournament Entry — Singles</td>
-                  <td>₱1,200</td>
-                  <td><span class="badge-soldout">Sold Out</span></td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
+  <!-- 12e: ERP Dashboard -->
+  <div class="page-panel" id="panel-erp">
+    <div class="page-frame">
+      <div class="page-frame-label">12E — ERP Dashboard (Operations Overview)</div>
+      <div class="page-frame-body" style="display:flex;min-height:500px;">
+        <div style="width:56px;background:var(--gray-900);border-right:1px solid var(--gray-800);display:flex;flex-direction:column;align-items:center;padding-top:16px;gap:20px;">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#F0DFA0" stroke-width="2"><rect x="3" y="3" width="7" height="7"/><rect x="14" y="3" width="7" height="7"/><rect x="3" y="14" width="7" height="7"/><rect x="14" y="14" width="7" height="7"/></svg>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2"><path d="M17 21v-2a4 4 0 00-4-4H5a4 4 0 00-4 4v2"/><circle cx="9" cy="7" r="4"/><path d="M23 21v-2a4 4 0 00-3-3.87"/><path d="M16 3.13a4 4 0 010 7.75"/></svg>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#888" stroke-width="2"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 01-2.83 2.83l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>
         </div>
-      </div>
-    </div>
-
-    <!-- 12f: Scheduling View -->
-    <div class="page-treatment" id="treatment-12f" style="display:none">
-      <div class="mockup-frame">
-        <div class="pt-schedule-inner">
-          <!-- Toggle bar -->
-          <div class="pt-toggle-bar" style="margin-bottom:20px;">
-            <button class="btn btn-secondary btn-sm">DAY</button>
-            <button class="btn btn-primary btn-sm">WEEK</button>
-            <button class="btn btn-secondary btn-sm">MONTH</button>
+        <div style="flex:1;padding:24px;">
+          <div style="display:grid;grid-template-columns:repeat(4,1fr);gap:16px;margin-bottom:24px;">
+            <div class="mock-stat"><div class="stat-value">₱3.4M</div><div class="stat-label">Revenue (MTD)</div></div>
+            <div class="mock-stat"><div class="stat-value">1,247</div><div class="stat-label">Total Bookings</div></div>
+            <div class="mock-stat"><div class="stat-value" style="color:var(--peri);">91%</div><div class="stat-label">Utilization</div></div>
+            <div class="mock-stat"><div class="stat-value" style="color:var(--gold);">4.7</div><div class="stat-label">NPS Score</div></div>
           </div>
-          <!-- Calendar grid -->
-          <table class="pt-calendar-grid">
-            <thead>
-              <tr>
-                <th style="width:56px;"></th>
-                <th>MON</th>
-                <th>TUE</th>
-                <th>WED</th>
-                <th>THU</th>
-                <th>FRI</th>
-                <th>SAT</th>
-                <th>SUN</th>
-              </tr>
-            </thead>
+          <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;margin-bottom:24px;">
+            <div style="background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;padding:20px;min-height:150px;">
+              <div style="font-size:11px;font-weight:600;letter-spacing:2px;color:var(--gray-500);margin-bottom:12px;">REVENUE TREND</div>
+              <div style="display:flex;align-items:flex-end;gap:8px;height:100px;">
+                <div style="flex:1;background:var(--plum);border-radius:2px;height:40%;"></div>
+                <div style="flex:1;background:var(--plum);border-radius:2px;height:55%;"></div>
+                <div style="flex:1;background:var(--plum);border-radius:2px;height:45%;"></div>
+                <div style="flex:1;background:var(--plum);border-radius:2px;height:70%;"></div>
+                <div style="flex:1;background:var(--plum);border-radius:2px;height:65%;"></div>
+                <div style="flex:1;background:var(--gold);border-radius:2px;height:85%;"></div>
+              </div>
+            </div>
+            <div style="background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;padding:20px;min-height:150px;">
+              <div style="font-size:11px;font-weight:600;letter-spacing:2px;color:var(--gray-500);margin-bottom:12px;">BOOKINGS BY SPORT</div>
+              <div style="display:flex;gap:16px;align-items:center;margin-top:24px;">
+                <div style="width:80px;height:80px;border-radius:50%;background:conic-gradient(var(--gold) 0% 40%,var(--peri) 40% 65%,var(--plum) 65% 85%,var(--gray-300) 85% 100%);"></div>
+                <div style="font-size:12px;color:var(--gray-500);line-height:2;">
+                  <span style="color:var(--gold);">■</span> Pickleball 40%<br>
+                  <span style="color:var(--peri);">■</span> Volleyball 25%<br>
+                  <span style="color:var(--plum-light);">■</span> Football 20%<br>
+                  <span style="color:var(--gray-300);">■</span> Golf 15%
+                </div>
+              </div>
+            </div>
+          </div>
+          <div style="font-size:11px;font-weight:600;letter-spacing:2px;color:var(--gray-500);margin-bottom:8px;">RECENT TRANSACTIONS</div>
+          <table class="mock-table">
+            <thead><tr><th>Booking</th><th>Sport</th><th>Amount</th><th>Date</th></tr></thead>
             <tbody>
-              <tr>
-                <td class="pt-time-cell">8AM</td>
-                <td></td><td></td><td></td><td></td><td></td><td></td><td></td>
-              </tr>
-              <tr>
-                <td class="pt-time-cell">10AM</td>
-                <td><div class="pt-event-card" style="background:var(--tint-pickleball);border-left:3px solid var(--border-pickleball);">Pickleball — Mixed Doubles</div></td>
-                <td></td>
-                <td><div class="pt-event-card" style="background:var(--tint-football);border-left:3px solid var(--border-football);">Football — Youth League</div></td>
-                <td></td><td></td><td></td><td></td>
-              </tr>
-              <tr>
-                <td class="pt-time-cell">12PM</td>
-                <td></td><td></td><td></td><td></td><td></td><td></td><td></td>
-              </tr>
-              <tr>
-                <td class="pt-time-cell">2PM</td>
-                <td></td>
-                <td><div class="pt-event-card" style="background:var(--tint-volleyball);border-left:3px solid var(--border-volleyball);">Volleyball — Open Practice</div></td>
-                <td></td><td></td><td></td><td></td><td></td>
-              </tr>
-              <tr>
-                <td class="pt-time-cell">4PM</td>
-                <td></td><td></td><td></td><td></td>
-                <td><div class="pt-event-card" style="background:var(--tint-golf);border-left:3px solid var(--border-golf);">Golf — Private Lesson</div></td>
-                <td></td><td></td>
-              </tr>
-              <tr>
-                <td class="pt-time-cell">6PM</td>
-                <td></td><td></td><td></td><td></td><td></td><td></td><td></td>
-              </tr>
+              <tr><td>Court 3 — 2hr</td><td><span class="tag compact" style="background:var(--gold);color:var(--black);">PICKLEBALL</span></td><td style="color:var(--gold);">₱1,200</td><td>Mar 12</td></tr>
+              <tr><td>Pitch A — 1hr</td><td><span class="tag compact" style="background:var(--plum);color:var(--gold);">FOOTBALL</span></td><td style="color:var(--gold);">₱3,500</td><td>Mar 12</td></tr>
+              <tr><td>Bay 7 — 1hr</td><td><span class="tag compact" style="background:var(--gray-300);color:var(--black);">GOLF</span></td><td style="color:var(--gold);">₱800</td><td>Mar 11</td></tr>
             </tbody>
           </table>
-          <!-- Booking modal -->
-          <div class="pt-modal-backdrop">
-            <div class="pt-modal-card">
-              <h3 class="pt-modal-title">Book a Session</h3>
-              <div class="pt-form-field">
-                <label class="pt-form-label">Sport</label>
-                <select class="form-input">
-                  <option>Pickleball</option>
-                  <option>Volleyball</option>
-                  <option>Football</option>
-                  <option>Golf</option>
-                </select>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- 12f: Scheduling View -->
+  <div class="page-panel" id="panel-schedule">
+    <div class="page-frame">
+      <div class="page-frame-label">12F — Scheduling View (Court &amp; Field Booking)</div>
+      <div class="page-frame-body" style="padding:24px 32px;position:relative;">
+        <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:16px;">
+          <div style="font-size:18px;font-weight:700;letter-spacing:3px;color:var(--white);text-transform:uppercase;">MARCH 10–14, 2026</div>
+          <div class="sched-toggle">
+            <button>DAY</button>
+            <button class="active">WEEK</button>
+            <button>MONTH</button>
+          </div>
+        </div>
+        <div class="sched-grid">
+          <div class="sched-header"></div>
+          <div class="sched-header">MON 10</div>
+          <div class="sched-header">TUE 11</div>
+          <div class="sched-header">WED 12</div>
+          <div class="sched-header">THU 13</div>
+          <div class="sched-header">FRI 14</div>
+          <div class="sched-time">8 AM</div>
+          <div class="sched-cell"><div class="sched-event" style="background:var(--gold);color:var(--black);">PB Court 1</div></div>
+          <div class="sched-cell"></div>
+          <div class="sched-cell"><div class="sched-event" style="background:var(--peri);color:var(--black);">VB Court A</div></div>
+          <div class="sched-cell"></div>
+          <div class="sched-cell"><div class="sched-event" style="background:var(--gold);color:var(--black);">PB Court 3</div></div>
+          <div class="sched-time">9 AM</div>
+          <div class="sched-cell"><div class="sched-event" style="background:var(--gold);color:var(--black);">PB Court 1</div></div>
+          <div class="sched-cell"><div class="sched-event" style="background:var(--plum);color:var(--gold);">FB Pitch A</div></div>
+          <div class="sched-cell"></div>
+          <div class="sched-cell"><div class="sched-event" style="background:var(--gray-300);color:var(--black);">Golf Bay 2</div></div>
+          <div class="sched-cell"></div>
+          <div class="sched-time">10 AM</div>
+          <div class="sched-cell"></div>
+          <div class="sched-cell"><div class="sched-event" style="background:var(--plum);color:var(--gold);">FB Pitch A</div></div>
+          <div class="sched-cell"><div class="sched-event" style="background:var(--gold);color:var(--black);">PB Court 2</div></div>
+          <div class="sched-cell"><div class="sched-event" style="background:var(--peri);color:var(--black);">VB Court B</div></div>
+          <div class="sched-cell"><div class="sched-event" style="background:var(--gray-300);color:var(--black);">Golf Bay 5</div></div>
+          <div class="sched-time">11 AM</div>
+          <div class="sched-cell"><div class="sched-event" style="background:var(--peri);color:var(--black);">VB League</div></div>
+          <div class="sched-cell"></div>
+          <div class="sched-cell"><div class="sched-event" style="background:var(--gold);color:var(--black);">PB Court 2</div></div>
+          <div class="sched-cell"><div class="sched-event" style="background:var(--peri);color:var(--black);">VB Court B</div></div>
+          <div class="sched-cell"></div>
+          <div class="sched-time">12 PM</div>
+          <div class="sched-cell"></div>
+          <div class="sched-cell"><div class="sched-event" style="background:var(--gold);color:var(--black);">PB Court 3</div></div>
+          <div class="sched-cell"></div>
+          <div class="sched-cell"></div>
+          <div class="sched-cell"><div class="sched-event" style="background:var(--plum);color:var(--gold);">FB Pitch B</div></div>
+        </div>
+        <div style="position:absolute;inset:0;background:rgba(0,0,0,0.6);display:flex;align-items:center;justify-content:center;border-radius:8px;">
+          <div style="background:var(--gray-900);border:1px solid var(--gray-800);border-radius:8px;padding:32px;width:360px;">
+            <div style="font-size:16px;font-weight:700;letter-spacing:2px;color:var(--white);text-transform:uppercase;margin-bottom:20px;">NEW BOOKING</div>
+            <div style="margin-bottom:12px;">
+              <label style="font-size:11px;font-weight:600;letter-spacing:2px;color:var(--gray-500);display:block;margin-bottom:6px;">SPORT</label>
+              <select style="width:100%;padding:10px 14px;background:var(--black);border:1px solid var(--gray-700);border-radius:4px;color:var(--white);font-family:var(--font);font-size:14px;"><option>Pickleball</option></select>
+            </div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;margin-bottom:12px;">
+              <div>
+                <label style="font-size:11px;font-weight:600;letter-spacing:2px;color:var(--gray-500);display:block;margin-bottom:6px;">DATE</label>
+                <input type="text" value="2026-03-12" readonly style="width:100%;padding:10px 14px;background:var(--black);border:1px solid var(--gold);border-radius:4px;color:var(--white);font-family:var(--font);font-size:14px;box-shadow:0 0 0 2px rgba(240,223,160,0.15);">
               </div>
-              <div class="pt-form-field">
-                <label class="pt-form-label">Date</label>
-                <input type="date" class="form-input" value="2026-03-15">
+              <div>
+                <label style="font-size:11px;font-weight:600;letter-spacing:2px;color:var(--gray-500);display:block;margin-bottom:6px;">TIME</label>
+                <input type="text" value="10:00 AM" readonly style="width:100%;padding:10px 14px;background:var(--black);border:1px solid var(--gray-700);border-radius:4px;color:var(--white);font-family:var(--font);font-size:14px;">
               </div>
-              <div class="pt-form-field">
-                <label class="pt-form-label">Time</label>
-                <select class="form-input">
-                  <option>10:00 AM</option>
-                  <option>11:00 AM</option>
-                  <option>12:00 PM</option>
-                  <option>1:00 PM</option>
-                  <option>2:00 PM</option>
-                  <option>3:00 PM</option>
-                  <option>4:00 PM</option>
-                </select>
-              </div>
-              <div class="pt-form-field">
-                <label class="pt-form-label">Court / Field</label>
-                <select class="form-input">
-                  <option>Court 1</option>
-                  <option>Court 2</option>
-                  <option>Court 3</option>
-                  <option>Field A</option>
-                  <option>Field B</option>
-                </select>
-              </div>
-              <div class="pt-form-field">
-                <label class="pt-form-label">Participants</label>
-                <input type="number" class="form-input" value="2" min="1" max="20">
-              </div>
-              <div class="pt-modal-btns">
-                <button class="btn btn-primary">Confirm Booking</button>
-                <button class="btn btn-ghost">Cancel</button>
-              </div>
+            </div>
+            <div style="margin-bottom:12px;">
+              <label style="font-size:11px;font-weight:600;letter-spacing:2px;color:var(--gray-500);display:block;margin-bottom:6px;">COURT / FIELD</label>
+              <select style="width:100%;padding:10px 14px;background:var(--black);border:1px solid var(--gray-700);border-radius:4px;color:var(--white);font-family:var(--font);font-size:14px;"><option>Court 2 — BGC</option></select>
+            </div>
+            <div style="margin-bottom:20px;">
+              <label style="font-size:11px;font-weight:600;letter-spacing:2px;color:var(--gray-500);display:block;margin-bottom:6px;">PARTICIPANTS</label>
+              <input type="text" value="4" readonly style="width:100%;padding:10px 14px;background:var(--black);border:1px solid var(--gray-700);border-radius:4px;color:var(--white);font-family:var(--font);font-size:14px;">
+            </div>
+            <div style="display:flex;gap:12px;">
+              <button class="btn btn-primary" style="flex:1;">CONFIRM</button>
+              <button class="btn btn-ghost" style="flex:1;">CANCEL</button>
             </div>
           </div>
         </div>
       </div>
     </div>
-
   </div>
-</section>
 
-<!-- ==================== SECTION 13: SAMPLE LAYOUT ==================== -->
-<section class="section" id="section-13">
-  <div class="container">
-    <p class="section-number">13</p>
-    <h2 class="section-title">SAMPLE LAYOUT</h2>
+</div>
 
-    <div class="mockup-frame">
+<!-- ==================== 13. SAMPLE LAYOUT ==================== -->
+<div class="section" id="sample">
+  <div class="section-number">13</div>
+  <div class="section-title">Sample Layout</div>
+  <div class="section-desc">Everything together. A representative page showing nav, hero, content cards, and footer.</div>
 
-      <!-- Nav bar -->
-      <div style="height:64px; background:var(--cream); border-bottom:2px solid var(--black); display:flex; align-items:center; padding:0 32px;">
-        <div style="flex:0 0 auto; display:flex; align-items:center;">
-          <img data-logo="icon" alt="Kosmas" class="logo-img logo-img-icon logo-img--on-cream" style="height: 32px;">
-        </div>
-        <div style="flex:1 1 auto; display:flex; align-items:center; justify-content:center; gap:24px;">
-          <a style="font-family:var(--font-body); font-weight:500; font-size:11px; text-transform:uppercase; letter-spacing:1px; color:var(--charcoal); text-decoration:none; cursor:default;">HOME</a>
-          <a style="font-family:var(--font-body); font-weight:500; font-size:11px; text-transform:uppercase; letter-spacing:1px; color:var(--charcoal); text-decoration:none; cursor:default;">EXPERIENCES</a>
-          <a style="font-family:var(--font-body); font-weight:500; font-size:11px; text-transform:uppercase; letter-spacing:1px; color:var(--charcoal); text-decoration:none; cursor:default;">SCHEDULE</a>
-          <a style="font-family:var(--font-body); font-weight:500; font-size:11px; text-transform:uppercase; letter-spacing:1px; color:var(--charcoal); text-decoration:none; cursor:default;">ABOUT</a>
-          <a style="font-family:var(--font-body); font-weight:500; font-size:11px; text-transform:uppercase; letter-spacing:1px; color:var(--charcoal); text-decoration:none; cursor:default;">CONTACT</a>
-        </div>
-        <div style="flex:0 0 auto;">
-          <button class="btn btn-primary" style="padding:8px 20px; font-size:11px;">BOOK NOW</button>
-        </div>
+  <div class="sample-frame">
+    <div class="sample-nav">
+      <img id="sample-logo" alt="Kosmas" style="height:36px;filter:invert(1);">
+      <div class="sample-nav-links">
+        <span>VENUES</span>
+        <span>TECHNOLOGY</span>
+        <span>ABOUT</span>
+        <span>CONTACT</span>
       </div>
-
-      <!-- Hero section -->
-      <div class="sample-hero" style="background:var(--cream); text-align:center; padding:64px 32px; border-bottom:1px solid var(--stone);">
-        <h2 style="font-family:var(--font-heading); font-weight:300; font-size:48px; letter-spacing:3px; line-height:1.1; max-width:700px; margin:0 auto; color:var(--black);">PREMIER ATHLETIC EXPERIENCES</h2>
-        <p style="font-family:var(--font-body); font-weight:300; font-size:15px; color:var(--charcoal); max-width:500px; margin:16px auto 32px;">World-class sports management for athletes, coaches, and venues across Southeast Asia.</p>
-        <div style="display:flex; gap:12px; justify-content:center;">
-          <button class="btn btn-primary">Get Started</button>
-          <button class="btn btn-secondary">Learn More</button>
-        </div>
+    </div>
+    <div class="sample-hero-section">
+      <h2>PLAY BOLD.</h2>
+      <p>Premium sports venues powered by technology. Southeast Asia and beyond.</p>
+      <button class="btn btn-accent" style="font-family:var(--font);">EXPLORE VENUES</button>
+    </div>
+    <div class="sample-content">
+      <div class="sample-content-card">
+        <h4>24/7 ACCESS</h4>
+        <p>Autonomous venues with keycard entry. Play anytime, no staff needed.</p>
       </div>
-
-      <!-- Sport cards grid -->
-      <div class="sport-cards-grid" style="display:grid; grid-template-columns:repeat(4,1fr); gap:16px; padding:32px; border-bottom:1px solid var(--stone);">
-        <div style="background:var(--tint-pickleball); border:1px solid var(--border-pickleball); border-radius:6px; padding:24px;">
-          <div style="font-family:var(--font-heading); font-weight:600; font-size:20px; letter-spacing:1px; color:var(--black); margin-bottom:6px;">Pickleball</div>
-          <div style="font-family:var(--font-body); font-weight:300; font-size:13px; color:var(--charcoal); margin-bottom:12px;">12 active sessions</div>
-          <a style="font-family:var(--font-body); font-weight:500; font-size:13px; color:var(--cyan); text-decoration:none; cursor:default;">Explore →</a>
-        </div>
-        <div style="background:var(--tint-volleyball); border:1px solid var(--border-volleyball); border-radius:6px; padding:24px;">
-          <div style="font-family:var(--font-heading); font-weight:600; font-size:20px; letter-spacing:1px; color:var(--black); margin-bottom:6px;">Volleyball</div>
-          <div style="font-family:var(--font-body); font-weight:300; font-size:13px; color:var(--charcoal); margin-bottom:12px;">8 active sessions</div>
-          <a style="font-family:var(--font-body); font-weight:500; font-size:13px; color:var(--cyan); text-decoration:none; cursor:default;">Explore →</a>
-        </div>
-        <div style="background:var(--tint-football); border:1px solid var(--border-football); border-radius:6px; padding:24px;">
-          <div style="font-family:var(--font-heading); font-weight:600; font-size:20px; letter-spacing:1px; color:var(--black); margin-bottom:6px;">Football</div>
-          <div style="font-family:var(--font-body); font-weight:300; font-size:13px; color:var(--charcoal); margin-bottom:12px;">6 active sessions</div>
-          <a style="font-family:var(--font-body); font-weight:500; font-size:13px; color:var(--cyan); text-decoration:none; cursor:default;">Explore →</a>
-        </div>
-        <div style="background:var(--tint-golf); border:1px solid var(--border-golf); border-radius:6px; padding:24px;">
-          <div style="font-family:var(--font-heading); font-weight:600; font-size:20px; letter-spacing:1px; color:var(--black); margin-bottom:6px;">Golf</div>
-          <div style="font-family:var(--font-body); font-weight:300; font-size:13px; color:var(--charcoal); margin-bottom:12px;">4 active sessions</div>
-          <a style="font-family:var(--font-body); font-weight:500; font-size:13px; color:var(--cyan); text-decoration:none; cursor:default;">Explore →</a>
-        </div>
+      <div class="sample-content-card">
+        <h4>INSTANT REPLAY</h4>
+        <p>Camera-powered replay on every court. Review, share, improve.</p>
       </div>
-
-      <!-- Testimonial block -->
-      <div style="text-align:center; padding:48px; border-bottom:1px solid var(--stone);">
-        <div style="max-width:600px; margin:0 auto;">
-          <p style="font-family:var(--font-heading); font-weight:400; font-size:20px; font-style:italic; line-height:1.5; color:var(--black);">"The best athletic management platform in Southeast Asia. Kosmas has transformed how we run our sports facilities."</p>
-          <p style="font-family:var(--font-body); font-weight:300; font-size:13px; color:var(--charcoal); margin-top:16px;">— Maria Santos, Manila Sports Club</p>
-        </div>
+      <div class="sample-content-card">
+        <h4>BOOK IN SECONDS</h4>
+        <p>Venue-branded apps with local payment. GCash, cards, wallets.</p>
       </div>
-
-      <!-- Footer -->
-      <div class="footer-mockup" style="border-top:2px solid var(--black); background:var(--cream); padding:48px 32px 0;">
-        <div class="footer-grid">
-          <div>
-            <img data-logo="icon" alt="Kosmas" class="logo-img logo-img-icon logo-img--on-cream" style="height: 32px;">
-            <p class="footer-col-tagline">Premier athletic experiences across Southeast Asia.</p>
-          </div>
-          <div>
-            <p class="footer-col-heading">Experiences</p>
-            <a class="footer-col-link">Pickleball</a>
-            <a class="footer-col-link">Volleyball</a>
-            <a class="footer-col-link">Football</a>
-            <a class="footer-col-link">Golf</a>
-          </div>
-          <div>
-            <p class="footer-col-heading">Locations</p>
-            <a class="footer-col-link">Manila</a>
-            <a class="footer-col-link">Cebu</a>
-            <a class="footer-col-link">Singapore</a>
-            <a class="footer-col-link">Bangkok</a>
-          </div>
-          <div>
-            <p class="footer-col-heading">Company</p>
-            <a class="footer-col-link">About</a>
-            <a class="footer-col-link">Contact</a>
-            <a class="footer-col-link">Careers</a>
-            <a class="footer-col-link">Press</a>
-          </div>
-        </div>
-        <div class="footer-copyright">© 2026 Kosmas Athletic Ventures. All rights reserved.</div>
-      </div>
-
-    </div><!-- /.mockup-frame -->
+    </div>
+    <div class="sample-footer">
+      <span style="color:var(--gold-dim);">KOSMAS ATHLETIC VENTURES CO.</span>
+      <span>2026</span>
+    </div>
   </div>
-</section>
+</div>
+
+</div><!-- /.container -->
+
+<div style="padding:40px;text-align:center;">
+  <div style="font-size:11px;letter-spacing:3px;color:var(--gray-500);">KOSMAS UI TREATMENT DECK — V1</div>
+</div>
 
 <script>
-  // Page treatment tab switching
-  function showTreatment(id, clickedTab) {
-    document.querySelectorAll('.page-treatment').forEach(el => el.style.display = 'none');
-    document.getElementById(id).style.display = 'block';
-    document.querySelectorAll('.treatment-tab').forEach(el => el.classList.remove('active'));
-    clickedTab.classList.add('active');
-  }
-</script>
-
-<script>
-  // Scroll-spy for TOC links (scroll-based, handles initial load and all 13 sections)
-  (function() {
-    const sections = document.querySelectorAll('.section[id]');
-    const tocLinks = document.querySelectorAll('.toc-link');
-    const tocHeight = 48;
-
-    function updateActive() {
-      const scrollY = window.scrollY;
-      let current = null;
-
-      sections.forEach(function(section) {
-        const top = section.offsetTop - tocHeight - 16;
-        if (scrollY >= top) {
-          current = section.id;
-        }
-      });
-
-      tocLinks.forEach(function(link) {
-        link.classList.remove('active');
-        if (current && link.getAttribute('href') === '#' + current) {
-          link.classList.add('active');
-        }
-      });
-    }
-
-    window.addEventListener('scroll', updateActive, { passive: true });
-    updateActive();
-  })();
-</script>
-
-
-<script>
-(function() {
-  var assets = {
-    icon: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAkYAAAJJCAYAAABPi/i5AAEAAElEQVR42uz9ebTVV53n/z/3/kxnvsO5E3CZZxKmkDBmIgMmQUXb2JVYSXfH6qa/S7u/Wkv9La31s+pbur5lrWW5Sn+rtLvSXaarklJLE03UTGQgYQqEQIAkQIAwXuDO9575fKa9f38ciDFmUjMB+7EWSwTu4a79CZ/zOu/Pe7+30FpjGIbxQRool+4II9U5trnpb81qGIbxQZJmCQzD+KANF4qfGi4WbzYrYRjGB802S2AYxgftVH//aq01TBhvFsMwDBOMDMO4cPUHwdr+4RGkMLcjwzA+eOZRmmEYHyg/YtJQsUKhVuN0oL5kVsQwDBOMDMO4YJWDYOlQqUzJDyj5/hVmRQzDMMHIMIwLVsEPVvYXKhRqIeV6sMSsiGEYHyTzUN8wjA/MINxWDhXD1QA3E1ENVZdZFcMwPkimYmQYxgemDtOHKj5VJOVIU41isyiGYZhgZBjGBRqMYqaP1OpUIk0pUBRqEf2w1qyMYRgmGBmGccGJID9c8alqi3KoKdUDfJhkVsYwDBOMDMO44ISazqFimdByqWNR8kP8wAQjwzBMMDIM4wIzCLdV/HB+X6FCbHsESEYrNWqhnmNWxzAME4wMw7igKEhV6hGj5TLaSaBtl1ItoB7F0wc1t5kVMgzDBCPDMC4oNb9OseqjLRukRblSI4yjlBY4ZnUMwzDByDCMC4YPk4pBTLEWEmBRiyxGqjUCJYig1ayQYRgmGBmGccEoRVzeW6hTUQ7KzRG7WYqhZLBSJ4K8WSHDMEwwMgzjghHZ5EcrAQES7ATKdqmGMbVY48OkAdQdZpUMw3i/mSNBDMN43w3CbQqSQ4UCSAuEACRhrKj4PiF0KUialTIM4/1mKkaGYbzvIsjXYiYPF0tYrkMsIUITakWhUsWPmaQRpgHbMAwTjAzDuCCCUWu5DoPFMsJ20Ei0tAg1Z4PR5BiRMytlGIYJRoZhnPcUpArViNFSFW3ZCNsBIYiFpFCp40egzaN+wzBMMDIM40IQQudIuUo1UkjLRWlBLCVCOpT9kEA3wpNZKcMwTDAyDOO8F0B3qRYQaYllu8RaEcUa4bjUI02kTMXIMAwTjAzDuAAM6saOtN7hEWJhY7keUlhYlkMYK4qVCsVqQAidA9ps2TcMwwQjwzDOY1rgxJArlAOU7YCw0FqgAKRNLVRU/JBIkze3KMMwTDAyDOP8DkbgRJrW/uFRhJ1AIVECtBBg21T9iEKlShSTF4LQrJhhGCYYGYZxXqsHdPUOjYLroaVEaYFGgmXjx4qRUpVIm/PSDMMwwcgwjPNcDNliHQaKJaTrESGIJcQCsGxCYVEs1wgU3RrMkEfDMEwwMgzj/KUgVSzVqfoB2E7jMRoSJSRKCpS0KFZrBCFOhKkaGYZhgpFhGOexGHKFaplAabBsFAItz/6wUFJS9mvUo5AI8mbFDMMwwcgwjPNWAOOqQdioFEmB0hoAJSSxFiAsamGMrxSBptusmGEYJhgZhnHeCqHr9OgQruchNUgh0FqjtUZYFrFwKJTr1DXEAnNemmEYJhgZhnF+6oe1dZhertVxPBcpJaJRMEJpiLXAkg5+rKmHGtNjZBiGCUaGYZy3FCTrEd1DIyXcRBqkjUIjkGgtiDVI2yEIIsrVKjHkBuE2s3KGYZhgZBjGeSeGXC2EwZEituOhlCZWgLTQQqCVQDo2QRgzUigRxnSaw2QNwzDByDCM8zYYVesxpaqPthoHxiqlkcJGCKtxUxI2sYLB0QJhTJeCpFk5wzDeL+b0asMw3jcBjBsqV6lEMdJyiWJNjAQ0Qgi0ECgtwLIZHinhxxqFMMHIMIz3jakYGYbxvokhN1ioEGkb4biN89GERRTrRq+RaPQZYbuMlCpEscBUjAzDMMHIMIzzTj+sjSFXqNSJLQfhJEA2DpBVSqG1RgFKC6TlUA1iQt0IU2b1DMMwwcgwjPOKgqSvmXyid5AQm1rdR1g2CAthSZTW1PwApIWSNqVqnUqgEBCZ1TMMwwQjwzDOKxG01mK6q2GMli5KWo1J16+9IUlJhEBbNtVIU6r5+DDJrJ5hGCYYGYZxXokhV/GhXPeRroeWgkjFaAFKgBCiMflaN85QqwYBw+UyoaJzAO4wK2gYhglGhmGcN0LoLNV8ynUf23VBCpSKoNFZBEIhLRrByHYIhcVoqUYEedOAbRiGCUaGYZw3BuE2BalCpUwtjBCO/er5aGfFaBCCWCuQNtJyKFarKGlCkWEY7x8zx8gwjPecRjsKkazU6kRKIW0HhQYJQmpiHSPQaCwQAi00lpegXK2hIGkqRoZhvF9MxcgwjPecQiRjyNXrdTSNfiKtG3OLzv5ca41SCiEECo3l2BQqZfyQrgjyZhUNwzDByDCM84YGx481WlqNriKlkAgaPUaN21GsASmIlEbLxiyjegyBptusoGEYJhgZhnFeiDW5Wszs3sEygRJYdgJL2NiWdaZqpBFYCCy0FsRCErse/cUKlRCEIDSraBiGCUaGYZwXlCBZD0lVAwXCRmuBRoKWrz5SO+vso7VYCCpBRKkWmOnXhmGYYGQYxvlDg1P1oVSrIqSNQhOjz8wwkmgkWkiUkChACxBY+L7PaLFIDDkzy8gwDBOMDMM4LyhIlmt1qnUfpE2kNEo3AlBjy/5vV46EsLAsi1jDcLGEgqSpGhmGYYKRYRjnBQ1OsVqj6kdgu8SqcXhsfOaRWmMnWiMoKQQIgeW4CMthqFBGQUqb8SKGYZhgZBjG+SCEzmK1Ti1UCGkTa4E6c07a2YqR1K/tM2o0YttOkv6RAjWYrSBlVtIwDBOMDMM459UV04tVn3qkEJZLfGZukRaAEogzt6LG9v1GWIqURkiL/pEyFWUqRoZhmGBkGMZ5oBe+4MdMrgQRYSxQ0uJscUjo3/zva38OEMcxSloUKjVqAWZnmmEYJhgZhnHu02DXAnIj5RqhlCAtlFLEUYDQMVIrLAG2FGd+rkFpbNvGSSQp+RHlAMz0a8Mw3g+mNG0YxnsqhK5KGFPyA2IkEo2OY1KujZDgRxFKSaQQSASWAK1jVKwRWqBiqPiNgGVW0zCM95qpGBmG8Z6KNK2VekihUicWjW35WkU0pVN4Fqg4BB0jtMImxrUthObMnCNBoDWjhbJ5lGYYhglGhmGcB8EI8uW6T6lWR7oeSil0FNKay5CwLXQUgY6xzjxSc2yJEBrQCMtBYzM8UjKP0gzDMMHIMIxznwa7UqtTC2Icz0NrhYgjWnNpPFsgdYilY4QKsYXCASSqccislFiOy2ixTAStZvq1YRgmGBmGcU6LNblytUY9jkHaCBToiFw6iYtCorGERscRllZ4lsQSgliFIAWO41CuVtAax6ymYRgmGBmGcU6LIvKlchU/iIi1ahz9AaQTIIVGCpBSIuIIS0A6lSSVcM/MMlJIy6FUqRJGdGpMODIMwwQjwzDOUYNwW10zveIH+GFMECkaY4oiEjY4KsYSGguN0BG2imhJWWRdiSNAnBkCWfPr1CNSvmaSWVXDMEwwMgzjnKTBKfs4A6UqwrZxXZdKrUwm5dGcBh2UIahDFJDxbKSqkU9JWpMWMgoax4XYFsO1KtUYEGZNDcMwwcgwjHOUgqSvNb4WaGmh0GhibAc8CyyixuM0DagYEUVkExa5pI0rJUKDloJaGDFc8anDdLOqhmGYYGQYxjkphpwfRAR+iMACpVFRSDqVwHXPHiDbCD+xBqUUnuOSTSdBx2gdY1kOQRhTKBbR4AzCbWZlDcMwwcgwjHMyGFXrARU/ACnQWqPiiKZMBtcBVAxnuo601iilsB2LdCqJhQalkLZFFCtGCgUUJM2gR8MwTDAyDOOcFGo6K35Ite6DJVEqAhWRb27Cs0DQCEMAsdZEWuE5guZMkqRrgVIgLCIhGBgZpa6ZbnamGYZhgpFhGOdsMKr6jYqRoHF4rIpC2pqz2BKEjlEqQhGDtAAFKiblgudKVOwTo5G2S6FSJVR0KkialTUMwwQjwzDOOZEmXwsj6kFjWKMmRuqIllwSqUFoRRRFKKUQorHlTMQhCRtSroXQMVprLNejXA+pR6RMMDIMwwQjwzDOOQNwRyzIBQpCpc/0GCmkCskkQGhANI7+0FojhEaicWxJyoOUayOIieOYWFiUawEVX6EgZVbXMAwTjAzDOKeE0FnxmVOoVImFjRKgooCs59CSBqlAKIUtz0y+FgJ0jArqZJPQmk1ho5FSYrsJ/EgzVChjKkaGYZhgZBjGOUdBsq40JT9EWzbSskFpsimPpA22BEtIJAKhFegYqRVSxdhAwm5Mv7YQgMSPYyp+QAStZsu+YRjvFdssgWEY74UI8tUgZLRcBtt+dVdaWy5DSoLWjbPSEI3+IqnVmQNmYxwgm3BwJUS6saG/HmlGylVC6DKP0wzDeK+YipFhGO8JDU7F9ymU60jXAyGIQ598LoN75lOZUI2p1/JMIBL8pmKU8RJYZyZlaySREpRqAXXFdPM4zTAME4wMwzinxJCtByGlWh3puGghCYKA1ly6Uao+M+laqxi0QqKwoXGgLJBOJbAFqChGSgmWTa0eEkZ0miGPhmGYYGQYxjlFQapUq1MPArBsIqVQKibflMWCxvloWjd2pOnGLjULgSUlEsilkiRsCx2FjcZsy6ZUqxPGONq0ARiGYYKRYRjnksZxIDXqfghCorVGCkFzUxMJwLJo9BYhsIRuHCKr1ZmGbMikHRKe12i9lhK0pFSuEkQKM/3aMAwTjAzDOGcMwB0BjKv6Cj9uzCmSgE1Mc9IjQSPZ/GabvkRqiQBsKbCBtAdJx2o8WtOgEFT9gDMt2qbHyDAME4wMwzg3xJAbrTFjoFhHWy4AUbVCWzZFR7PbeJTGmYqRsFBKNI5Fw0KqGA9IW9DkOeg4aDRgC4kfKQZGi5geI8MwTDAyDOOcCkZ+DKVaBMJGIrBFTHPKw9EgoSpo9BlpLVCAFtaZm5JAQugISLo2UoVIrUAKAqWpR7EJRoZhmGBkGMa5I4ROP4golkuNqpCUoGJasllsARJqwKvno72WEAILiraAXDpz5rgQgZCSehBQrlVNMDIMwwQjwzDOHTHkqkFIqVxBOnbjRhNFtDTlcGUjGEkaO9G01q8GorM/l1BzYailOYctQBMjhIUfRpTKVUJFp1llwzBMMDIM40NvQMd3BJrucj2g4gc4joPWChX4tKTTOBIsKL62VvRqVYmz2/YpWlBszaVxLQuURktBoBSj5SphTKc5FsQwDBOMzgEvn+j59YDv32FWwrhgCUkU01oqV6kHEdJy0LFCqJjWpjSuoGjDkNXoNTpTJZKvVoyUUujGISLDzZkMSa8RrBCCWEGxWqMW6C7zOM244D+EjBTNe40JRh9+hWJp1a69+354pOb/o1kN40KkEEk/1pNHyzXqUdwIPCrCEYp8NoMDvRYUG0MdFVKfeYwmABrhSIMjIEwlJZ4rUTpCCVDSoupH+LEyfUbGhRuI/OCOfcdOPHnw0KEfmtUwwehDr3PsmO+f7Btky/Yda3cPll42K2JcaDQ4QSxyFT8giGNi3Qg7jtA0pTxsGD7bY/RaZxuxtW6cGmtBMWFDwpYIFaPPBCM/1gTKrLNxYTpSrvzjrr17f7j/0MGV2daW3WZFTDD60JvY0vznc+bMCY8cOcEzz+2asb2vXDke8G2zMsaFIoLWSGmGSmWUdFBobAH5XJqs6+BCjwVFIcBzXKQQ6CgmDCOklFiWhXXmcVvKJWxtShOFPkIIHC9BuR4yUqzgw2Sz2saF4kTE37wwWt71+OZNa9dv3khLZztzp05eYFbGBKNzQndn518uW7KUw8dP8OCTG1Ivnej/8hHNP/ZqvmBWxzjfKUj5kabiRwjbQQGxCskkEnhCICCERpP1a29AorEhDa0FEmoCIhuGUo4LUdj4PSGp+wHVICLE7EwzLgxHIv5xb8/pr/3s4Ufnb9+9m6VXLGPm7FlfNivz3jAHMb4HxnrW30aTJ+QHa/6Xf/7IY5yuVLk8vHztvGldB0KbTjfUPZ2O+IFZKeM8DUZJXylGS1Wk7QEQBSHNrSkSDgiIfuvTmT5zyMfvfmqr2TDclEl0xVGIoyWW5VCplSjW6sSaHMKst3H+GoA7hkM+tfPg4dXPPLebl17YzSdWXc68i+d+f4zlfMes0HvDVIzeIxM88ZUFF894cPGSJRwf6OfeR9bx6y37Zuwf1l8r22LpAJjdBMZ5SYPjR1CoVMF20EIQByFN6RSu9Zvhjo0bkODsBOzX/hAQCghtGGrKZiAMG79nOQRKU6mHhJpO8+/IOF+dgL95ZTT44bpte1b/+okNPLt7D0tXLOfaq67emLG8rWaF3jumYvQecgUnl1+2gGPDQ+zYf4gnnnuek6MFbli68PaJeW9J1WKeB0e74HtmtYzzRQxZPwwp1erobBZL2mgVk0ul8BqnfiAgavRa/26l6GwTtgVFCbWWbKZRUVIaS9ogHcp1n0jTalbbON+c0ny1JphzoD+8/alnn+OlfXvp7+9lxuRJfHzVdTS59mNtcI9ZKROMzkkJHRzoyrp3rly2eG1/ucqJkYDtB1+hb3iQ65ZdNmPpzM5UK9w7AHe0w11mxYzzIhhpcsVyFT8MEdJGi0bYyWXTuBZDAkINzm+FoUaViLPzjM6SUMtm0riWjdAaISRS2FSqNfyArjhptuwb54cBre4IhewcFty849Dwoqd2vEBPby+jxRpTJ03lzz7z7+hM2d8fB980q2WC0TlrjOM2ngGPa+HUgoVr/23Dc8SOy+HROvdueJbTwzO7V1w8/YvjU2JjbJEzlSPjfBBF5EcLJaJY40qJUgrLsmjOZbAFQwD6Nfees03Xr/7/V4ORAiSJhIPn2oRKIbRGCyiVq9RqEXHSNsHIOOf1w9qakLN7Ar747IEeHtq8g/5yHR1EtGSaWL3qeqa0eN+dCH9uVssEo/OCo+ldNm9S79Hhka5fP7ODbMd4RuOYR7bt4tiJk6xevuiKBd25YQ32GDANdcY5zddMKlSrxNpCSos4VrhSk0u4ONB3pn/oNRWj3yQjcWbY45ldaSFAQoJnWYRKg5aEWlKuh1SDgEjZraZT0jiXnYKvluDyV0aj1U/ueJEnn9+LTqSx01m0LnDTVZdz2fS2dSYUvX/MLeV9kNAcbJXct2bJRayY2U1YKaGdJL6bZffJYX6yYSePHehfczjg747CP5gVM85VvfCFwKJrsFIHaSE0xLUqGcci5zok4KALPRKqQgDy7KTrGIA4jhsVJA0SWUvB7pYkdOQy+JUykYqJhEWxFjJSqiLlbxq5DeNc0g9rj8I/nIYv7xqOV//zY9v5xTP78FNtRHYSHVS4YsFMrrx4IsmYvWbF3j+mYvQ+aJONRrnJabfvY5df9o2jP1/PydFhEk15hJdiX/8ovY9toe+yOayYNfnzfs6ZNBM+albOONdE0Fo9syNNWDaWsLHRZFwbT+hXp16f3bKvBCAaDdhS61c/rQlBeHb3mgPVtOekdFxFCIGwbPw4JIzMsSDGufsBogxLTitu3bL/FA9v3kVvRZAbO4WYmLg8xNimNItnTqLN496UjveAZRbufWIqRu+TuB7mbBia1ZV/cM2KS2i3fKJSkVjbiFQLJSvDg1te4t6nn2f78cLq50NOmFUzzjUaHN+H0dEirpvAQiN0TCaVxHGcs9vwo7d8Da1fnXV0tkm7OddEHDeqSpZlUQ8Dav6ZWUaGcQ45rflSAa7fPVC/9eeb9/NvT+3iUEHh5rvwtSCuVRmbSXLdgrnM627d3SR5rN2yzOac95GpGL1POhPODwBC6Lx67pTuai2c/29P76ReTyLTzdRDC5Vw2LD3OCd6R/j4lYu6g4ltemyCb42HvzAraJwLFCTrgaJYKuO4+cZjsiikKd2CeyYY/dYnM/0GHyL0a3qOIHSgr7WlaTLqGAKFlhI/CCnVagQx3eYuZpwrjsXq74ciecuBwVrXgztfYPP+Y9it3SRzKXwEhCWa8Fk6cxZXXDR+qEXwQAfcaVbu/WUqRu+zbvirdsld1y2cOXTNornIagG/ViESDnUnDfluDlcEP35yB7/a/jIvj8ZfOxBz/+lIf8msnnEOBKNUNQioByHSslBxhI4jmtJpEnZj+72EqoTqq5vy9Rvfhs7uXJNQyzflsIhRKkYIQag0xXKdesh0M+TROBcch2+fDOUX1x/s7brn6WfZfmIE2idQFh44CWqVUVxV5rJp41g6fTztNnd1w1+ZlTPB6ILQBd9r87j7uksvYvnsyVAdgbAOlk0NF9ncRV/k8Iste7h3w07291fWFIRY1QefM6tnfJjFkC2WKwRKI4SFUgqpQprSCVybooDwzYbTKfG753ucrRi1ZDO4tkTHIVprEBalao1qoLpfPxPJMD5MTsLX98Oju4f8Lz+85xC/3LGXfSM+onkMysuiLYvIL5FQFabl01wzfxZTW911bkiPWb0PhilCf0DSsGNas/jxtQum3do/PMJLA0MEKkZ7GSqRwEo14ceKDQd6qNZrrFp08ar5k1o7I4u8GfBlfBgNam6LBbnhYoVYC0CDinBRZNMJEi4HXxN4osbRH425RK+lReORHBosQcmCYibh4lmCWhSihQXColwPqEcxMTJrVt/4MDoBfzOouf3F09XuDS++zPbDpyhbOURrJ7600XFEytFYlVHGOhHXzp3K7I7ExlmSj5jVM8HogtMG92hw5o9ryg9fdtGq4obnOB35KCtFDfBjSObaESrDs0d6GCpspbTikvnzJnbNl2mqZt6R8WETC3Ix5IrVGhEgYrAtgWNBxrGwYciC0plgFL6T1zx7XppnSWxLoFUEWoNlUw819VhjKkbGh1EP/HVvzBeeO1ZMPbbzRfb1DhNnWgicJmpBjGcJEkTYUYm0qrJ01gQWTeqiRfKAWb0PlnmU9gFqh7uaJQ8tmTqmd/XiuTSrOsHIAHYcohufhImcDHFmDEcqkn95fCu/eGYP+yv67w7Bj06D6TsyPjRC6CyFXDEwNIqXyGB7LmFQJyEhn0vjQF+syZ4NPFJQdS2bOIxQSjUatbUmVHHjEZqgrx3ucqAv5UG+KUMU+AghsB2XkUqV0XKNOkw3q298mByDvz8S8pcPPX8i9ZOnnmPPqQKiZSyhmyNUkPQ8bB1ih1UY7efirjZuuGwB3Sn7W+ZD7wfPVIw+YF3wPeWRXDyt+1s9AyM8tGMfyk/T0tROqR5RiiW2m4FEiuHaMA/t2Mdwucgnrl526+Qma06o6Zog+YpZSePDINJQqNQJNbgapFakXZuEpbGgeLZiJKEmNTVQKaDRgH3mkZrWGgWps5UgC4pJC7JJD6Ebs4yUkASqUTEys4yMD4tXp1gXWP3ozgM8vecA9UQTVls7FSxCLCwJkV8nrX3soMTU9iY+cflixiZ5wOxANsHIOGMs/K3I2eE182f/Xd/QCM8eHSR2PKRME2mJsm3qUuFk2okdjydfPsnRwUf5xBXL5i+f0TI5UrROkfyZWUnjgyQgChUMjhbRWOgzISeX8kg7dmOGkfjtR2hn24vE6xqvlSIpZOPPSqh5Nj35ply3ODGIEAItLOqhphqEhIpOU/s2PmjH4dsFuP6Ffj3/ngfXc2ioit06hsDyqEUS4bj4vk/Ksck5DsHgadywyKc/+jFm5+11M+ATZhU/HMzt5MOTUIdndSXuXb38UqZ1ZNHlYdI2OLZFEEf4saYUCXw3g8iP53Ax5s5fruPnz7ySO1Ljs/sinjTblo0PkoJkLTgz9dpxG78WR+RSKRK2hYCoHe46G6KE/t0+IyEEUv72bUlqap7kSGtLDhWFaA0IiyBUlGpBY5aRYXzAoeiEz5efOerP/4efPsL+YR/VPJYo3UroJBGOh3QahyE7cYAqjdBEyKevv4qLxySPzMI0W3/I3o+ND4N2uEtBcsGkXPfo8kuW/viJZ+gZPo3d3EWgQWMjLElsWSBs3HyaamWQn2zczom+fm65ftlKkSEMFN3jpNm1ZnwwwahU8QnCGCeXIEago5hcysOzfrfhWggi8VsDHjUIhWVZSEnt1W39WmMJUWxuyoKOIVZIaREoTalSIYzo7HdYawbhGe+305ovjSpWn6iwcv2eY6zbsZeCyGC1tRLaCcJYEam48d+2jkgQ40VV4pFTfPza5Vw/r7No/rs1wch4C53wAwXJpTM7ph87PSn/qx0HiKMs2WQTdSzCSBGFCiUlWlrg5nCaLNbvP8pQqcTNVyxbNb87u0hIwrHwt2ZFjfdTBPnRSolIaxzLOdNQHZNNJXEdq3j27LNXg9Eb7EzTNKpGr/29DinuLMD1zZk0thREUYiXzKCERaFSxY/ilMJKmitgvJ+OKf5+VHPT8QozHt76EhtfOEqQakUlmtFeGj9WxDpGqxhHKlwhSSgfUe5nxcVTuPKicbRoHhgrzL3aBCPjLY2B7wQW3SvnTf9i32iRjYdOEsTgNrVhIfB9H1RMqASWnUA5Hq7j8dLAAIO/fIJPXLE4f/nMsd+qp5meg/VvNkzPMN5tMeSKpTKxAldIlIqwpSSXSZGw5UEJ1dd/jRD6DfqL1O+8toAwk0zgOA7VKCIpJZEUVKpVwigi1lYOYa6B8f44AX/TL1j7/Mli6tHn9vJizwg624aVyROHGhVrlADbliAkaUuCX0GXBrioK8MNi2cxMcGPpwr+g1nNDx/TY/QhlFZqx8z21A8/tmIBk5tdLH8U7VeQUYSNwLFsBBZKW9S1Td1O4XaOZ8RO8/PNO3hw50H2DqnPjsJNJxVfNytqvB8C6K74EYHSxEpBrLAEJFwXx6LXgb43vgkpEL8JQ3Eco8EZ1Nz2mk9wwwkXkpZAKwVSoC2HaqwJtSSCVnMFjPfDUfiH4z5f2/DyQOr+Z3az48QwVa+JKNVEwY+oR5oYjZQSoRQ2MSKoYtcKdHmK1YvnclFHev00yWfMan44mYrRh1CblPe0wT2qK5tcs2LBrf+/nz9G0a+Tbp2C46SJtMIWEGiIdUygBZblYKVaGKkX+fmWXZwcKnD9JXNunTMmVY0krRPhz83KGu+VflgbwLijfYM4yQw6BhtB2nPJJhNIXtMzdPbmIxh2hJyMjkEpkBZRpBoVIwVt8jd/XkIta8GY5jRDAwH1ekCEw1DJp1gLiVscs2XfeE+d0ny1KFj5Yl+4asvLR9m8/wiDgcRu7kZJj3IYg5ZIC+LYRwqL0K/h2gIrqJCNylw1bwbLJ7U9YHagmWBk/IGSmn1LZkzk361cyo8e305QHibVlkYpgUYgtUZgoy2Laj3Asz0sO0uixWPHkT4GBkdYOX9O6qq5476oEqQ8OGLH4XCH5ZhmP+NdFUJnHbqGy1WEtBq/qGJcKbAtgSUpvvFXKuSZBmytGz+RGoQgHNTc1iYa4UhC1ZWQTbg4ooZlWUSWRS0MqUeKUNM5KLjNPDo23gvHNH8/AmuePTQ4ed3zBzg0VGEoFJBqRuERKYmwbLTWWFIgLVCAa1kk4gqJeoklMyawZNp4Moqt5lmNCUbGH2ic4JvKFclrF8z92sBonUd2vkKQSoGbox5rXDeBUoo4EkjhoLRGC4e61uSaOjgyMkBxyy6K5RpXzJ2ydkqrfDCDvc2srPFuizW5egyDg4NYVuZMLopIpTySroMNw+/0tcQbHCZrQdFzqDY1NaXoqWJZAiElVb9Oza8TxZm8luZoEOPddxy+3evzxY0HBnj4uT2cqMSoTBN2JkmIS4SFwGocVRNHCMsj8H0sCQkJXrXEnPYWrpo9jZntqR86cdwHlllYE4yMP1QS9k7Jcu+/u+qymwt+xJb9J0h2TsHGRQU+lu02dqgpSRT5JL00IrSpqxgr3cForcRjO1+mf3CE6y6dtXrBxKzTB5/rhB+Y1TXeNQLqPowWSthNrQghiFVEOpklmUhg8WYVozcORkIQaoVztqHagpJr0dPW0jxDxcfROkYIQRDGlOs+IXQqMDvTjHfFIPo2hUgV4PrBkJt/un4Xmw72UEu2EmVTqESKCIsoVigtUSrGjjWObRPHIVIrPA2qOERXQnHtwhlcPDa9Lg072i3rLrPCJhgZf4Q2uCfS5Kfm6Fy9+KIrek6epLfUT7J1LH6oCAIFdhIpLKRMIJRAKAsnkSYWITEJAuHz7NF+BirbKSxfsGrJjNbpwwE3NzmsM1tFjXeDBrtSj6kFAUnbAhSomFwqSfpNgpHWv33/kajGnKI3zl2hCyfzTZkZOo6IwrBxNAiaYrVGqOk0h8ka704oUrfVkdOLsPLAaHTF/U/vYsu+Yzj5bqJUE/VIUK9qpFQI2yGOY6TWWJaFUjE6ism4FnZ9lGRcZPnsGVwyufVIXvKTswNOjQ8386TzHNAl+F4LPDBvTK76icsX0aTKVPuO4REjdUQU+Fi2bBzA6QfYtku1FhLEFnUcyiShdRxHy/CPDzzBz7cdnTxos7IkuPxIxD+aFTb+WDHkRgplorixG0c2ut/IpRMkPMnrZxi91S3obK/RG/zJai6bxrEE6kwwQtqMlisEMSlTMTL+WP2atVXk/FOarz15qP+K/3n/42w/OYzdNZkg2UwNjxAHaXtI20MIgSMtbKvxYUBoRUIqqIyQqA1x1ZyJXLNgOm02d5tQZIKR8S4bA98Z5/DN62ZPDj8yfyatURVRHcGzwXEFkfLxgwpCxpSrFaSUWI6NdFy041K3U1QSrRQT7dz1yGb+xy+3s3uI1TWb2Sfgb8wKG3+MEDoHCwVCLRuBRWhsFOmEQ8Km552/kkbrGK1xtPhNBUhAKKGWcm3SngM6RkiQtsVoqUItVOYwWeOPcjKOv94fsfagz5d/+dwh5389vJH9RYWfbqfmZYidBIE6sw1fgtIxFgLPlQgVE0cRniVwdUAiGGFBd47Vl81mcoq/7Ia/Mit87jCP0s4hY+FvZYra6svmftcPIta9cJjYsklm8tRijWsLtFZYlkARE8UaRKPJL4gVjpvBcjySyRRPv3SM0UKZT1655IpLJ6cmR5BPx+zosMx4euMPCEaarkKpRqxBI5FoBBEJW+JKet5ouONZSoAm5mxD6htXjDQSUXNlYwRAKYpePUy2XPfx45gYaYKR8QfphS8MYN3R46vJD2zZzfo9B6B1LNrNEVgplHTx6yGumyBUIQKwbQupQYURjhQIIYlqJdKqwtiM4MbL5jC1yfqhg2m2NhUj4z3VBd+b2iz/btXii7hkciei0o+qDpO0Y7QKGk2vaLTU2K6FtmIiHRGjCWKBr2xqyiXdPpEDgyH//PBmHtnZ3/1KgbWjmpvMQbTG76sPPhdpWntO9ZFIZhuBJQ5JuTbN6QS2YEhFKvXarzl75IdlWWit0VqjlMIW8syv/Xa/UBviHhuGWjIOnR2tBPVaY2u0ZTNarlELFaGi01wN4/cxAHccgX88qfn6roHa5B9teJ4n950kbBlPmGwjdrIEQhLGGtt2ieMQVITnCOLQJwzqoGN0HJGwFBkRkNVl/v11y5g7vmVjinhPB5b5sGkqRsZ7bQJ8JWxPdK5cNOf2U8NDHKuMIBwHV7ooFWFZduPNSccIoUFqNI1GVZBYTpJAOaTzaYbLw9z75LOc6pvER5dcvCZuIhdadJqz1ox3SoOjIFnzY4R0iRUIpXCkJmELHEFfhy3fwZuDesvftaBoA7lUCqFBItDSphZUKdbqRMrLm496xjt1PNTfrjti+mmfNdsP9/PY8/s5OFyF1jEEeETKQkjROGVAxWilkRIsSxCGIaBwXQcVhGQciRuXiUZPc/niWczqzNECD3Rhfc+stKkYGe8TF3oWTmqr3nDZXDoSCqteJGNDOpnAs50zwUgAEintMwdzKiyhkZZFhKQaW5DKE2Y62PjSMR54Zg+7TpZXDipuf0XzL/2w1qy08Q7iTDJQdBUqFYRlowQoFZGwLVK2gyN+9yiQN21Efc3RIEL89iGzFhRtQTXflMPSjcGQUtpU/ICRUoVYmx4j453ph7VlRyw5MBKveepAH/du3sOe/iq0jEN5GZTtgRCgBFo17qNCaKTQaC2wLAvXdpBoLBuioEQ00suSmd1cN38Gkz2+Nga+Y1baVIyM99F4+IvYJnflvGmfH6rU+NXm3aSaWqkTISybMIZQR3CmeoTSSK0a/9aVREgby3EJ4oBAOKQyeZ49eJLhUoGhi6bMWTB13Bydwq4rPX2CFF8xK268lWoApXId4SYRjc5Ukp5NyrXecoaR/j0OfrXRw44QfU2Z5GRU3BioJwX1SFGq1dHC3M+Mt9YXhp8LHKd7IOaOI8W4a/3ug2zce4SKk8NqShA5CWphhOXY2NgoxZlKkcQWEk2MRACaWEVYUuMRQq3AxBaX1UvnM6XZ/rGpuJuKkfEBmQT/bYzLD6+cO4PFMydR7T+OVBWEDlA6QAAWAltbWAosDVI3ysFKKIK4TqRCsC1Cy0O2dHFgsM4vt77EozsPcGhU31qTYvYp+KpZbeNNww045WpA2feRloOQEoQm5bkkXPvVfqI3/mL527WnMwfKCkH4+q9rR9zlWPRlEgkc0ThsFi3RSOpBiNmub7xlKILPBY7TPQi37zpV6vrJhh08uONlhkkRWAmk5RIFAZYQCA0ojY4jhIqx0I1NAsIi1powDPEscJUP1SG6UpqPrVjArA5vdyZW5nQBE4yMD1JasWNKztvxiSuW0pWyKJ8+RlwvQhxi0QhDllZn/rFLtIYoirCsxs6hTNprzJ1JuASWC9k8p+uC9btf4ZFnX+SF0/7qoZhbeuELZrWNN6IgWSxVCMIIy3LQWiNUTDrpkfIc0O/e32VLhlKug+c4xGGEEI0zqirVOlGk8v0o8/jX+C2DcFsP/PWo5qbjAV/beHC4+6cbd/DsoVOI5nacXBvacgiCgOZMjqSXQChNFNRBqcbjMxURxzGxjoiiiITnYqsYWauQrhe5cdEclkxuKzbDQ12WNH1F5zhTej7HdUp+gASr3S7efNXylf/7l+uoVItYSRssF6EttD4TigTEWmPZjVZsRyrSnoMnoDAyRCgltm1j5/KUgxob9x3l1OAw118ye/6i6R1f9S0mTYQ/N6tuvL5iVCiXGj1tQhLHMZbWpBIJUo2p16U/5HXf6EBYC4pJzyPhOpQi1eilk4LRYgk/DPIykaiaK2K8lg+TazDn5QF/9eb9h3lq/wn6Q5CtnQgvSblUQWuYPGEiqWyGo6dOQRygVaPNCEuCsNAiBg2eI9F+DRnVcctFbrr0Yq6eNobxkq9ZkV/E9syim2BkfODhCH5gCYrLZnTOG7hqSf6nG54D1wORQAkbrQRayDOPLRRxFJBMOYS1gHK5zLRJExnT3spLL70EuFhektiVREqzr2+U0fXPMlSY3XXtpVPXSovaePgLs+rGaytGVT9CSQtbCFQcY+kYz7HwXHo7xJvPxvrdFqO3LmI70Jd0IelYiLBxXppGUqzWqIXxG4Yp4wKtFCl1WyBl9yjctOtUfenj23ex80gvw3YGncjiOA5BvY4tQmbNnkNLc54X9h2kUiojbAfLskELpG6EI0tCHIeIKMCqldGVYRZM6OSq2ZMZ6/H9TviBCUXnB/Mo7TzRBve0Wtz30eUzqkvnTCQoniasF/CjCiEhMRGKGnFQwsKHKMCyLIZGChw5coSuthaWLrwIVRmlVi4RxmBl8pAbQ0/V4ucb9/CTJ19MHajwtcPwT2bFjdd8Ip90qm8YLA+FRAUBnhC0NaVIe+x4wzctuE1AJLWCWGELG0vYxHGMin93R9pZSdiXcTRNaYmKfCKtkLbHwHCRcgTH4O/NFTEG4I6ilCtfrvGte58/tfR/PLyZp1/pp5LrhFyeQAhqxQJRZZTF86YzY2KeAwf3MzQyjO0kAYswUARBBFoT1Wv4fogKAuyohlUbYnJGcNOSi5iW5+6MYKtZdROMjA+hpAr3ZjWbbly6kEunjccf7sUVAZ4LUVxH65AJE7pIJyT1SgEVxaS8JIVCic2bnyGXTfOR664h5YEKq1SrVYSbJpHvpuI288hz+/nhrzaw/cTwZ1/Q7DoJX+9TfM6s/AX8qRxuq8bML1braCGwLAdbWrhWo6rz5mekvaZqpBs/XntberMDYTvgzqQjaG1KIYlRSiGkTS1UFMs1/JjJ5qqYUDQYc/v+Ap/9yVO7uOuRDRwpB4jWsYS2R1Cv4ZeGSdnwsRtWMXVqF4+v38CJnlOkMo2JD0EQkPQcpkyagOfY2JYg7VikHbDro3QlNB9bvog5Y7wDWdjUJkyl0gQj40Opy3a+l9Osn9uRWv/pK5czd2wbFIZQ5QKO0ISBT+TXmTtzFhnbJqyUsTQ4doJQ22zfuQdpC667+jLyaYUTVQhKI+AIkq3thOk2th8d4P88tIlnDvTPPxHxjZLkctOYfeFSilS1TvdosYwUNpbQ2BJcS5JMetgw/K7ftAQ0ZXON6lIYYts2URRRrFTNHe0CdxK+fizku9t7qyv/4f4nePj5g4jmTmS6mVAJomoVp15kWluGP/nkSjq7JL9+bCdDNYnX1Eq5XqVWr+DZkhmTxmPFAX5QRhDixgFOaYRMUGT5zEksmd0etlnc04E5RskEI+NDbazkb2fDNbPanSOrL1tIlweiNoqjamQSDkePHaZSHmXp4ktoSXvEQRXbtnA8l8HRIk9v3oLUmqsuX8Kksc04qkqlMEK5VsVraSfRMZEjo4J7HtnGuueOcbzGrSOw5jR8yaz+BRiMJMm6H1Ot+Ugpz1SAFJ5rk06l3nKG0VtWkd5ii78lqDZl0wjVqBhJKYkjTbFUMbOMLlA9kfrrA7G+/1idbzy1/2Tuf//qCV4e9lFNncR2Cls6VIb7scMyl8yayC2fvJyEA7/45Sb6Ryp4mWYipbEE5FIuC+fORuqIgf7TJFwbixCrVsDzR1k2fQLXLpxJu+QuV/0+ByQbJhgZH2z1SPK9ZdNbw1ULL6JZhFh+BUuFJD2XHTu2k/Bsli9ZgC0CgvoocVgn1dxMoRbw1Kat1Ot1rlw+j0vmjscKSgSlInGgiEQSLz+ZgSjDfU89z789sYuX+v2VfZrPn4SvD+r4NrP6F5aaHxNEMcK2GrOFopCU65DxvD8mGEVv9ntJl31NqRSuLREolFJEWjM8WiII6TZX5MJyVPMPZVsufbks1tz7zMv808NbOV7zINeFk24hCqE6OMCUZpebls/lhmtmU67Bz375FMOlgEQmh2t7WHGMq0Lmz55CUoYcfeUQKoxRUQRBHV3tY3pbgtVLLmZyzn4wrdnRLt9kgrthgpHx4WPXwqFuj79cOrObZXMmkcHHCqt4tsDzPNY9/hi5jMM1V15GU0IQ1IroOCSda+H0cJmnN22jUCixeNEMbrp2GePySWqjvYT1KrESeM2d1LwmNrzwCj9et4XN+09PPunz9YqwFpnVv4AqRpAsVmv4YYQQFqgYFUdkEgnSnoeEd337vA1DKc8l6dho1WiOlZZDoVglUHQPggnnF4DTcfilV+BfRgRrdpyurbpv407uffo5glQer7mTUAvqpRLUCszsbuPGq5dxyZxxDAzEPPLERgZGy7jJLBaCanGEXNJi3uzptOZSHDlyGD+IGkNyVYwuD9Gdtli9bD4z8okHs0Sb3mq3pWGCkfEh1JZ07nHRPdPzzt0rF85k9thmouIALop0tpmRQpFnNm9gcnea5Ytm05TUBLUK9XqAl8tTihwefHQjRw4PcvH0Fj5+zaUsmdONXeknqg2i4wA7nUVl2nl5wOe+9bv55ea9zv5+/4v7Ip48hTbTsi8AIXQOlcpUgxiFRgqwdERT0iPhWG9Z+dFgK/H7/50O9GVcu7FlP2q8vG27jJQqBIr8mzVuG+eXmuXMGVTcvuVAf/ePH9vClr1HcdrG4DW1EsUBUWGAdFxg4cRWbrxiIdOmpugdCXl88w5ODlTxsu2EsUAEPmkCZk3uYub0PK8cOcTpgQG0Y6OB2lA/udjnY0sXcsnE9mIadowVtjny43wuLJglOI/DEeIeBakp+eT1S2ZO7jo9MMzJ8ghREJHNNnH8+Am2btnBVSsWYVuLePSpZykU62Ra2nESWYpDFZ7YsBXPXsLCOe00N81mbHsTz+7cT+/ICbyWdqxUish36KmM8tC2vYyWq1y/5OKV09oTybHSnBd0vgugu1jxqYcR2mkcN2MTk3JtPJshG4Z+39cUbzMpOwEHM65L0nWgFqC1RiEZLdeoBaCS5miQ89kA3FGCy4+W+eyWfa/w5M79nKxEJPJjCYWkUhgiqldo9wSXzZ/NorlTaG2Bw70h67ds5/DJAommdvwwwlI1Mo5kwcI5jJ3QysuHTnD85Cls10FIgapWUIV+rl4+j2UzxjLW4lvmHDRTMTLOcR1wZ4fFnUtmdnP5nGnkXfCkIJPMkEq3sW/vK7y8/xCzJue5btk8OpICf3QAFYc0tY+johPc++sn2bT9KM05WLZwLJ+4fhGXzh6DP3ycuFZAJhKQbaeYaOGxPcf413XbeO5oYelL8Iw5Z+38foOKNPlCuQq2i+MlUVGEiEOaUh4Zj61vVr1pg3ukoKa1xrZttNZo1egX0lqj3+JDmwVFR2jamnONR2mA4yYo1QMKtRBfmy3756s++NxIxJp9veFnH3pmHw9u3U+Pb6PSLWjHIagWsYMRxmZCPnrlRay8bAodLXDoWJV1G5/l8EABJ9OGbSfw4oi08rlkVicXT2+lNOqzb/9RwCWRSKD8IvXhHlbMnshNS+fS4WAOhzUVI+N84aJOttjygcWzJq8p+iHrdh0mijSem6QWVHnxxUO0NbewaM44WtIp1m3czlBhCKe1k1RzG3WheeTpLSQTimVzpzBjUhOdLZfSnm/hqe0vUC0q7HQLTi5PXQh294xSfWI7heJFSxfPGLM0TpEz07LPPwqS1YB5hXpAjI20JIQhniXJJl1sGG7n92tOPVstEpqIN3nMJiBMODbZZAJU3JhMLCV+DOV6QITTaq7O+ecE/M1oyE17jo3Of2LHS+w8MUiYasHyUgRRSL00ij9yimXzpnHFZRcxYUwTloC9R8tsef4ljvcVwE0jhCAsF7GrI1y3cgnz5nbQOxzy/M7d1GohbjpBXKsTj/YxISP4+IqFzGzi7hysN1fBBCPjPCH8MMx63sbZHaliMHfa7Yd6hjjQXyK2smRa2jk9MsKmrS8wtvkKFs9uISsu4ZFN23ml7wS5zm7sbCsFv8YjT+0k9jVXLJzK2Ga4dsFUOrNpHtn8HP2l00SpNlIt7ehEEy8PD1HZ9BIDpSpXXDzla7UWMacZHjIzP867YJQvlCtnjgOxiJUi5dm0NWVxxZtvZR6AO970v1fx1o1HUlPLelZPSy7VLVV8psIkiSJNoVxHi7TpMTqPnNZ8yRdM7g9Z+9Seo85j2/dyuqpx82OIY0EUQ1ytYPtD3LR0Ltctm0dLxiIE9hwp8tRzeznaV8RNtBJEEcKvo6pDfPyqhVy2oIOSD89uf4kjx0+Q75pAFGqssE7eUXzmmmVcOj69MQW7f9+Qb5y7zKO0C0C75901Br6Thh1zujLrbly+kLynCMqjVCt1kpkWRkoB257dQXlUc9msNm5YsYDuFpfh00fQcUxb5wSKdZsnNz7Pth2HEUB7GpZc1MUtN1zJ5HyCoNBHHNSIhIWVydMf2jy6Yz/3bXqOF/tqawbhtuPw7UG02TV0nqiFEeVagLRckAKhY9IJj7bmJhzoe7uv11r//v89C+7ybI40pzNIzjx6E5JIy8aQR+O80Q9rC4JVB0t8/t6Ne51fbNxJjy9x2sbgC0kU+vjDvfi9x/jUNUv59PULGZuxCDUcPF3nsY3P8fLxPqxEhjhWEISUTh3hY1dcyspLJ+Bq2L+/j4OHjtHW3oWOYqgVUSP93LBwNisvGt/TBI+Nge+Yq2EqRsZ5qAu+Z0Fx+czWOf1DF3fft347QuSwXQclPHa/fIJ8U45rl83i0tljiCX87OENDPYeobN7Gk0t3ZSG+nn06Z3oWHD5wsnkE4SXTM45ufSVPLB+Gy8e7cHJdOJlWlCxS6Go2fDiYYZKJW5afskV8yc2z8kL8ZMQOs3N5tymwan7IX4UI2wHpSCOYzIJj6bMW88wem3v0R8SjlxJTzrh4Vg2UaxAOGjLpliumQtzHhhU3FYVzC8Llhwa5YofPbKR51/pQadbcLKt1KMIghA13M/UZpfb/vQ25o73EBCWwDl8qsq96zZxYrhMIpNHCZBRgK4N858+cT3LFnQhgJN9Po8+tQntNaEVENYR5UEWT+3i2oWzaZPcPQ6+aa6IqRgZ53P1CO7qgu+uWTajd/lF0xD1IsXCEF4qjU5keWzTdvbsO06sYfHMMXxm9Upa7IjB44cRwsHJtjES2PzqiS08vnkvQz6OBUzt8Ljj41dy/YLpWLUBioM9xDrAyWQR2XZ2Hu7jf977MI/sOJo/FfF5HyYfU+bAz3NZBPlipdqY9yJtlFLEYUgmmSTp0fPHPHp4s0NkXxOMTqaTHgnXQSkFlkRaDv0jIwSYIY/nsgHNHSOKNUNwy2Mv9F3xV//wL2x/5fSZoz2aUEpRHR4gGjrF4mld/PdbP8rc8Y1T7WNwXnylzF33PkzPcI1kcweWZVEfHUJWh7l51RVcs6iLrAXDRfjJLx6mEku8RBodRESlYabk03z6muVMbLJ/aHojTTAyLhBj4Dt5zU/+/colzOjI4cUhhUIB33WoJ9I8uGk7h3oKOMDy6R185oYrabZDCsOn0baD19pF1cnxxK79bNh1lGIASejt8ijevHIuqxZNoyNRpz56GhXUcRNN5DqnMKyz/OjRZ/j5+t3sHfA/70smn4SvmytyboohNzwyQrVWR0tBrDVhGOIlHCzx9hOv32zHmmz8eMvSjyPoTSWSJJPJV48FQVr09w1SKUeLBgjvMFfoXAxF6o6yYOkg3Hzf5le6/+f9j1PyWnHbu5GpDFFQJy4OMM6L+OTSGXx29XJmtbLVhqEY2LBvgP91/zpGVBon14HSFsqvMDZt8+9XXsZVF3fgAXXgJw89zYliHeGmiIIYO6zT5drceOk8pjZ7u6fAn5krYoKRcQGZKPnzSU38eM1VSxiXc4mqo8Sxxs20cnLY59ePbqF/IMACVswbz5/ccDUZq87IwFFiYlItHZSUza/XP8OzL5xkqEKXK+lpddn7qZUXs+aK+czsSEN1hKhWwrYc7EwLKt3Ko1tf4O6HnuLZw8U1I7DGhKNzU6AYV6jUqIYhGoFEQRTiSIGl39lRIFIrhObVXqHGzxqN3W8X7pOuIOFIhI6xLAssm6FSkYof5YLAVI3OuVAEd5SFXLq3P1h75y828bOnn0M1deLk8iAlUa2MKvQxKWNx63XL+MQV8+nOsNGBPg3O1peHuevnj1KIncYuWctFlUukoxrXXjqbKxaOJ+dApODX655n7+GTpFu7cL00cb1CMqhw5UXTuHTyWFot7jNXxAQj4wKUhh2XTsqt//TKxUzMeuhiCSJJItPJ4VMlnnxmN+U6eFBdPm8sf7LqUsamA6LKMPV6jVSug7ps4uePbWXz7qMMlZkjoZaDrVddNJFbr1vMiukdZIIicXkYR2jsVAbR2s3OniL/5+GnefT5k4uO1/jGEfhHc5TDufUmVolYNFj1qcVg2RKhFOmETXtLDtt668GOZ48K0SpC6hALjdSKIAyJVEysyb3V1/fCFxxCWtMOQkVEUYRIJBgs1egdqeC4Tp+5SueOU4qvDkbcvv14Ye1dDz/NU/uOEWbaIZlDWgKrXiJR6ufaiybxZzddzopZHb3NLhsl1EYjbnrmxd7cT371NKHTQlPbeFQcQ3GI8QnNmmULuPLiSWQtwljD1p3H2bLzZWQyj2WlEWGMW6+wfPpYrpk7iSnNztfGSdNXdCEzzdcXsDHwnRhyCyfllwwunJP65ZYXKNUqOF4OlWpm3YadtGZzrFoxM9XssveKi7vn+PWFrNt2gN5iAc/x8DLNBHWLX294jqQjWDxnwqIxabEubbH7ojHpXMd1SyZ3thxiw/MvMVKqYGdbkaksERYnykP87MlnGC1ezJXzpq+d3GJlTVP2uUFBsh7RVamHKDSxUug4xEaRcl1swfDbvYaAEDRSg1C/3YCtxVsf62HDUNpzyCUdRBw1Dq+VAmybih8RQqe5SudIKIKvHi+rb+04dIJfP7OTE5WY7JiJBNJBxxH10UGa8Llh6XxWXjKb7izrPTgC0Fvns8++fJKfP/4MQ4GN09KM7UisUoV2N+aaSy5m+cXjaU7Q60PXgeODbHz+JZSTJZHMosMQakWmdjSxYs40ZnSmvmuGOBqmYnSB64a/6nb4y6vmTeGy6eOw6qNEYYnYstCpFh7ZvIutu05SgzkZOHLdJTNYvfQSOjyoDJ9G6ZA4mWRU2ty3YSsbXzzEkGKVgCgLm8ak2XHdoml8+urLmNmcQA+fojY6iJASO91G3W7loWdf5qdP72LXyeqtgyG398IXzJX5cGvsSIupVCqNuUNao6IQS0gymcw76jH6Y7TBPQlPhk2ZxiGgEoVEIISgUCoRaPMo7VzwiuZf9vQF33pw+35+/PgOTpQt4kSeCAsVlqkOHqU7rbn1umWsvmw2k7Lcm4GtAAMBn915eJCHtu2jN3JJt3WhhabYf4QWWeHahVO5/KLx5FMckFA73Ffm8W27OTVaJdncgi0jonI/4zIW1y2awyXT2x5Iww5zVQwTjAysiNLYFHdefcksZo5rQVdHcC2Jm22mFFk8/PQ2Dp0IiBT5jOTIsovHcvOqyxmbdfCL/UipcLM5RmOLBzc/z5bdxykrFkXQ6kBvV5p1Ky4a2/vvr13Ookld2PVRdL2M47rIdDNBIs+ml47x0ye3sfnA6fknfb5+XPNtc2U+3Kq+T7Xu49geQgh0FOO5Nrls+m1nGL1R4/Xvu23fkfRlUkksCUKrRiVLwVChSKAYZ67Qh9u+mCefP1m5/ecbdvLIc/sZFgmclk60tCCsUj51jIvHtXDbTVeybHY3XUnuTsDBCPIjEWu2HxzgwS276K1pRLYVbUsIKzRbPisvmc41l84gn2K3gGiwyuRtew5y8OQQOplDCRBhjURYYvGMcSyfM6bXizjSBveYK2OYYGTQYXNnBrbO7MrsuHH5fCZ15AgrQ3heEivTwrHhKr947GkGSjoH0OpxZNlFeT5+1SWMy9rUR/qRQpBs6WA08vjFk9t5du8gRc1KC4oWFHMW6+dNzK779LXLuG7hLNK6QlgdJYwDRDKL3TqOl3qr3LthFw/vOJw/UuDLp+FL5up8aCtGdq0eUPdDXNdDIlBxSCbh0JxOn3lM9g5eR+s/aI4RgGdxJJdK4tqCKAoQOgZgtFAigry5Sh9Ox+Dvd0QMPrLr+MofP/kc244NUUu1YjflqQU+xdF+dHmIGxZfzH/66EqWTmrZPT7Bd9OCHbEiV4i4fvMLPfl7n9zKkZE6cSpHJCSF0X68uMzNV13KtQtm0uKwMSnYW/WZ8+zug+w9corASuGkMtTrNaiMsGTmeG5aMo9WwX0Tbf7cXB3DBCPjVe1wV06wftH0MQcunzuNjAhQfrmx2yeR5sXDJ/n141so+UyWUOsQ3LvsonHcuHgeHS74w/2oGLxsnpHI5d51G9m0+3hqJGaNBichOJiAg1M63Ac+umI+Ny6ZS0YVUeVBVNA4UkInW+itWjzy7F5+9cwedpyu/90r8C/m6nz4xJAr1QJqfoSwJEJpdOjTks2SSYl3FIy0/t0hj79PSHIlPblUEs+xUVGIjhWu6zJcLOHHTDLN/B8eA4G+oxe+cADuP1rjiz/b+EL+x+u388LpAnUvg/YSxJFPXB6iiRo3r1zCLdctZk4+sTsFewREAXQP+dyy6aVTkx/d/iKnqzE6nQVLooISGVXhk1dcysqFU5iYtu9FQ0lxxd4jg2x94WVOD1ewE1nQMaWB04zLefy7lSuYmBbfmGTx38xVMkwwMn7HBMlX2iT3LJs1hWWzJ0NpkKhWpDnfhsy1sfmFQzz57Mv4MCmEzjab9TcunnrklpVL6bQiiqdPorUm3TaGUzV4YOPzrN99LDUYsqYCi4RFmBLsnpjl7tWXTuc/Xr+MDlmkPngYO67hugmsVBujUYrHdr3Cj57azobDI7c/rzhxAv7GXKEPjwjy5UqdWj0gjjSxCiEKac6kSTj0CIje6+/Bgb5UwiGTdBAoLAS25TJSKuPHdMW89c424/0xGHJbxRKLhuFTL4+y5n//ahMPbN1Lb5wgTDfhpdMEtVFKJ/czqQm+cOtNrL5sIlMS/LgZHnLRPRG0DijueHrf6fwDz+zh5cEKVi6HsKA8cpqw/zCfufoSVl8yMRwL3wUQgujQqVr3o8++wKlihJdpIQ4DakN9ZHWdm69dzoQmZ70bRSfNVTJMMDLe1Dj45uQW5/vXXXIxc8a1kdI+KvaRtsdoZLPhub3sPtCXiiFnQTGt2LFywYTdf3Ld5XQlBOWBXuI4JtXazsliwP1PbWP9jpcZiVl99s0yBbu7PL67cu649V/4008wuzPL4CsvIoManudgJ7PEqWZ2HOvl357aysZ9vd19MZ/vgb82V+hD8EanuC2C1oofUAsVURQRhxEqDkl7No54B2ekvUWP0TutGkmoJYQg6Xl4lmwMebRsavWQIOZtt/wb7w/fYXJBcv3WI5Ur/vG+dWx++Thhopl0vg3XdSiP9hIPn+Lyiydz+41Xsnxqfm8XfD8J+yAiQuRLcPmzB0fy92/ezrFCHZltIogjYr8IxVP82Sc/wscunX6gTXC3gpSE2okSKze+eIgXT/Th20mk60FYxyqPcOsNV7Fkeuf6NsndHbZtDrY2TDAy3loqZs/c8dnvfnrVVXQkbaLSKK7jkM61c3SgyrqNe9jfU5vvQk9CcjAr2HTtookb1958ExNyDiO9R5EWNHWMo78Kv3jiWTbuPkYffK6EviJEdSXgYAq1e3ZH6sH/75+t4ZaVy4iHjlMZPIFlhTjpRn/TKwNV/sd9j/Avj+7MHSrxl0c0/2iu0AdLg1MPmDFarqE0OIkkURRBFNLe2kxSsrcLvvdWr9EBd1qColKKOI5RqhGwpJQI8c4exXlwtCWXobUpTejXUXGM4zgMjpYYGK2YPqMPgaOKfxiCW9a/dHrG3//rfWw/2ofb2oWdSCJUjbBwkmRtgE+vXMT/9cnrWTYpf28LPNBo3lfE2LkRzcc37e+d8b8feJTTFY1IZnAsG78wilsb5f/+k4/xiUun9KRhhwdHBYQDNW5/ctdR1u18mTjVjEylCYKAcHSYaxbO5qYl03tysP6PObbGMMHIuIB0WNyZUuyZ3pnau/KSi3CjOrXCKF4ijUy2sOdwL089t5eDg+HnKzGLXOhJwZ6l03Nbb1+9ks6EwB8ZIIoicvkxBE6O+x7bwqPP7E/1V+OVAXJcJa4vSiH3NMNDHTZ33vHRBTv+w0dX0ulFxMU+bB2SSKZxm9qgqYtHnn2JH/xkHc8fq6014egDDkYCx4+ZVKr6SCeBisFCkLBtcmnvHYWas/0/r68OnW3GfrPjQl4frlIuQ2nPxZYACoSFH8eUKnViYSpGH5RBuO04fPt0yOd/8vQLc/7p/keoJZpo6Z6E7SYIKgV0oZcpzTZ3rL6ST14xn7EJfpyGHa7SPQ70xchcf8ja548Pd93z4BOMRg5urgkRK1RllO6syx0f/whXzBkXtsADCTjox3pSGZY+d7CPh7fspO6kIZHB931UtcjCmZP4k1Ur6BR83xwOa5hgZPxe2iV3dab4/srLZlQvmdGNDMtEkY+dSREmc2zYvZ8drxynELMqhpwHR3Kw/vIZTev+441XkqdOZfA0SkVkWruoiAy/2riLZ14+yaDmVttKDIfoTpQmA1tzsP5ji7oe+PynPsL8cU3Eg8cgquB5HtLNIbJjeWmgznd+/Gue3FdY+0LErtPwpQGFORPr/Sag4ut8sVZDSQsQ6FiRch3yTTks3tkMIw221rqx1f9sIHr1xzsbPpty2dOcSr76h7UUBEowVCiizQDbD0QffG4Ybt49FH75h49s5adPbyfItSNzrURaEZSGyMQllkzq4PZrlnL9vKkHxll8qxkesjXDnVL8oA7TR+Dj+waqzj/d/yS9dYmbzUEUIqqjTMw43HL1YlbO6hhqg7vP7n6tSjH/hd5o0b0bdjAaW9jJNKCIKiO0efDp6y5nXJo77ejtB5AaJhgZxu/ohB+MS/PNT16zgmljWymPngYRIzyPkrZ46rk9vHTkNEXFykiTT8LeZnjourldD9xyw1WNytHoEFEckG5ppUKChzbs5IntBzgZ8eU6YjpS0A53TYCv5GD9/G7vx39645XcuHQB2bCCKo3gSbC8JCLXTn/s8c8PPc0DW4/MP1Tm76qSeQOxNuHo/c1FYbVWp1KtE8UaIW1UHOM5Nvlc7m0PgD0TihwNzptWjPTbV4ygsWU/k/CQaJRSCGkhLYeRQuVtz1sz3n298IXBkNt3Hqus+ZdHNvPozn04rWORyQyRXycoDNLmRly7cCafvnoJy6aOeaBT8oPx8BdBGHV3CO48AX8zpLhl5/HSjB/+Yh09hYBEcztCK3S1wLT2HB+7fBFXXjS2p1VwXwIOutBTgFXHC9GiX218jiPDJZIteTSKemGAjqTghqXzmdZu7UhrdnTYmL4i402ZT1TGWxoLf1vtcuatXnHJrYd/+itqlQHcTCuCNPtOnOShjTtoTV299KLxmZ4EHLRhKAl7V80fi+ddu+an6zZyqr+HXOd4sq0dDAz18av1z5JOp1k8fdxnO93GG2An/MBWDDVJHpvdah9tWn7x11pSKZ7auZdjw6fwmjqIZQrSLZyqjvCLTTsZKhVYteiiL05rde4VmrBNmOFs7wcFyZpfp1oLiHXjjDSlFKmkQ3OWd1QxOvuoTCn1RwUjS1M80/BNVTWOBfESSQqlMgpS5mq99/rr9bXCS4SBoPtUla9ufLEn9etndnJopEKybRzCshFhgCgNMiHj8IkVi1gxZxKdHj/MwLYOuHMQfRuOzVH4h8GI27cf6s/95IktHBmo4DW1ISKFE1YYm3NZtfgiVszuOtJqNUKRgmQV5veHrPrlpufZfvAIiZY8sY6QYZWMqLFy3jyunDuVJljXIUwoMkwwMv5IzfDQpTO6Vt64YmHXg1t3oYIEUjZOsH7paC+Pbn2epuzlN1tNopgRbPM0RzU4V8zKrxNq+aoHnt7KsaGTZDsnkGlto1pU/GzdJgqjC7nu0hm3T/XYMaC5o13+phFSeITXL5hyy8TOthm/2rKDvT0DBG4L0naxm/MUysM8tv0Fent7WXP5pTcvmNKWqyumdzv8lbli760QOis1n3K1jhAuQRAhlCabSZNwOfIOK0a21o2KkRDiN6FLqd/rUZqAKJVM4rk2KlDEWuAkkhSKJWoRs80d7r0nEolwNOamPUeGb372YA9P7NjHiLbxmjtRWqPKFcJiH/MmjGHNVUtYPqNtfRY2dvObf6sRIh9BfiDmjmde7k39fP0WjgzX8ZrbkUKg/Cpjsh43rZjPstndxSabxybAVwBOwN/011m76aVjbNy1D51oQkgbK/LxdJWlMydy5bxZtDk8MB7+wlwxwwQj44/WBvcELt0fXTr/W+VymfV7jiJSbaSzbfjCZcu+I2SbcqxZMe+z3WlRTAr2TYCv9MT89YoZHY5jLV75yw3b2XvyMJmubtymNoaGB7l//VZQAvuS6d/tSvBdrN/8nYlQHRznyW+2TMrNb8ms+PIj23bz1EtHCRPNVGOJk82hHZvdPUNUn9zKSG3BqqWzuufEkJuImWD7ngajiK5yuUq17iPsBGEYQhTR1tKJJSi+o+GO4Gjd6DE6Wyl6bdXonbIExXQySSqVQvsBWmssy6FQLlGu1mcM5hK3mWMe3qNKUczawGLcSMya5/YPzX9k226ef6UHlc5jpdIISxJVRnGqQ1x58Qw+fsWlTG9PbWzT3N0ufns3mIJkb50vbD142rn3ya0cHalBNo9wXGy/QounuXHpQpbNHlvscvhuAg4CnIYvVWHevhND/PLJrQRWCstJQejjRWVmdGZYeckcxuXcHS0WD5irZphgZLxrHD/qm97kfPlTVy/7u0oAW/YeQztd2Mk0tVrIY9t30Zx2uP6yOWsnuHylN4q/0G1bf9UHn1s8vQtpL12pNmxn36mTZLu6ybR2UO7v45frt5IUmpULZ6y1kwyPk42dIm2OPPtmdo9oc8PMNZd9bcy4Ln65YQeVcoib70KmMvgaDg4UKT2xjcHRke6Vl1z0RTKSBBzshB+YK/fu82Mmlet+Y1aQI4mJIarT3JRFampSvH3FSOrGn/mdDHT2F1RjXlKbfOtQY8NQyrVIeY12yViDEJJy3adaj4hyZsv+eyWwGHeyzl8+vfMoD2/eyZHhCm5TO8r2UFGEKhVIqxqrFs/n45cvZFKzuDMLG18fVA/H/NNQzC3bDvQ4Dz2zh55ShEy3Im2bsFok7yk+edVSls7qIu/wkwQcbIN7TunoqxVhL9p9vLD6F09toaRsvEwTSkji8igtiYhrF13M3O781qyKN7VLy2zNN0wwMt497Z59F4DKe6mPLZ//jYHhQY4MD0GmBZHK0j9c4dcbtjOmvSOVmd52c0ZaW6HROxRKOhdNbbelXHLFjx56mn0njpLrnECiqZ1qYZRfPL2DUJNademMr+oktgsnO/hNH8B4+AsrSTE3b/xNXbncFXf96nGGigNETgYnmUEkMpwuDPLQ1pcYGK5w3WXzvjhrTOoBS1I01YL3IBhFTBoYLTNS8XFTNoiAMCjSknFJCva+k9kwHYI7hwS3hGFMFEU4orGzjTiCUGEJim8XiqDRz9Scs8mmLPx6GeGlsKVDoTpCJYgx06/ffSdV8PWKdBed9Fnz4DN7efDJ7cTJJhLt41BCIFWMXxhkWj7FDcsWsXz2RCZnxTfOBprXVpxCi86yxdKnnj+aemDzTnpKAcrLkcqkUbUCtj/Emmuu5Jp5XT0t8EBas6NNcM+A5o5A2N3HRuObH39+H68MV6hZGVKuS1wukLUirr10PpdNHT/UKrl3jLS+Y66c8U6ZXWnG72UcfHNOd8vGNVctpj0tqI30ISQkc3kGapqfr9tEzygrQ0nn2a9JoA9mUNsWTspv/MxNVzGjq4X6SD9CCFJNLZRIcP/T23h8x75Uf8zaMiwZ4Le34Y+Fv20RPLB0StPdX/6Pn2LBhDbUSB9+cYQ4jnFzLQwFksd37udfH97Ic4fLa0bhJnNe1nsSjCZXwhjhOEQqbpR3dERzLvWOt+oDr9tOrxBnqkXiNRWlt9MG93iWGEq5FjaNxm1pO4RaUqjUCKDbXLF3R49f/usTRH9T0u7lhwb8NXc98DT3r3+WMNOKk8sTaUVUL+MP9jC7M8fNVy/hpsWTdk/Oim90w1+9/kNKZNHaU+MbD249NOfBrbs4NlrDyeVxXZfaaD/104e57caruXHR1ANtgrsnCf7b2UdwVc283iqff/zZF9jx8lGUlyORTFMpjhKXR5g3ZTzL5kyl3eOuMWBCkWGCkfHearF44JKpE6o3LJlPk6ijygVsIbETLbx4rJ+fPb6V/pjPHoZ/Oq31l9oQ90xAfqVF8MCiyfl1n75mGZ1JCEf7QDdCTUVmWLf1RZ7afqirHLO0rFj6+r93jOA7U+E/TEnzwB03Xs5Nl84kXR/E9kdxJSRb8tS9HDt6hvmfD6zjlzv7bj2h+NZJ+Lq5au+eql93SuUKSNnoB1IKR1q05fPvaKv+2xFCIMTb9ymd5dqiJ5tO41gClMa2beI4ZqQwSqzJmiv2x+uL1ediN5OrYC/ac6q66p6HtrBp1xGsdAd2KkfNryLCElZtgBUzx7D24yu5dn7nujz85LVN1mcdUfxjv2bttkMnuW/DNg4OlHByeYTlYAdV1MBJ/suaj3Djwsk9zfBQEva++r3A54qicdzH07v2UZNp6hFo3ycRVpnb3c6qyy5mcqt399kGbcMwwch4Tzmh6utO8perFs8pfuzKJcjKCI6KcBNJkq1d/PrpbTyy5RUqsCgS4tUejzHwnRZ44LJpbXv/8ydvoNWJKPSewLIs0s1tnBit8bPHN7Nu6/45vmTSUc0/nFTh74SaVkvdOyUnv3H7TYv3/tdPrWJMUhOOnib26zS3daBTOY6VIr7/b/dzz2N7uk/EfOMQ/Oi01l8yV++PfIOEz9XCiGKljBAWlmURhwEJ16Epm/m9g9HZ7fmoM9Ui/WoweseH0CYkB5szWTzLwtKN7f8qhtFCyWzZfxcMwm11S04fjrh53Y4jq37wkwfZ8Uo/yZZxJNNNxH6dqDSIUx3g01dfxhf+9CPMH5u8Nw8/GQt/+/rXO6H4mxJcvv75I5Pv/vU6RiObREsbUkrqI/0wepr/fusn+MSKWbs7JHdOhD8/W206pfhqv2Ltlv2n5j/67AsMBYJQJrCkQ1AYpt0RfHzFpSya0HxvGnaYq2f8Iaz/5//5f8wqGL+XlCX2+IqpaZsd6VzLqmKpTM/JXrRMINwE2rI4cvQVOtu7usZ2ZKMQxmRhE0AGtktBrbXZs9vyHTMOvfIK/SOjSDeBTGQYLtc52duLm2ya2tbWdHHatnbUVHRxRshtr/79QuzJwVNKkuzuzA2NH9c9d3B4kJGRIhECJ52DZBJfWLzw8kFOnBqlvat7bkvWLtZhlh/Wp6Yte5e5kr+/Elx5ZKi6auPulxkJJNJNEtaLtCUsPnn1Aloc1udgwzt5sy3D0o3P7+8+PlzFSedQcYwMqiyePYXpY5pfzEt+9g6/p6tOjtQW7zvSi68tLGkR1YtMbMty6eyJL+fhJ+bK/WEGFHeUBSuOl/j8o8+9nPvp41vo9V2SrWPQQhAHZSgPctG4Zm69djmrl87Y223z/06UfCkNv/NvrBe+MAofW//CiYX//Ksn6QskblMHtmUTF4ZpkwGf+cgKblo8dXer4L7XHtsxqNRtVSnm7z45uvrfntzMwcEKOtWClg5WGJAOynxs+UJWXTJp/UzJRzOwzVxBw1SMjPdNm+QeK6Y0oy3xdx+/cgkzx+aJq8M4QtPS3sFwLeJXTz3D/tPVleWYpf2atWe/th3uyio2rZjV+cB/ufkmxqQkhf7jWJZFc8dY+uoW//rQU2x+6VhqOOZTdezpvaH/hdd/D2PgO9PgM3PHZe/+Tx+7hqvmT8GrjxAU+nEEOKksdssYth86xQ9++hDr9w3e3BfwubqdmG6u4B8m1HSVanXKlRqW7aJ0hNSatpYcSe+dbdV/fcXotf8Lv/+jNAuKrZkMac+FKGoMjRSSQqWKr5hkrtofphe+UBSsPFJg7b1Pbuf+p7dRFElSLe0oFFGtiCr0M6+7hT9dtYIbF068u1Py/Tc7QPhkxNdH4aYndh1fevevn2BEOySa20FrgpEhOhzFn1y7nBsvnXmgRfDA688yqwk55/Bgde1jz73AK/0FdDKD5XoQ+kTFIa6+ZA5rrpyzu83ibnP1DFMxMj4QacmOJnhM5LyFGjmrb2iQcq1OhEQ6Hn19vYRhwMRx3bNSCTnaKvjF2a/NCjYpSLbnU2FTS/Oc48ePM1ouI5wUkZWgFsHRo0dJp5vyY9qami1FJZY0p4TY8/rvoxV+4SUsNbYzvzLjORRHRyiOFpCOh+1lwPYYLfu8criHUiXMtLXkr1BJOSEUdJUjlmQk283VfGeG4JY9xwYWPrv3MKGdJtYQVwvMmzaeq+ZPfCULmzK8/XpWYV4FFm/Yub/7+FAFJ51DK4UMayyZM5VpXU0vtgrueyffUw0uLoXWDbsPHmegUMVOpIiCKk2e4JI5M7uSrnglBXvM1XuHVaI4vmMI+adDilv29JSuu3/Ddjbs3kecbCbV3Erg14jKQ2RViWvmTeG2m65g4ZjsN2w/GB1rW99+o9fsg8+NClZv3HvyujvvW0dBe9jpFmxpoYojdKcFN1+xiBsunba13eGu1z+C64e1fQH//akXDuUe2fESvpMFy8FGweggl00Zy3+66XImpPhmB/wvcxWNP4bZrm/80ZoFD111yYzuYj1Y9PMntxEosBNZal6OzS8cor0lx8eWX3K7laA4yeK/vbZyFGo6V148AddedfM/PfA4p0ZOk2gfj3ZbOdl/ggfWb6MlnZpxyeS2mlCECp3qkOJ3RvqPg2/KXKLatOziW9tbWxb9etMODg2NohIaN5Ehsj36RkdYt+1FoqDGlQtnfnZqd9P8pGSvhNo72WJ+oetXem0kRL5UC/CVQCFAKVTg057L4MGRdzo76syAR+f11aOzlaPfp8fIhqG055K0LHQYYAmNRlKu1qnWI1TaMX1Gv4e6ZU0f8Lnj2UP9+fvXb+LESAW7qYNQaSqFYaLKCBOa09xw2WKuvWxOtd3jrm74Kzz3jYMW3FGAVdsPDa/851+uo2InkKkm0BAUhhmfsfnklZdy3YIpO9oc7rZCVcT57YcZo5qbtu3v6X5kyy5qIoXlpSEKqA2eYu7YDv799ZczpYmvmdllhglGxodCB9wZ2IxbPnfWouO9gzzx/EFsN01T21hq5REef/YlsokUqy6ZdUcizcHXltrdSPVYjiwunT4mV7lu2ap7n9zK4b5jpNvGkW5p52SpwD//+gmq162Yv+LibseVoufNvo8x8B0kXD5zbE97NrHmoWd288xLR1GpToSdPDMQ0uWR5/ZzYnCE65YvWjRnYtsiUo2DUc3Mo7cmpajWfGbXIo0fa6IwxLZtRBzQ1Z5HRzjv9I7SDnf1C9Zq3Tj89exRIK8GpBj7nb5WG9wzmOb21lx6lVQhQRDgeR61sEqhVCXON5mdae8w+NaEmH1wWH3xmf3HuH/Ds4wqQSLXRj0MiSsV7LDMwkltrL78Mi6d1L23PcEP32o7fA/8dRmWPndwdNVPH9tMf12S6GgnDEP8kUEmNCf55OWLuHrBlCOtDvfKmNprhrsCjSM/Dpyqrnnsub2cLGvIZhFaIuoVxiQlN69cyqLx3t+5MT2vnZ5vGCYYGR+obvirerM9/SPLLr310PFejowOY0kbO5llYLjM07v2Ma4tn8pMa1/T5fwmGL16ExRw3cJpoVJq9U+f3MbRgWO0jJmKlC0cGTzJvY9vxfWumrNkZvvNQhCOEW98Mx4j+M4YS3wnMT7/7ab0ii+3ZDNs3HWU0XqdZLoZRBJldfBCzyh9Dz/NtYvncuWCGbfHGXIR5N+sP8KAGHJ+zOThSpUIgbQdoiDABtpasiTsxjENfyyh/6Ab2VDKdUErJIJYSPwgolSvE9Nkhjy+jT74XFGLlQf7qjf/avNunn7xECqXR2lFEMUE5QLpOGDlJXP5yPKLmZLP7OiwufO1g1hf7xR81YfJe45VVv103UYOD1Ug2YxSjf6k7pzDTUvmceW8qb2tNvfZSg+3W+K3KrenNF89VuJrD2/dzfNHTkO2HUvaxOUS7Q58fPly5o1v650AXzGhyHjXPgSaJTDeLc2Ch+aPz9z5px+7Dqs6hF8exbZtnFQzr/SO8vj23RwarKw8Bn/fH0VrX/u1nZIfzJR89NoFMzbect0ypuWTlAePo6Um3d7NoZE6dz/4NBtfOL2oKph/OnrrrfcT4CsTW7zvfuLKS8L/tOYqxmUV/vBxoqCCTKQQ2Q5O1y1+ueUFfvb0LvYP6TUFuP645tvmSr4xBclqEDlDoyUiLKSUqDgk6dh0NDfjQs/vFYAUodB/WBB6PceiL5tJNB6j6cajtLofUShWzJb9tzAItx2Dvx/QfHbzocGb//XJZ3n8hVcoySTlMEJrRXmghy5P8x9uvIZbr1/KvK7M99sc7n67U+oLMas2vdx/+0/XbeLgYBmVaMHyklRHBhiTgH93xWJuWDzrQJfH9yYIvvL6R+T9sHZYc/PD21/isef3E3qtWIkMMgyR1VGWzJrGVQtmMi4jvmmupGEqRsaH0tlHUZfOaFt086rLF/3o8W34jkMimaMeh2zff5jWXIrWlYu/OKnJ/ss3eo0myWNXzZuWQopF9zy8mf7RARK5DrL5To6NDPCjh58mYV15+2XTx85RktTZs9XeyETBnyfS9kF3eueXXe/KyQ9v2sm2fUdxWkC4GWQix0i1wLqtL3Dy9CAfu+Ky1YunN3WfFnzJTMt944pRteYzVCqhsFAKhNJkUx6ZhPyDhjuefXwmOTPKSP9hKckSFJuyGSwBoVaAwI9iRsuV103YNl6rCCt7Snx24wsHePSZPRwbriKzLWgNUsfExREuGpPnE1cvY8Ws7p4uj+++3b+NXvhCUbNyx5Ghlb96+ln29gwjs3lwHKJ6mRYRc/1lC7nusmm7WwX3ObHuwxK/E9hKcPmTu48vuu/JLcTpdlLZFiK/jlUvMHfSGK5fvJCxGb5v+ooME4yMD304igT5j11+6aLTgyM8tfsg2rJxvRRhHPHYs3toyaX41NULbkE2mqZf+/XjLL7pWRxZMWvyN+JIT/7JY5sYKPbjNrWRae3gdGGI//PrDVSvv3zRlQu77RhybzXdVsZxrcuxvpec2nl9R8tVq8e1t/DotpcoV4oksnncZBORlWTXkUEGhh5n8IrL5q9eOiEKNV0TLDM197eCkSJXqlcpVupIz0MDWkU0t2RxJe/K1Os/lIRacy6N41rU4xhhWYBNpRqYitHrq0SK27TEGYE1e0/W1jy49Xk2v/AKJTyiZDPE4IqIyuljXLlgBrfdcBUz29JbO12+/3Z9eH3wuYGQO57Zf2r+rzY9x6HeUexMC0hJVC0QjZ7m1ptXsXLhtGK74K4u+N7rQxHAQMRnnz06vPKfH1xPxcnheGl0FKBLw0xo9Vhz1WJmdlk/nsRvNnMYhglGxodWF3wvzIjOP1l11ddOnurn8MggTksn0ktTqtX4xVPbyLe0zll58YRPWTbFLvHbfT1tcE+UlPmPXDbteinl6n9+8CkK5RGcXDtetoWTI/3884NPUouvmn/tZRPzcUxuss1/faPvpd1qnKjdBd+zmlM/alq55NbOfBv3P7mV00OnsXN5hJ3CzbRyujDMjx98itHBixZ99MpFi9xmemylhtqkNE3ZgIJUpVZntFTGclqR2NTDkHyuFcduNOH/Ia97djea1n/4MzUBYTaTIel5jIYRlrTRCEqVGvWQ6b+9/+3CNYC+oybFnCHFLc+/3N9977qNvHhyCDvXiRI2liXR9RLloZPctHwht910NVOb+HFO89TbhaJT8NVhxc07jg7N/+kTmzg+UsPJtKItCUGV2sBx/q9bPsF1Cyf3tFrcK+IoxPrdt6Dj8O1TFbXyp49v4lQpItXeipASVRml2fK5bvEC5k1uOZDRbEOYa2q8Jx+0DOPdNx7+YkqHd+9n1qwi5yhUvYSQLna2jf66xd0PPsXunsL8UcFNA/q3D4w9G2Sa4aHrFk1Z9x/XXE+T5VMdOY2WGre5ncHY5UePbOCRbYe7y4IlpzRffbvvaZrkM+OS4lurF09b/3/fsprZnSkqfUcIKiMIIUg2d1EiyS+eeo67H3ya506Uvjsi5ZqemL82VxRiyNaDkFK5gkYQo4mDkHxrKwmHA79/IHp340oi4eJ5HnEco9AoNOVqhXI1WmKuHgyo+h2FKLr+QIUv37tlX/f/vH8dL/UWsLIdCCeBIzX+0CnigSP8xxuv5M9vvbp3RhN3ZmDb2/UTnYKvngr52uYDfYv+9wOPcKIcopM5Iinx62VGTh/mv9/6CT6+ZPLGNpu7J0r+vNOyf+sRWG/of+EUfPVkjS/f+/gW9vWM0DpuCkk3QVgYJRVXWLV0LlcumE6zzUOv/0BlGO8WM+DReC8rDJl8W9p2Ui0zXtp/gBAb18uAkIwWSvT39zNtysypTWkx1AK/fP3XZ2B7DLlxXU2kMs0z9r78MkGosL00MpGkXKtx8JVX0Fp0jR/bNdWSFNPid48heK0meKJd8M/plmT79OkzFgdBnd7TfUhpoYWF56URtse+g4c4duokbrppTr6taUxk0V6LmXMhD4McVNy+//TorCd27gcvi6UFYXmEFRdPZsnsMZu0UvYbDeB80zdqzX/etGNf97HhCm46h4oVMqyy5KKpTOtqfrFVvrMBjwAVWDzi6xuefWE/A9UQLAft12jPeiyYMdFJpp2BdzJ48nx1Cv3VoXr8p6dq6sYfPvQ0P3vsGWoiSaq5HWl7OET4I710ZyT/n//yGVYvnbq3CR6bDP/17Y7WOAVfHdTcvmn/ye7/dd+vGfBBpnNYtoOl6th+kTvWfIRPLJ22rhXuGyt+9/w0gIJlrxqI+c/3PrWj5aGte6g5TdheGup1nHqByy+axM3XLmFsWtw5SZhHaMZ7xzxKM94z7XBXoOi+et6UlUNDQ6n7n96BUIqmRBM1JDv29/CvDz7NF2+7+rPSovZGN7tO+IGA6IZLJmHr61bf86sn6RuK+P+z9+dxdpb1/T/+vO717Ouc2WeSyU5WQrYhZIUQAgHCKqCgBm1swRYrtpV+PmL18/1of9VWbdVWWkEFAWWHEEhCyE4Ssu/LZJLMZPZ9zn7Ovf3+iPRjWwWSjAp4Px+P+XOu676v+9zXeZ3X9V588XI84Tj9Az28sHk3mu6tu3bq2K8L//urRzQcPu8p0RrCt1z1rZryA+rKjTvp7O3BX1KFHopiaSoH2ztpf2Edfak5Y+ZOGfVwicaagmXW1WrKH13sUbfF8kyRaW3d/ZjI+HUdYdnIwiAe1lGh83yOHHvg7nOukYOwzzWRtW0b07KwHQdHnJ+bJNnkYkHpRCykj7Ha+pE9PoSm059KM5jJIuNL/rG+hy3wtSRi4f6uXP3PXnmDXae68cWGoXm8CMDODpIf6OSKCcP59M1LGBlXnw3D2vdzNNoJ9/U7LHtj15nx//HiarKaH08ogpAcrEwvupnlzqvnccPlY3aHbNaXSb89UHoQrl63t6Fuza4jZJUQ/nAcDBMn3cu4ighXT5/AsADffreYQhcX1zFy+cATEmwSKrbXH1mUzRc429KGrHhA9oCic/zECWRkRgyrmiirZH7Tr1M/7HZs9MrKKLGS0nGnzpyldyCJrOuoPh9F06bx1GnCwUAoEg7PdxShhyTxno1MA7DDUVDqasoCsWisMjWYoqu7m6IlkDUPaB5S2RwnTjZQtBw8ft/IUNAnWRKRoGDbH9NzzDjM7CnyiR3HmjjU3I0nGAHTQi2mWDzzEsZWRNeEYd37Hc8HB7odPrtp95Hqs70ZFF8Q27aRzBz1E0YxsjJyukTw5PsdLweX5B3G7W9oGnayvR+henEcE69kc+mIGmpLQ28F+eN6ZgDNFt/qc7h13d4zl/3rM6s43Z9HD1WAUBGWgZHpJ65Z3DBvGrcvnktdTHnfoqjV4Sv9Dste23nyiidWvonhiSJ7giiSwM4OENdsbp4/k2tnTGpJyPz0tzlFACctntx5qnvpK1t30zRYRHiD6IpOfqCbSh98Ysk8ZowuecprOkcDsnCbw7q4jpHLh5tK+Hsq/eTqp32ztyfJgdYefPFKfEoA24jz8rrNjKop88Wn1k7usHigXP6fsQMJiccS8BiTql90WLDsmTe2cGagFyUQRvdFSA728JOX38CyFsavmT7uVjiX4fZe11YNXwWba6cO315TWnr/82u2snlfA7aTONeENlKCYWb45ZvbON3exW2L5tZPrg56LYWQbnMmIf9xtBIRMka2aNLd34csn6ukZ9kGIb+feDSGAr3nPaY4v4az70aJ4Ik+mdvi0cg5F8S2kYRMvlhgMJXGhPgf23t31uEbLWm+tPKtgzy/fhsZxYsnHEPYMnY+i5PrYXRFhKXzZjBnSl0yofCoBi3vRxR1wYpBwdXrDpya+/grazC9MYqWICRLmIPdVHgcPrZwNgsuG7M+IvHqu6X4nzb5UWN37q6VW/ZwvHUANRDBcmzMbA8eY5Al9bOZPiqxeZTEx5HcaGsXVxi5fITE0cSa0LQlV0y7rWf1JrrSfWjBON5AmIKV5bnVmymPLL330uGRR99tnDFwkzap8vuyU3//U29spXlwENsbRfaFyaUsnl+/A9M0pyyaNr7OUKWy4fp7xyJUK9JXAZxynxq/9eoVFYlS1u0+SHtfFiUUwuML4k3I7G5oo3/gdW5dMGvK9DG1U6pDfLPLYkWpfGHZWB8mzhV3LNI3MIgsy0hCUCwW8Pt0wkE/MqQuQBiZQoj/1iPtwr/4NEFLIh5DOA4OIMkyxaJDKpPDsgn9saSadMJ9KYs5DZ3Fu1Zt2c3qtw9iesNoHj+O6ZBP9uCz81w2pppr513G1FHlR2Iyz3qg4f0cQzebhW9lFX3ym/tOzH369U1kJB+a6sMr2RT6uqgOyty8cBYLJo9ZXyLx+Lv1IWx2+FZLylyxesc+9p1sx9aD2LaDMAoU+tq5ad5Mrqmf1BvT3n+8mYuLK4xcPjREFV6qH1s9uqtv0pQXN++ikMuie/w4oXJOdrbx4hvbiN+25F4tKlpkw0xWqMpv/JXpt5zdV02s/YEqa/c/8fpGGvv68cbK0Eqq6Oxp4+erN2HJUujqS8evUDR61YLRWeZR37MIXJ3M5zwhTtxx1ZR7Y2Hf+JXb9tLY2YltxfH6I4iIh6b+AR57ZQM982Zy9YxxD1WGeFSC7Ee9z5oFoXS+QH8qjSzrSI6DaRQI+6N4VBUJshcz/sWm6wOo0FkWj6FIYOEgyyq2I8gUihg2ZR91YdRpGffZsurtN1m2+0Tn3Jc272XHsVPooQSSplMs5pGNIgnN4oopE7imfjLjq/2Ph2D9+22i3AZfTkn6nC0HGut/uXYrPXkF2RtGcWTkQoaIV7Bs/izmXTpmd0R1Xk0gfuO43ZazPIuY3G+zbOPBRjYeOEle8eHIGgoORrqf+jHV3DpvGtVeHnaLOLr8PnHT9V1+b5QInpgU4NJr6iclZ48fhVRIYuYzaJ4AejDBvsY2Xtu6m5Y0D9uq8luL8iVk8dhwic9fMb788U8sWcjY8hiF3k7y+Ty+WClJycMTr77Ja2/vV/ttlhU0te79XmMF/GO5l+9dO2v05k/feCVzJ42GdB/F1ACqquMNx+k3FR5ftY7HV23iZI95b9JhYafNfR95YZQrksnmkWUZBwu7WKQkGsajXJgwfOco7dcF0cU4RhJkSyIhPLqMZVlIkoQjZNK5AtmiM/mj/Hy6YXleVkc3pa1vv/b28blPvL6RHSfP4klUoQX8OEYBKd1Ppc/hY4vquXXhTC6r9j8chjXvVxR1w/J+k2U7jp2tf2XTbvpyCoo3jCIUiul+QqLI7VfP5arpY9YHhb25Qoh/fLd3OCuYsvtES93r2/bQb8uogTDCATM1wLiqBHcvvZoRcc83XVHk4jpGLh95hgX5wk0LZz56tqubvafaCZZ68AZjDHRneHP3YSpKovinjrxVqBiV0m8P2Bwp+CTjSxHWjHueXL2Bhp5OfKUVBCLlpPu7+MW6bTiyMuXGWRPKJJVstcxX38/1lcIjQsNYOK5kR2no8i+Vhv28ufMARtLE9vjwxuLkMirrDxxnIJvhlvn1904ZHq02LMqq1fc3x4eNgsXwZDZLJldE9sg4loljF6lIxPCqHL2QMQUY7wihi3WLAGRIBX1yNuDx+HqTeWyPF0mSGEhnSOeKY3q8+t0l4qPn7LU7PJgVTDnUPHjP+r1H2HKgkf4CSMEotiRw7ALGYBtj4iHuXjqP6eNrdid0Hj0fwdEDd/c53Hqoqav+hXVv09iVh0AUVVWxMoP4nAw3LZzDVTNGvBqRWFWG9K5jN8F3Dp/tX/jK5l20DGYRoRJswDFylKgmdyyax+TayA9q4G/dHdPFdYxcPvIk4LFRZfo371yygIqASiHdh2EU8EZL6chYvL55D7tPdEwpCOreSev+bYQFa+rHlb/0iSXzGVMWJt3ViiQEoUQFGcnL069vZOWWfeVpQX0XrDifa6yFv7q00veljy+uz9593TwiUgY704tlFgmXlOIEYrx94iw/W/kmr+88ubgzx/3t8OBH8ZmZFvFs3qRoWEiSDLaJZBvEwgE8yvkXd/ztLtKFO0al8IhX46hXVbCLhf9sJpvOFskWLCxB6CPlElnW8mabbw3C4h0nOu55evUW1m4/Ql9RRQSjoMhkkr10NB7i0mFl/M29d3LV1JpvTtSZfj6iqBPu63G4Z8/xtqW/eG0DJ9qSyIE4DoJssh8n2c3d11/FNZdP2ByTeO69xm52+NaZfvMLr23Zw6GmDrRwAgtBMZfEHOzglqtmM3106YnhbrsPF9cxcvljogb+1hoTC9153fz7f/Dc66SxiCaqMYMJjrS1sW7XURLh8IrJNd7edyv7XwJPWAqh+vEVhmXPuu0nL79BU08b3lgFqjdGJiV45s3tSJK0+PYFk41S6fwCpSvgHx0f6g1XjFsYC+uLX3xzG0c7u8jhgKqjRMs40NZL9+ptdHYPxq+bc9m3i1FR7YMDCfHRyVgzLMp6egdRVA+qqlIo5MEoEAv4UB06L2RM28H360HXjuNgmuavHKQLq4rtE+yPhfzTRGsfEgJF0cjkiySzWWx83o/SO1SQ5eF9Freue/tE3ctvbqd9oIASLEHVdIqWiZFNU+zv4I6rZvOp66+i1s/D/7034Xtx1uEbWcHkXY3di59/cxtHWvqxfQmEpqMUUqS7m7n3Y9dx3a+KN77XsVwXrEjbzHrtrT1s3HMUOVaGJUk4xSxKoZ+r517GNZePS8YUN9jaxXWMXP4I0Qy75frZox+9ctYkkp3NpJJ9qB4v3lgFm/YeY/W2fTT18dB7OT1lEj8cLXP7zDG1mz990xJKPYL+9hYURcMfrSCNj2fe2MZz6w8sPQEvdvM/W5C8G5WCvx8nuGbOxLpXP3fHMqYMK6WvqQHJKqAoCoGSCjrzgpc27eLHL6xhb3PyC0nBwo+UY2QT7x9IkS2Y5469HIuQz0s44EGTaLnQcd8RRkNxlAYgQzJREsUyC5imgWmaZIsGedPB4qPhGHU5rDgL3+iFO3/+2ta6H/1iJad7s8ihBLKuYxZzJNvPYPe28MV7budPbrqq90JEUSfcl3KYs+1419LHnnuN/Y3teGMVaD4v2XQ/g22NfPqmRdw2f9JLIdte/15p/t0myy0IrtvTPPfFN7cj+WOYjoJjW2R7OxidCHLDvGlEBK+6R2gurmPk8kdJpSr9fResWH7jgnu6unvVLUfbkMp1dE8AvDFe3PA2FWWl+KaO/BpBeC+3Z7yXeb5Jld9PZxbc/+OX36Cjp4NgaRWOJ0xXyuTx1zdTdKRlN1wxcU7ew+gacX6b71jB9cFy/5ejH7/hmzWJbazcvB1CJSiBGL5IjEJWZ/XeBpr6B7jpyvp7FkwaNiuh8lglvz1O6sNC0aa6P5VFSAq2I3BMi3g4SDwYQhH0DZUwuliBJEOyqqwEq5AH28R0bJLpHMls7iMhjHrg7gHBdSf7rGWPPv8am/ccwRevRNcDGJZFprcbK93NpKo4n/vYx5kxquSpMKx9vwHW/yliYPkAXLfzZN/cHz7xAl0Zm2BZLQUkrHw/Uraf266exZ1XT9s9Bm5Ceu/f2KZCbOvp9Lf/7ZlXyGkBPF4/uiyT7G9nZNTPPdcsYEzE+2pEYpW7O7r8IXErX7v8QfHDbkdBqRk2Yv6hhkbau7qRVR++YBjLsTl+4hh1NVWByopg92/qp/bfMaCsuipqhCKl4481nqZ7YJBQOIqkauRMk8PHjiHJiq+6qrIeFUKw6XyuNwhbNJ2BKZfUpL3e0PhTJ08yOJBE1jzIugctEKS9p4cDh49RMIhXVlctkjTs853ng0ZTjr97Y/cx+g0HSdUoZpMMj4VYNGsS4z3cdCFf8FmYumHn4brm3gySN/Cfla8vnziakRWRxhLp/AOlUzC3M8vC1Zvfwh9KIJAw80nGDq9m/PDEkffzGfogO0X9sGzj4dZlP3zqRbYdOk1J9Rj0QIRcNouTTeG1M8ydNJI/u/NGLqsNf3cErPDz7v0Df5NT1GNyz/q9zYv+5SdPk+VcYUjbkbCKaTQjyS1XzuLuJfVHIg6rwuK9K553wn3HB/jej55/ldacgx4rw7Ft8slegk6Bu69dyMIJw9eMU7nOJzjg7owuf0jcozSXPzjV8NVLyjzfXb70KuoiGkamC8vO4wvHSZoyz7y5hcMd+XuPGazuwn7XY7UEPBYWrL1mes2z9954FZWaSar3LIoqkANhMoqf59ZvZ+WOg2pLga+fsvjx+V5vOXxvNNx+x7wJj/zlXcu4fFQVTl8ripVDURT8sXKKnhhPv/E2j7ywkf2d5tcPF9nWYtpf+7C6FDnDIJnNoXq92AKsokEk4MVzgTuIw7kYot+FYxQLh9EUGdssIkkSpgPJbI68yegP4/p3wn0d8MCZlP39Vdsblv37c2tp6jcpqx2DrHooZNKIXJISpcjtC6Zz323XMLnM+5DfZvf5ztUBD3Sb3LvteNvcHz+3kqSl4igaWCYiP0hMynPrnOncNndaSwk8/n5c13abB1vyfP2ZDdvYe7oNT2k5BdvELKQIySbXXz6F+RNGZaMyL7m7oYsrjFxcfsUw+MsrJlatv/WqywlJRdKDPRRtCzWaYO+pVp5c+SY9RRanbGnOe41VCo8EYcuS6dVrVty2hAqfYLC7BeE4BCJlFOQgT726gZc27afb5N4WuCDBEjCc7VdOqPjCZ2+5hsUzJyBlerDT/XgUFUkNYHsjvLbjIP/85AvsaOyoHxTS4rMO3/iwPRsDypLZHL2DSYx3dIuwKYlELji+6J3g6qGOMRJgRMMqQb8PwzjXcUSRNTI5g3yB0V32+89M/CDQDg+mYM7+LuO7v1i7Vf3Ji2voN1UUfxxN9ZJPDpDvbWdUSYDP3LqY266cdaI+oolK+PvzddzaHL7ca3Hn7lPd077306fpKTh4ozEURcHOpQlJOW5eUM/NC6afKFP5wfs9Iu6zuO2Nncfjm/YeQQ7HyRkGZrGAk08yeWQlV82YSHVYerhMdusVuXwwcGOMXD4wxGWeXnjp6FltvX2+5zbtJS3reAJhAvEqNuw8THVZKbdfPf1Or4cj77Upl8P3FOi9cnKN6nDlwl+u3cqp7gHUSDl6oJzcoMzzb2xFU+DaWRMexqf8qm/a+yehnavqK5VpueDShd+pKI371u8+zOnOFvRYOU4gSk7zsLulm65nV9G2YHr9lZeOrXe8klqrqB+aDuGGQ/lgKkk6l8PxREASqLJCoqQETb1gYaQg/qcgGgrHyO8lWRKPhtoHLCQHHFkim82SyVvlllcOfljWvQ2+3Gdy26GW/mlrtu5j+6EGBk2NcKwEy3RI93QjFZLMm1jHTQtnMHN06Q/8jr0bLqzkQW+RO3ef7pzyw6dfZMDWUUMRDMdGLmaoCKlcWz+dpbPHb4/JPPtuvc/eocthRUYwbefxzvq12/eRtVR84TDJbBbVyDKiNMx1V0znksrwN9/PeC4urmPk8kdHqeCRqqD2f66eMYUFU8YiGykwC6BoaOFSnnltI+t3N6ppqD9rvrfzUgJPBB1788LJddvvvHoewyMeiv0dCCHQgzEMxc8vX9/Eup2H6TW5871qJr2bQzU8xOevu3zy6TuuvoLxlTGc/i4kI4fH4yEQr6Ata/LTV9bz/IadnB7If+lEtvDihc73exdGgrJU3sQWEoqsIRzQFZlo0INHoeEiHZ5fCaKhaQ5aAk94BA0xvx9ZlrFlgeUI0rkc+ULxQ7PjnYVvtGb4ypt7T0776Utr2bj/KHnVT7i0ErOQJzfQgcdMc/3cy1h+/ZXUjy799nD4fEJI510iogtWHDHZ9NbRlik/fmYlXWkLofsRQiCMHCU63DB/FjfOv3T9+xVFAFnB5CMt6RWrNu/iTHcSzR+hmC9gDvYS1wS3Xz2PS0eVbfbCEXf3c3EdIxeX30KlxN8XykJ1182YvKKzp5+j7e1I0VLw+ZDUcp589Q3KItqyeRNqerttliekd8+2qVakr0o2ufkTavFpV9Y//fpmjnW3oYbieEMlpPstHntpPQVTjLl5/uSvmwrxcvje+V53Ah6zvIQWTa0dXR6J3L92+z62HG4kmc4h/BGUYAWOUeCFLYdp705z9YyJy+rHV3tN+cLm+32SsZjW0ZdClnQUBDICj0elPOpHFRdWw6hM4ocDDtfZtn0u6BoQjoRjAY6NJJG7YNfIIFkdj3CwpQ9VVnAkha6+QTKFPCbe+Ad5rbtheQrmNPXZ97659wRr3tpNX85GDVbgyDLJgV4KyR7KAwrLb7uGORNGGbUR+a8u9DPU6vCVrjwrth9trn7mzW2cGSighaJYRhGRTVId0Lh14WzmXzpuf0Tm1fcrilrhK0095v2r39rH0ZYehC+KgUQhO0BE5FkyfSrTR9UkY4LnPup9Bl1cYeTictHUaXyuMKJiePvsqYsH39hKe2YAX7SMgqTQ25/i6VfXE9KvvXfmqMT7OsaplPh7TaNl1tiKnCwvWPjYqxs40d6KEilH90XImxZPrlyPqoi6ZXMnLVckei9ksy4XfK/H5u4pw0LJksich+LREK9s2UVHdzu+eDmOHiRvOmzcf5rewQypXHHx7Al10yyvCFVJ51dj5veJKYi19/YhhIwsZGzTwKsq6IqEKui4uNFtHFuAI+E4FkPhG3lljpRFwwsdy8JyQCgqRdvBsMz/DPr+INJsWt8qKnLV/qb+u1Zt2ce2g6cx1QCOqmDbDoXMAMXBTqaMrOD2q+ewYNLwV8dKXH8xcw7aXP3WkVPVz659i8buNI4WQJFkhFkgrsEti+awYPKY3RN9TH+/Y3bAA10Ze8XGfYfYfOAojieOonrI5tMUk71cVz+Zq2dOpdzLd2XLSiLL7qbn4gojF5f3YpyPa1KXjs10DyZ9z6zbQWagD2+wBCVaypEzZ3hu7VuUBK57WCpXc+8nCLQEnihReEIeVfqied28Zc+s3sSRU82ES6tQ4+Xkk7089cpGZKQpSy+f8FBOtsfXyNJ5F5l7J+DVDkneZfMvva6munTMo8+vpqm3BTVWiaL5kWM6R1t66Xt9C2d7++NLZ1/2dTMkYlKumKvxaR+ownbdsNwwKe/s6EaSJGQhMIwCoaAXXdcv2DF6h//eAmQoTrpUic7yslIMw0C1TTRJIZdLkc3msSxCfAC/h9vhwbQkz1r39qm5q7ft40R7P5IeRJE1Crk8hVwKM9vNDXNncsfVVzCh3PuwbJC80AVrtayv9Bnyrev3Hp3y7PrttCUN9FAMwzAoDvQRlArcteQarpo+ZnOJcn4/EgZNrt59sqn69e17GbAFmiIwimnSva3Uxb1cu+AKhkWVH2jQmpDlx9zdzuWDhhtj5PKBpdbPXy2acSmzxo9ELWQw8zkcoeKNVrHnRBsrt+ykLcVD59OfLKrw0qxR5ZtvW1jPqPIQ6d4OZCHQAjEMNcjPXlrHCxt2jx+wpesuNFsNYJjMX07xMnbW2MrNf/WZu5hUmyDd3gRGDkfIyKEYfYbMSxt28tNX1nOwI/+Fgkcb/kF7BhaEMnnoTQ6gKOd+RzmGQTQcxu/VuahjEOfcFuQ4DpIQSM7/E0oSZC90WBmS8UgYxzJwTAvHcUhnMgymMhQtqj5owvO0xY9aszz85Ot75j7+ynr2NnYg+WPo/iBGsYCZ7kE3Brn/47fwuVsWGZPKvV+qgv9Trl7Y8dlZh28kJXnhlgONU55bu5WWgQK2J4BlWah2kWJ/B3dfv4irZ47bHFZY+14Vrf+L6wXfaugaXLpq6y5aUnls3UfRLFDI9uOxU9xz4xIuqfS8pDm0nM+4Li6uMHJxAcrghyPj6g9uWjibMVUJcv09YNlogQhFJcjqXYdZt+94aNBm8fsVRwl4bLzKvAUTah/91I1XUxnWSPZ0IKsKaihBUQvz4obdvPLWwSm9Jne2wZcv5h7Gq8ybUOF5/KE/uZ1Fl41h8OwJsoNdWJaBUL3YeoTX3z7E955+mV3Ng3c1ws+67fNrWfK7xIRYtmiQTGWQFBlZODiWSTwcwqepxsWO/5uaxoqLzNxXoDcU8ODR1XPHc0KmUDBIZ3JY9ger+nXKYU7jgL3iP1ZuCT3+2mZ6HT+eaCX5gk1yoJ9k91mqIzIPf/6T3Dpv3KvD/Xz+YjK4umF5j8E9a3afWvjU6q2cTdoIXxwkjVxmkMHOM/zpnTdy8/wJz5YoPHE+bUTa4cG2tPWl59dv40BLF3hDSJpOPpck19fKfXfdypVTh+8PwPZK8eGvBu/y0cU9SnP5QDNc4vPmiHBsyeWX3dXauZZUehBLUfFEowz0FXhxwzYqE8HFs8ZW5mRB6v3+Ch2h8BlpYlUumV14/78++xqp7ja8kXIUX4RMboCnX9uELBhz3exJdyoKfRfz63akxCfVIJ1/9elrby2PRup+sWYThplDj8QRioYnWsrB0+1859Fn+MTSK++5+rIR1YZDmSZouZDqz0OJ7eDLZIskszk8ugTYSLZFPBxAV6XTFzs2nEvRF0JgD2FmWtDnezwRDdNt2jhC4AiZZCZD0bKrPwi/B1ssvpaG+kNnehY/sWoTu0+2IQIJDMmDhINdyFAYaGfB9PF8etkiLin3/mD4RXSb78rnV5gePdZvi2VvHWmu/renXqQgAmjBOLZQsIoZ7FQPn75lCbcvvmyN13aOlErifX/muxxW9Brc9eqWnWzYfRg7kED1BrCLOQp9ndy04AqunzPhRARWqUWrE82NK3JxHSMXlwsmBBsWzRix+9rZU1CL/RRS/ciKgi9WwunOAZ57YysNXbllKZs53c77d1uGw+evnTnq0T+59RpCZEh1nUXTFDyRBBnby09fWMMbO49N6cxzX5dzcYUBa+GvSiUeue+2yx//6n13URdySHWewsoNICETiFbSMujw//3oaf71hbcWdglWZCWm/KHX3hZ4u/r6KBo2yBKWaaJgEfb7UeQL75H2bo7RUBD0iRPlJVHMYvZcbSRJZiCVJpcv1v0h17MH7m52+NaAYOmrbzcsfvhfH2f78bMowRKE5kdVJIoDnciZDu69YS5fuPM6ppR7H7oYUQRgezzejqJ4YO3e0/X//LMXyEkB0IM4joOVHSDXeZoVN1/Dp5Zevt0Pu6slcV41vdKCWev2NUz75dqtmFoE3ReBYpFU+1mumjKeT19/DVF42WNZDQnNjStycR0jF5eLohQeMVVit1xZP627q5fNh5vIJGX0YBBvPMHBU228vnU3vjkz7xldqp2Xi+GH3TfMGoPkcO+Pn1vDYHcb/mgZejBKpi/PL1/bjEeWp8yfPPpuSSdbIi7cwamUzx0fOFNqFV2+/q6X17/FwTMdFC0H2RvGE0kgVJ1fvvEWXf39dZ++6eovmWVabAR85g8mjMDb1Z/EEgpIAtsooggbny6jQO9Q/T5zhvg3mibTGvZ7xxjZLJYvhCMkkuk8ubxJNyw/36aqQyWKsjClNcuX1mw/zHNvbGHQ8SGHgliygkKRQm8PI2Jebr5qAdfMHLe7TOMHF3utrZbzlaQkFu5r6iv/8TOrKMh+PKE42DZ2LoXHzPDxW5Zw88JpHRFYdT7HZ3Aurmjvqd57n3p9ExnhRw/EcCwHM9nLJRUxls6eQV2Ib3ptjpTIspua7+IKIxeXoaAS/r7opfrO6+bff6bjWRp6epB1DX8wSsG2Wbt1D1WxOPHwJbdJOrn3266gjHNtCK6bNUbVVe2ef/35i/R2thCrHoacqKalq40fv7COXN6ce9WMS8rwwsXWXQkL1s6bOKyvLBa+/+X121m/t4HUoIXsi+EPJSgoGhsPnKK7/xluXzLn3ivGDZs2ycOlf4h1z1mM70tmcWQZWVKxJYuAV6M0EiKoseWiNh+ZXk3TMAwDxTAQloWCBJJ0LjD7Iswkj0JDWUl8IbZBMZdHCJlkKovhiD9Yyv4gLD7c0n/Pqm1HeW3LHoQaQPH4sCUZxyiQ6mth6vBS7lx0BQumjn50hHzxgrgLVmRlMXnT/uaF33viRdK2RiBWimUUsXODhESeGxZM57arpu2Oazx1vvFL7fDgkc7cl/79xTW09BeQwwkcAYVUP1U+jXuuW8ScCbVP1cDfuucTLq4wcnEZYoarfN6pDqj33HTNikeee52OZB9CxJH0AOlUklc27aCstGR8/djEYlkm+Y7oeT+MFHyyMGH48OzNS+b+/LWNdHW0IAeiKIEoXel+Hl+1EVtSxlw5ffS3TM/FFWVMwGNCOMaEqkivf8mChxOJBGu2H+JMVxfCSSBUD55oOXtPnSH5wmq6Zk+bMnDZeGdkwvuQYtJXqvz+snksh1BfMoNQPVg4OKaBT1fQpHN9yS5mbAdU07JwBCiKgoVNwTTOxRuJc/FHF7Gx9cbCfmTHRlNUDMMgnS+Qzhcw8cd+by6Rzd15wegBi6V7G1qmvbxhB1uPtiIHSs5VEQeKmUEUI8k10ydw26JZTB9e8vXzbU/zG50im6/0Gdz61uEzU773s1+QloJ4IvFzxRuLWYIUWDJ7KtfPnZq8UFHUnOHbT72+gX2nW1HClSBkMskBAmaGK+fMYvro2o6Iwip393L5MOFqeJcPFXXwuZnjKnYvmzeTgLDI9PcjhES4vJaTnQM8+8ZmGruzC/Mwuss6v7ig8R7mLZ4xbvMnrltATLcopPrRPT4CpTV0ZASPPPs6r2w9Wt5e4EstzoWn8gOUIJ7QDePMmBLP5z42f9rmu6++nEtrY+S7z6CYeXAkAiW1dGRlfrpqE7/ctJe9LdlvpiVm/T7Xu2hQ3dbZhax7zgklo0DY78OjSShcXIyRAWWOJJBUBRsHy7ZxxK+y+C/+F19vWTyKLguE5CApMv2pLMlsAdPh91b9OilY2FbgoTV7T03756dXsuVIM3KonKKtgiqTHmgn5AzwyWvq+ZNli4ZMFLU5fLm3yJ1bDp6a8oMnnycr+/BE4gghMLM9+Kwky+ZN5+YFs5LVYe3h8xVFnXBfj8M9L215mzd2HsBfUoHQNIQw8Nt5Lp8wgkWzL6MixLfdytYurmPk4vI7JiLz6uJZE4Yn82b8mbWbyadVVH+QYKKCfSebeWH1JiI3L/nCyBBfOm/BovPE4vqx2LI09+nV2+lODyA0H8FEOdm+bp5etZ5iNlN921XT7632XdwXWEJVz8WOqLBk5piGipL4vc+/8RYb9zUggnFkXxC0KKYs88L6HXR29nDd7On3muMq4zGdZy8m3ul9uR1wd6ZAqL2rF0UNgSQwTZN4OEhQ07mY2JdOuM928DpICEnCchws51xrEMdxcMTF7U0K9JVEgvh9GnnTQpE1Bgf7SGbyFA2q0H63n9EuhxV5weiGzvy9q98+yPpd++kvKuixakxLRjgFkm0tjKuJcuu8GSyYOq7jsoBcMVTz9+W4bfPB0+N/uXo9/aaCLxqnaFhQSFKi21w/ZybX1U/PDgtJX7iQ55iCOTuOtE15bctO8IaQdR9yPoeVGmDamGpuWjibETH527JFCjcBzcUVRi4uv1t0yzpTHpC/d93lk78+MDjIi1v3Imk6qqqheIOs3b6PirJy7lx86V1IoBp2Z4kqvS8RUSp4RFLILpkxGlXR5/585To60gPgD+OPxUkP9PDc2i14NL1au3LStrjK0xfb66xU5pFSeMQ3Kn6gLHLNdxOxMD979Q300hoUbxBJ8aKEVLYdaaJ/MEPvwORlc6eMvy4XFeNV6Pxd9VozIT6YStOfSqMk4ghksC0S0Qh+j3pRgdcCTFmQNE0T27bPNSwVAttxzh3ZOagXE2MkwAj7vYT9PjKpIronQM60SWXyFC2qf6eiCFYMwtX7m1K3Pbd6M5v2HkWNlGLrXizTQbbzWH0tLJg8ijuWXMHk4WVrSlQeH4q5u22WD1hct27n0Wm/WLuVtqyBL16JYZqIYh6vXeCGuTO4ce700+Ve6XvnK4q6HFakBbMOt6buWrnxbbozNr54KY5lohlpSsMqS2ZNZuKwyBoPNJTKbhFHF1cYubj8znkn3deJCeXaK6Y+3DGQYk/jWaRglEAwSsa0eWHNJspi4WnXzKxr8avS7vNyjeAJR0G9amotkrhy7hMvv0nLYDd6pARPKEqmz+aJlW+gqNQvnTMpJGskhyLLqVzie+Wl2vdCN8/bFS+NTPvRM6vIZFMEo+XIik4gXsWJ9k5aX1hN58CgevXsmQ+NLFUe/V2ts+kQ6+kboGhaaIqKI0CWZaKRED6POHCRoitWdKg2bQtHEtg42EhIgG3bWA6hixFGFoS8HplYJEjr4MC5RrWyRl8yRdEwq/H+bra+Dnig1+LON3efrn95w3aOt/TgLanEdBSKeQNh5DBT3dxx9WxunDedUQnvkARZA3Q7LO8pcM/anUcWPvvGZlqTJlIoTt60sLIZ/GaOW6+Zw00LLj1yoYK+IBje2J27d+Wmt9l/qg1vuAyEip0bICoMblwwj+ljh7WEBOvdytYuH1bcGCOXDy2aabdOrA0+euOCGVSHPdiZNIqs4w8lyNpefvL86+xvzi4rwPDzFl/wWELhsSsnDVt/15K5VIVU8sleZFlGDcfJaUF+/tomnt+wZ3xbgS+fNfnGkAk/nUdvWzj51a89sJwxFUEy/a0YxRyG4SD7YmSVMC9v2cfPXnmDnSe6722C7/wu1tcRqH0D/SDJSJKEZVloqkrQH0BXuajijpZDqFCgzjRNZPnc+I7jYAuwHBvbxtvNhVcAlyAnSxil8RiWZQESjpDp7xvAsqzfSfXrVvhKQ7/53cdff7v+Jy+vo6E7gy9RQ8GwKWTSSNkBSpQCD9x9HZ+8fo4xvtz79SETRbD8bMb5xqbDpxc+vXojLckiargEG1CwSHU2c/P8ady+4NL9kzUmVInzb1rcBStO96Yeen3bLnYdb6IgeRGaD8coUhzoY9bEMSyYNsEo84ofuJWtXT7MyH/3d3/nroLLhxK/JHZHBS9rEf8SVfNWHzlxkrxhoXuCoKi0d3fR19/DhHGXTFU9wi7a1PoE79vp8MM+y3EiVdVxKV5aMfJMUxNdPf3ogTCy5iWZSXO2vQ2EiNeNqIxLEjk/7LvY+wrATksQSZQEuGzK1DGO5bB//z6QZDw+H6o/QNFxaGnr4GhDA7o3XB+uik11BIoPDgzV+vbDzTuONc/c2XAWbyiGYxj4HIO5k0cwtir8ehjWXfDYgpu7DWau2b6f9pSFNxzDskzMbJqZl05keGU45JFoMGy7wifO353yw74uw1nR0NIVOtjYiuLxY+XzlEV8zJo8xlftlb82VOvUAQ90wYqDZ1NffG7dW6zcsou85EMJRMnni5DPUxjsYmQ8yOc+dj3X1o96tVQT/1HF0Ijps/CNLoMVWw81DXvi5bW0pkyUUAxDkshlBsl2nuWLy+/gjkVTd5dp/Jsfdl/QPRZZsWHvkfLn1m8jo/jxBGIUcgXMZDezxg3nUzdcRV1E/dpQ3ZeLiyuMXFwukFKZH/vjJR8vFIz4qTNN2IoXxefHQNDcchbDKDBydN1Cn8qhEGw4L5Eiix0lEk9ESoMj/b7glKPHjzOYyaP4fPj8QbJ5g4MnTiJUb6KkvHwZKvrFCIZfF0cl8KTPI9Kj6obNURVJ3X9oP4ZjoXt8yJoXS9bpTKbZc/gYOVsfV1FTcQMKFG279kLExH+nDb788qYdw0619xHwRzAzGRIeicWzJlAd860NwaYLGfe05fxoQBI3vLzlWOjljbuwtQiS6kXCwTQNujp7CITiaiIemBJQxI4A7LiQeZJCXNXWnxmz5WADkieAbJt4ZcGsyWPwBdSBgLiwcf/7GvXa3LXtWPfSR559jW1HTqMEE6B4yWWzyGaefE8bl19Sx5eW38mccZGH6wR/GoRtQ+VSddmsWLenadgjv1hJV0ZAIIIpyRQKSYq9rXz+9uv4xNWXvhSU2Hwhfda6HFYMwuLNh8/M//nrG+ksyCjBEmwL8gO9JFSbz9y8mBnDwg+5osjFFUYuLh8QbJWAPxRe1N0/yKmWNiTNgzcUwrBtGo4fJRKKMLy2LOJI6BfyRRsTvBBMxGbX1Y0auf/IMTq7etF9flSvl6xhsmP3HiRZZtiw2rmSSiHIxRU/fIcgbBMq9uRLhg2MHjth/KlTJ+ls7wQhofkDOELBEiq79u2npbVTHjFy7MKwXz5vAfjf6YblA3DDKxt3RjsH83i9QTBMKsJerpg0nOqI79kA7DzfcXvg7kFJLFm17dik7//0OXyJWhR/GEfICAF+f5BUJsumLW9RUVGrV1SFRtiCwIWsZ9Lhqta+zNR1bx9CD0XPJUcZWeovHUd5xLM3LC5cwHba3Ndl8aftOf7q5Y37Kr/145/TkTbwJypAkjHyWYrJPjzFDHffsIj7P3FNx4i4/A8XcoT1bi5OR4G/XLn9ePl3HnsKW4+gBiMISVBIDWAOtPMXn7ydTyya+mrAYme1dP4lJnrg7oxg2v6zA/c8/uqbnOlL442WgySTH+zHGOjg/jtuZOGlta/6bXufXxK73d3IxRVGLi4fAIKCLZ6QbvsjJQs7OnvoH0whdA+KqiMJibaWZsoi8fKqsmh3TPDChcxRIvNEtMSnR2Plc080nCCbz6NoXpB0LEdw8vQZhCxTXVmxCE1IFytOfv3e4vBMvMQfGDlsxOx8NktbeyvJwUECgRCqx4sk6zS1tHG2tZ1QKDbfHw/URgUvX+icg7CkF257euUmcrYHTfPhmEVGVsW4fMIIygPa0+d7bNdtszwJi17f1XTDDx5/EcVfguQJYSsa2byBZdnImoaQdfKmxb4Dh6iqGhkvK/FVIp1z0c7zHhZ3Z4szN+46gtADCCGRzwwwa/IoahKhhqh0Yetz1nC+kZZFfWuKu55bt5PHV67D9kcJJSooFIqYmUEKfZ2Mq4jyZx+7kduumvBUXOYXlRL/MFSf97PwjQ6LL76x90zp9594FscbBs0DmJBPEpMNPrfsWj62YNKamMSLFdKFxaENwHWnkzz07BtbeHPXYTzRUhRFx86lcdLdfGLpldx65eQjcZlnyiTxQ3cncnGFkYvLB4gi1JbFvMeFFpx7+Nhxktkims8PCPr6+hjs7aOmvHKKP+iTQvKFiZYwrCutCOmhaNnct3ftYTCdxRuKIms+LATHjh5HU2UqK8rmq5rcfSGuyrvMvTYU9hbq6kYuciyT9tYWMtk8iuZB0jxIqpfmtjaamlvRvaGpSjD0WckjFS7kGpKwsKPIwidfXousR1FUHauQZnxdFbPG1BqjvfLt5zNeOzzYb7DslS37b/nJKxvISyFMxYPQvRQsQJbxeLzk8kUsRxAKhRkYzLBjxw6qyioSJSXR8bJC8nxiuFIwpy9bnLvjcCNZU2ABRjbFrPGjGV0Z23uhwqhTiD8/0p5b9u+/fI3X3tqLFqtE8wVJp5IUU/1oZpaFUyfwJ7ddz5xJ5d8dIVgxFMd2v+4UdRX4sxe3HC7/7k+eRo1UoPrDSLKDme4jSI5PLl3ELXMnvzpO47oLiSmCc7WmuvL86cot++OvbN6JHitHUr3owibTeZb5l45j+U1XUqHyT5Jh5AKyvNPdhVxcYeTi8gHCBwfCsM4TCy0pWk716bPtmAgcRUVWNfr7+rFMkxF1w+YrXmngQmNXwrCutDIS8HpCs080NNI+kEbxh9C8QUxbcOxkA5IskSiNL5V12Q4JsWmo7jEo2OLzSc11w4dPi0djoY6ONlraupBVD6oniFC8DGQKHGtspGg7oViibKlQJT0snd+xURpmNyYLi55bsx7dH0WRVcxsimljRzJjdPXOUo0fn4+70Znn/lU7Dk/5xZq3aEvaqOEyLEWjaEs4ioSq6Ri2g6yqKKoKDkgCbMfhre07GF43IlpREfJaEHq/Qi+PNXYgby7ddaSJ3mweoWoUsikuG1nLhGFlh2Ly+TmHrQZfaXf4662Hu27416dXsrexA39ZDUL1kcukEel+Eh6Hu5deyceXLuSScs/DNfC3Q/kZ73B4YMDkuk3726f+06NPYQfieEMlWJaJkekjpll8bNFsls6e2jLRJ8240Hl64O4+h4+t39c887GX1pCT/fhLyjCLBYy+LibVlvKZmxczIuL5bo3gK64ocnGFkYvLBxihYJckKpZ1DwxwtOEkwUgcW8gUDWhrb8fv1aiprqgoU/i3C3anLKpH1JX1Knpg6onTp+kfSKFqOopHp1Aw2HdwP+FQiPLysoVD7Rz5YZ+kURhWXZIrLakYn0ymaWo6i42E4vGj+HzkTYsjx46TTmeIxUrmesIePe8wNiDe33WkYdaBjv7Fr2/ege4vQRISIp9i9qSxTB2ZWPN+3ZZWm690Frh/9fZDpU+9voWugoweLidrOBRNE0VXKRgmjiwwLBtJEmCbyBKoqoqqecgWDRoaT1JakhhZEo+Uv9+igQEh7eyxxF/vOn5Gbe9LI/v85FODXFJVzqUjq1tKVJ58v2veBSvacvyvN95unPL9J56nLWXiKynHkTRSAz3k+tqZMaqKjy+9kusun7i70s8/qIbR7ZflfUP13Hvg7n6bZW/sOHvto8+sxPCGUPxhJFnGygwSkYssnTOdWxfUJ6cFlNKLEmAmDxzqNG77t1+upCsPnnAc27YoDPZQ4XH41A1XUT+2/Ju1gr92dxwXVxi5uHzA8cM+RxF6WWXV3Na2dprbOlA9ARzVR65o0dXRQSgYKA+WxOcnFH56QXNI7LNsQrU1ZYGKsoqRZ86cpndgEEnV8XgDOEJm3+GjaLqHikTZYiHLRlAemoBsOBdv4wj0ykSweUzdqHqvpnHo+FEMHAwbHEnFQaGxuYXO/kFsxTc3Gg3XWTKhoHjv6xiEJbubuuev33EATyCBZIPu5Jhz6Tgm1MReCYn3PopstZyvdOWdFWt2Hi7/5Rvb6MoqON4otqxgOBb5XApJFiDLqLqOKgRmMYcoZBCOhePImDbIqk4yk+P06SbCoUilHgl/qlwT71mcsMe2786hTDrS0pM4eqYV1R+kmEkzLOpn6tjRvgrP+4u7aYGvHestfvvV7ft8T762npwcwhcvJV8oUEj1ouT6WDx9PJ+6fj6zL6l59hIPVwdgx1CKomb41ukB89tbD7WMeXLletqSRaRAEEmSKCT7CDg5brnycpbNm0lNQPm/IcEFu5TtDg+e6DH/5pHnXudISw+hRAU2Nnamn6hq8PHFc5gzccSRMbp8q7vbuLjCyMXlQ0JYYp3HLxfC8dJFew8cIlUw0YJxFM1LKpWku6uTqrLyumCJPxAWrL2QOXwSB0pknggmIjMi4ciYo8ePk8pkUT1+hOqhaMORoyeQhZCrqqoW6V6peSjqHP3n/IIDEYnVHr9cGD6semZJaUJvPttMV28futeHpGlYQqa1s4vjJ0+hqMFERVXJOEnhPeOOeuCevad6pm7edQhfIAGWSUg2mXPpWMZVRH75Xv/faXNfrynuen3b3nHPrN1KV8ZC9SeQNQ+OlWGgt53LZ1xKMZ8llc2h6TpWIYeGwZxpk1Acg472DjRdQ/X4QUj0dPXS2dlFaUlJ1BMLL5EUCu8WAJ62nPqMI6Y19WbKdxw8huoJ4hgGiYDG9ImjQ7W+965l1Gjxs/3Nyb94ctU6XnjzLQw1iB6KUygUyA10ERA5bl00mzuuvoKJtZHvjlCHpmDjfxGY8JXOPH++5WCj/vRrG+lKO3iCcQzHxDFyKLl+rqm/lI9dPYeakPztGon/faFzdcPythwPPfbSm6H1+44jB2Pnim/mUyi5QRbPmMiNcy5LTg3pNe4u4+IKIxeXDxlB2BKI+SP+UKJ+194DZG0ZSfMiJJWB/kH6enuprRk22xdS0xdVV0YglZXGAuWJspHHG47T0XeuCKSi+LEdhUMnjpPMZqisqlmm+pQhS+X/z/sUbKnU+ftYWfyq4ZXVw5LJAU6fOYVQFBTdiyKpZHM2e4800Jc2QiUVpUsln5KIwKrfNmYf3LZ+76kpe481ESqpxizkqAyrXDlzMjUR78vvFdDbXOAf1+4+Wv/06k10ZGz8kTIs00EysvS3H+f6qy7nlhuuYO+eQ6RyBkKSkbGRjQzXz5vO9PEj6e1qo6+7E1X3IcsKkqQzkEzT2tFBOJqojkeDlY5AD0i/WaT5JbF7EJa0DhTHvX3gKKbwoMgKmigyd+al+L2i/bfdRw/c3ZjjZ2/uPbX4qdWb2NnQhqWFkXQ/hUKOga5maoIqn7rxKm69cmZHbUT9N69tHvdL0pCmq3fCfa1p++E3dh4JPbPmLdqTJp5IKSYOjplBZHq59opLuWPxXOpi6jdrBV++YFFks7zbYPmzmw5MevbN7SjhMhxJQbbyWINdzBpTzV3XLmBMie8vLjSg28XFFUYuLn9gig7DIrHoRKF6ogcbTp07YhIqkqTR2tGKcBxqh9Uu1vTf/iX5fpybEoUnlEDw49FYLH767Fn6kxk0bxBJ91G0bU6eOo2NQ3XNsEVCE/rF1ND5bSQUHvOG/RNra6vGC+D06VPgOKiaF68/zGC+yMmmJtq6WojGojNDsZBesBjpl/7nfXc7fGbNjiNjjrf24A3FyKeTjCwNMnfqJUwKqDe+23WcsvnxGztP3PTEaxvpM1W0YIKCYYNRIN3bysLLL2H5Xdfi98FLr24kY0h4fH6sQhEKaa6YMpqp4yLUVNTQ2nyWZCaP5guial4cSaF3IElPXx8lsfLqcNhbbtiUhZTffHRUkBjekbYWvb3/GI7iPadinTxzZk2l3Cdt/E2CuN3gwba09b9Xv31kzPPrtnGwpRc9Woqm+shn0xSSPYwqD/G5269n0fRxRxI6j9VI/O+hFkXtpvNgR9r6wtq3D5e/sG47ZwcNhDeMjUAWBv2tJ1l6xWV85pZrGBFVH66Gr17MfH2Cj63f3/SJn7yyjoIawBeOYRXyOKlexleWcPvVc5kxqvSh31XTYhcXVxi5uPwe8At2Syq5RHnFDb2DKY6daABFR2geVM3DicZT6LrK8BEVlUJgXMxRV7lH+n6kumRGJBwbc+xYA/2pPGogiKZ5KVgWLa3t5ApFRgwfPteSiRg2lX5p6I7WAOIKz4TDnvSE0SNGl0Yi0dONDQymUgjNg6z6QNE43drGscYmZCU4t7KmJGBKlPx3gdBj8alVOw6ObBvM4Og+Bnu7mVgVZ+FlE7JVHvGN3+aytMOXnnvzwKefWr2R1iyYWhhbKJiWSaq3i8njaviLe2+nzEcya6G/ueUAjuLHllSKRhFhFLhiyhhGVAZJRDWG1Y5m7+FjdPQO4vUHkVQPsqLT1d3PyVOnKCmtqKyu8ndkDSb/phIMBRjekzJv2bn/CClHAkXGyKSZN2MyZUH1TFSw8tcdkx6bTzX0FB9+as2W0HPr3qarIOONlZHLFbCyA6Q6mpk7ZQxf+NTHmDEmsSYiO6uqZPF/hvpz2wn39RTFJ1fvODz+uTe20Zax0MIJUFQcM09fSwPL5k7nvjuuM6oD4mtVXFzhyE64b+vxzm/+bOUbdOVlpECYTDKJx84Rl4vctGAmC6aOeykgsf182uq4uLjCyMXlgyiOYLcpk4iXls88295KR1cfms+PLxgim89x5nQTJfHSyhGVkYYwFxZv9A4lgidD5bHZXk9g5P5jx8gbBoqqoWg6lu1w6kwT2VyBiqrq+mBAuuj5fhNB2CarJIdVlxrRSGz8yVOn6enpxecPIGQFQ5LpT2ZpaDxD3qCuorJqsazxX44Tzxb45mvbDoQ60ueKWNr5NFOGl1M/aXRnhfY/g5a7HZYnBYtefavhnn/75Uq6CjKBsuEUHIWiYVAsZBkxvIpPf+JWqkrAAT0LrHpjL/05kFQdIQSSZTJ5bB3DqkMIIBxWUEN1bNu9j4IFkqJTMB0UVaOnt5fTp09TXlk3qaTEY+ctZ2xYFv/FictaTE4WxC27jjXQmS4gdJ1UXw+XT53E6DLv9gis6nbs5Skh5ncX+GxDp3HLvz79Auv3HEEEEmj+MLZjYqR7Sbaf4u5li/jCp240hsfUJyOC1RWSGPIGvu3wYHeBe1976+DUJ15ZS3cO5EAESygIu0BvSwMLLruEv/70zdkaP/+7kotr2NoDd5/sy//H46+uY3djC1q4HMt20Kw8IWFw3awp3HZ1/atjPdzoiiIXVxi5uHxEiEis8gbVQCQWn33sZCPJTBoTiUAwTDpTYM/efUydNH12MCRfcH2jd7AFvuHDSwuhYGz8gb37SKfSeP1BNH+IfNHg1JlT5At5qmrqZtseURvlwitUv4sY3GcLAqNr4pvHj52weLC3h9OnTmLh4A1EcGSdXBHe3nuAtp4BqkeMXuz4xNgiVPc43NOTZdHKrXvozztIioYoZJg9oY7LJ9esMaDy19eo3eHBfptlv1h34JZ//MkvkaPlaNEycpaEhSCbySI5NpeMG4eiqBxvbOdEywC7DrZyuq0HS/IhaT4QErZlkU6laGjq48ipHpp7HHKmoKmtg6wBiu7F5/FhmAa6z8tgOsmO3bspq6itq6wKkYXJBlS+4/z5JA702PIXD59u0xu6+1A8forZFNMnXcLIymAmD2OLQlR35vnzFzceGfkvP3+Bhs4k/ngVQtbJJAdIdjQR04s8+JnbueeGyzeXq3zPZ3MoIfHYUD+3LljRbvA3T6/eNubfX1hNRvYh/CFUj0YuM0C+r5Xrr7iUL3/2luxwD58vg4uqNt0Ny9vz/M0vVm9JvLn3BEq4BFCQjDy57hbmTR7Np29a3DLRxwx3F3FxhZGLy0eMMKzVosHZsuYZ2XjmDLlCEW8gDLJKX3+SjrYWJk2esMSj03gxXer9gt1xwTPRypL54VC07kRDI8lcHs0fQmg6SIJjx0+Qymaorho2VffJQ9Y+5L9dx74gbAuFtfbJkydM1DQ1evrUSQpFCyFrKN4Asu7jyIkTnDzdRKKydpIa9F5lCMrO9hWir27eBZofTdbIDfYxbXwtl4yuQRV0ZmFyDib1wa19Nretfrv5in/6yVPoiSqkYJy8LcgbDiBQZIGua7S2nmXfgYPs3neIPYeOcfJ0K2gebNRzgeKKguM49PUPcKa5ldPNHezae5CG003YQkFoHoqmhWlZIEsIWUZSdbLFIrv27CWeqByWKIuMNgTlecHYPIztd7i5r8iiYy3dHDjTieILkhzsp666krEjSutMibLmfpb+8+Mv+X7+2iYKWhB/PEHBMimkB7EzvcwcP4wvffYTzJ8y7KUwrKmA7/ikoXVOuixWDEpc3ZLn68+s3ZX4j+deQ45WYKk+NFVDmHmcdA/Xz53GX9x9XbJM5d8qufgWI2dN/n+vbztS/+ybW8koPmQ9gJnN4MVgUm0p99y4mDGlnocv9seCi4srjFxcPqAYwimLlsQWWrYjn2g4Q86wEXoA1ePj9OlTGEWDSyfU2XGJZy52roTMTxM1pRODscT4wydO0D2QxhuKIIRG0XQ4faaZglEkniifrwW1SARW/y7u2Q+7hYoxcWxNazgQmtbS1EJvTz+ax4/k8eJIGs2dXew5dhxfolYOxALR461p1u/aj1A86I6MR7KYPWM8w2rifhsCKYP5AzbXnehm8cq3jpU/uXoDViCGowcwHRnHkZAlCUmAY1uoiowkySiqju4LoQciqF4/QlLQdB1ZERQKeTRVQ9c8yLKGR9fxB0LYQkZSNAzHAUXBdCyQFEzTQZI1dG+IvOWwdft2FE/Ep/pidcIjzS061OVlxqUh0diVZ29DK6o3SD5fIBIOccmEWhrOFuNf+96/s+90J/5EDWoggmkXKCa7CUg5ls67jBUfu4Hxlb4fhGC9VCjm/MrQ1SeCc8eQpkTiTJpvvrxpt/7Is6+hxYdha0E8uh87P4g10MnHr5nLZ29a2FKt8XdD0cW+yeE7u050f+KpN96iNWWghOIUC0Wc7CAx1eKzty1l1uiSh4dCgLm4uMLIxeUDSlCIbWgS4UhkYV9/ilPNrej+CLLuQ0gyba1nCfo842NVZVPjMk9f7HxxiWdKauJjvf7wpOMNjfT3D6LoPvyhCA6CpuYWcsUC0Vii3hPSIyZOwocY8jiOAOy0IDJiWNmpqoqa2ZZp0dLRTtGwUH0BUDwMZAvsPHiEAgGau/po6hxAUjwYBYNwwMeUS8cTjPrU1u5cZUNbb3TttiO+p159g60HTlBQfBQlD0XLwbYFsgSSZYJt4FFBwsKrKwgcZEByHKxiAaeYw8olkaw8wiigCxthFvHIAo1zbUF0VcW0DCTAH/AhHAchwLEFjiNhIYOk4guF2LX/IFt27aWlK0NLdyoxaPoSSUvnVGeS/cebELoP23GwJYV8QeWXL6+iO++gRxL4Q1GK+TT53jaGJ/zctWQ+t1xVb1SHpH8ZDg/4Yd9Qi6IeuLsgGNla4OG1bx+W//WpF5GCZejBGDiCYrKPkJPj9quu4LaFs4xKr/QPF9oQ9tfpgAcau82/e+aNrWw73oQnVkEmV8CDg5TtY/nNS7hm5ogf1HLh6f8uLq4wcnH5kBCCTT6/1u0JRpaebm6hozeJovvQ/AGS6TStbWeprakd54v7ay1B6GKO1QBs8NZUJQKl0ejIxpMNDKRy6P4gqsdPwXI4fLyBQtGivLysPhrUT/0uArLhXC+5gkVdRVng0IgRI+eqisTZ1hZy+XNHioonQNaCI6dO09afwpR0dG8AW8j4gyE8wRCHG9p55vWNPLt2C/sa2+gtgh5K4Eg6sqKBI9BkhWxyEMnOg5HCzvYjzCz5VD8Us5AZRDOyBIVBSHEISxYBigQlA79TJCBMRCFFMTuIkUlSLGSRbAMZG7tQQJFAOA4q4NgOqqKherwga1iKl2Te4WRbN7uOnmLP8SZ2Hz9LS2+KIjJC05E0jcF0nhMNZymg4YvGMewiVj6NOdjFrFE1LF96NVdeNmp7uUf8y8Wmwf9Wp8hyluclMa49z9+s3LxP/eHTL6NGKlF8YSyriJpP4TcGuHnOVO5ZMmf31JBUE5QuvgZWNyxvzfDV5zfsCKzaugc5WoEt6aiOQ6q9iXuWzOcT10x7aoQ09MUqXVw+DAjHcdxVcPmj5KTFk6/taLjrJ69sYsD2oATC4Bhku5uoH1fLp29cxLSa0BeGqm7LcYOVWw6eXvroy5s43ZNCDYRQdS/CMUh1NnPNzIl8YulCLin1f7NGGtrmo/+dFvhaa4aH39x1nLU7j3CsuRc1XIIhyeQdE8sRyIqGhIwuK2iSQ3awl2RyAF80hKzqCEnGMCywHRQcPIqCU8xhZpJUlITxyA5mIU006CVREiEYDBILBQnrPjyKikdT0BQFWbKRZJAkCSEEhmmTzhcYzORI5/Kk8wYDqSz9g0n60jn603mS2SKmraD6wxQdGcnjw3IEkiKfk6LCRhYSmUwK07SxbPCHI9g4WDhYRRNZSHgUBUW1yQ104DUzLJg6njsXXsHYCvWpkMSGUt5fX7YLoRW+0lVgxWvbjlT/7JU1DDo+9HAM0zSxM0lCVoZb5s/glgUzk9NjWngo5myHBzsz3L9uT0Pdz1e9yYCtkhE6sixj9XZTP6aav/nkTcwuEcLdIVz+WFHcJXD5o3WOZDbMnTq6/kxnX93KLXvIpU0CkRjeWBn7Tp5lw9sHKA3N/oYISkaZdHHZPwBjVa6XL617UpK9d/3bL16gub8HOVqCoup4Y2Vs2N+A5cgsv/7Kh7RyveViM47eDb1onSn3yt+9du7YZbFERd2rm/ewr7ENWw2A0JEVFdM+18hV8/rJZVJI3ih+1YeiqkiKSiaXA1ugyA6asLHSvZDp4WNLFjJ9wmh8moKRSxMMeAn5dYK6ctqrKkd0WZxRJHplQVKBPgAH1HeuzQHFgDLDorxgMTxvMjpfNOvS2TzZgk1vMktHf4rjTW1sP3gU0xTo3lIKjgToFA0LywFNk5E9QSQHHAGOrJLP5dC9HmxVQgiFvJFHZJOU+b0smTmNq6ZNYHRCvOSH3b9TUWTzld4id67edqj6mXXbGLRVRCBA0SyiGDl0M82yK2dyw9yZ1MS0h4Zizg6LB5KChXubuupeeHMr3VkDfF5k20LKpqgr9XD30oUMLxEPubuDiyuMXFz+CCmFRwpeht+4cNZDp1pa2HzoJB6/D0uooEfY8PZBSqNh37LZkxaXeYZGpIyS+LgzsVw1zKW3/eT51zjZ2YavpBzdFyZrwMa9J7BzBVZ8bOkPRJlq/q6+nBOa/FgbfFl2SI4aGWLiwHgau1K0DebRg14KJphGEVVSKRgmisePYeTweD2YpknBMPB4vDhWEVHMUkz34LeSrPj4jVwxaRQjYurXVei0CIYU6Lug+5B/9adBj0+524oEQhaEZELJzmz5/VdMGT1+fv1k1m7fx6a9hzGVwLl+eIpGNpujaNtoHg+KqiFJCkXDwuMNYtvmufGFQMgCy7KIRhNMmjCReBRkSP6u3breAneu2X54zEsb36a3KBCBGLKmUEj3I1J93Hzl5dx65WxjZkjShmrejMO0hu7M0hfXb+VUbxLZH0HVNKxUHyLbx6fuvptpoyOPXmxdJBeXDztujJHLHzVhWCd70Msrq+fuO3KUgVQOXzCOhUw6n6e/t59YNDguXhYdsjYecYlnImXhkfFodErT2RY6B9NIuh9V9+EIhVNnmklmM5SWlt7gC+kX18ftt9AJ96Vh9pHW/JWb9jWz5/gZOgYzCEXFsk0UWSBzLqNMCAnVqyEUibxRwLZMLNPE41XxCAsr3Y2U7uKvP3sH19aP3lzjk/+hEr4VgJ1B2DIUfbV8cOCd8QKws0zlh6qHwogS71s1dXXzbcvidNNZbEkGRcVypF+VADgnikzTxDZtBAJZFhjFIg4msiKwbQvhwEB3D7mUgU/1TIkE1IaI+O295C7IsSmaDwzK0uKePJ/auOfEqF+8sY0zfXksbwRLUcAoYvV3c93lk/jEkvmMCCsPBsTQpMl3w/IuhxWPvrAusG7vCUSwBFn3oGBQ7G3jnqVXctMVk9eMVrjd3RVcXGHkCiMXVxytC4R12xMpXbh1+w5MS8bjDyOrHnr7eunt7qSqsnpuNOptH6rmmbaEv6I0NlBaXjG1qaWDjq4eAoEwmqYjFJWTpxsZTCaJJuKLgxH/kDWebYcH2y3+5mjn4Bdf2bRv/Kotb7N133G6UjkcSUHTNMx8mmyqn2IhQyDoQ1EVCmYRCwtd0xCYeHUZIz2IMdiJJ9/P/77v08y9pObIRJUZAX5zU9ehJijYkrWYEvLSOGpszUzLUjhw+PC59H5Vx0EgJIViLodjO3h0jYBPp5hOYuQyyFgoMng1HduyOdvUzKlTp2htb0PI6kwlFvtYUaE6BxOHoo5PSpbmdGR44PXtB2ueW7eN1qSBCESxZRUsg0zbGa6bcxn337GEuqD8UIXgH4dqrbrgzx59Zcv8Vdv2YXnjWJKCsEyyPe1cP3catyyoZ1hQ/Qe/cJvDuri4wsjFBcjDuNrKyED/QHbK7n0H8QejGI4Cik5rZwfpfI66UWNusGQqo9L/6691MQ5IVOLlkrKQHfCHFracOU1/MoWierEkgSNJNHd20dM/SDyRWBSI+C66CGQTfKcpw8PPbdw77rFX17Pl0Cn6TAlLD2AjMAt5MgNdFJJdXDK6lrvuupmamgr2HNh/Lm8eCYGNU8yiWAUKPW3Yfa38fw/8CfPGl69JyDz2mxrS/i4JSOzIFe1LNFW01NZWTO3rHeTAoUP4An6ErIAjkISgmM3gmEWmT76ESy+pwy4M0tfVjlnIowoZx3HQfQHQdJo6e9l15ARNbX0J2RuaG4r6E5ZEsAAjLyRDsds2l2eENLMtw//auK+p/JdrttKcLKCGYjiyijBNBs6eYlypjy9+6nbGROSHhuo4q9N27msX4q9f3Hronn9+4iWUaCWW8KCrCmo+ybCQyvIbFzO5JvT1oRRiLi6uMHJx+ZDjh90GVIy/ZFR5b3+m8mhDI1oghOLxI2k6DadPUzDyjL+kbrgiMzBUzlHBZuTwquj+RLx0/qHDR+jq68EfCiN+lX5+uqmZjs4O4ony+YF44IKKQLbCV7rhsxsPt37uu4+/wOtvH2bAVPGE4ghJxSoWyaf6KA70cMW0Cdz3mU+y9JpxSLrCSyvfpD+dxXTAo6k4xTxWdoBCXxthcvzfB/+MuWPLXorLPP27aJHxvpwjWWyLwssFwcSJ40eNtxzYt/8ApuXg0b0oio4AjGKO3o4Wpk4Yw+J5YxkzfBTpnnbONB7HNopIioysevCHogzmCpw808L2PXvp7ktVJqpqF/t9ck/aYfb5HKn2ONbdRUkZ1l7kr1/ZdKj8x7/qI+eNloIkYWRTJNubmD9pNP/3i59hVEz+bo3gK0O1Nv1C3LzpSMvnvv3o01j+ciQ9giQEqpXFZyT50zuWUT+24tk6mfvcXcDFxRVGLi7/1X2AnZJMdtjwkbecam7mZEvbr4of6jiyyoGjR/AHI7664aWViHNi6qIFmWBfCDYE4pHa8kRsanPTKdr7BtACIWyh4KgeGpvaaOvoorKyql4L+8bGJJ57P2N3wYouWNHYb33p8de2Tvn+UytpzTp4SirRPEHsQhEz3Y/XzDC5toy//NO7uemqS4iFBR298J0f/ILGlm68gRJUTUeYRRQzg53uoTai8pefvIUFE6ueHSNx6wehuWhc4hlFIT15wvB4cjBTeeL4aYSiIYSCouqoMmTSA5w8eogJo8Ywc1KAq64Yx+TRY8n0dfwqxiiDZVn4ghEkn5+8Ldh3+ARv79lHMFYxrTQRidsy3oLNyPdzzz1I93SZ/OkrWw6X/ujplRAsRQqGsRwbp5Cl2NfGsjmX8Vf3LqMuyENDKYpOw4+OdBe+8I8/fZbmpEW4fCSFgoFq5GCwixW3X8vi6aM3RyVWBqTfz/Gni4srjFxcPmT44IDklaTqYcPnH2s8Q1f/IJKiIXt8FIF9B/ZzycjRlaUlAdsB5WKLP75DVOblcCKeqKyumnnsZCOdvf2oXj+S6kFWvXT29NLc0kqitHxStCSgh3l316IT7usx+NT+swPL/u3pV3hp49sEq0eh+qOoikqyuwu9mOSSqjgfu2Y+n7hlHuUxzZAEclO7w2NPvszRpi4CsQqErBLw6hjJPnJ9LYytCHHfXTdxxfiazWGcdUEhtn1Qnl8QttngnThhdO1gspA4cbIRR1ZxBCDLSALy6STHjxxk3IgxlMV0auJ+FsyayPDyGqxcmr6eHlKpJJKqY6MSisQZTOVZt34TQvIkxoyqLdMU2otQ+27PvxW+0lPkU0+v2V3+0xdWo0YrMTUPYGPlkqj5QT529Vw+c9MCY1iABysYuqOsDnjgdJL/9aNfvMKuxg70aCW20DDzOUJOlsX1U1g8czLVIeXfKuSLr6Tt4uIKIxeXjzAhwQbLr8+PhON1DacaKZgOqtcPmpdsNkdT0ylG1Y0aFw/rPVEuPt7oHSIyq4KJcCAajc4+cfwYyayJovnweDzYjszZzl5aO7spLyubG4r7dcMxKnxC/h9fzGfg+2ez9t+t33uy+rGX13KkdQAtWonpKDjFIoMtTQyLKNw4dwr3LLuSmZeUvarJ9NkOgTOdlu+pl9/krQOnkIOlqL4glllAFDKITB8Tq+PcvXQeCybWPhsVrCwX4p8/gM7fDlkiWVNTd4vtOBxraMBWFGxJQ6gauqZTNItsfmsrI2rHMKLCT1Rm89jy4L4Zl4wdGfRIcjaVpLOzC1XSUdDxeMMILcCOvftJpYrl0ZKKhYGQmjEEFb8p2LwdHuwscv8LGw9V//SFddi+EmzVBzhIRpKQyHPH1bO585pZvcP8PDiUNau6YEVbjode3rQntH7PCQpaCG8wipHLIWV7mT1+OHctmce4Cs83VdPqDsiS6xa5uLjCyMXl3TElSiLh8GgQ0cPHTlC0BLLuxev3c7apiVRygEunjJ9mKwSGsoVHGNZGy+OJkpLSmSdPNdHb24/P60fVvRRRaO/soq+nm7LS0rnl8dC+EGz69f9vhm8d68p/4bXt+/nFa5voSFnI/ihICrJVJNl2hgVTRnP39Qu5Yf6k7aUBdY0G7RaETrRlJz3z2ia27juFGqlA8oYQSGgUKfR2MKYswD03LOLKKcOe9Vhmg+JYfX5J/kBmMfnggO4T3ZVVtUvT+TzHGxsxbYEtJCRVwwJS2TzHDh9kVPVwqkoCGT/sjnhZPXJ4JcOra+qE5dB29ixGwULXfaD7ELJGQ+MpOju7iESjU0KRYMiQKQvCli7LWOGX5N3N8K3OAn/+/Pp95f/xy5UooXJkbxBZkjCTvYSkLLdeWc9NC2Zmq318dahFUZ/FrRv2nJj69OubyQgfaiCCUSwgZfsZUxbirmvmctnI0Hd1mzNlivRD9213cXGFkYvLexKEbbaMNxoJL0pnsjQ1t2AiYyPj8/ppPHWKgC/MyOFlJaZDIiRdXMbYfxFlEBtWGTtUEiuZ39vdSUtHJ0Lz4PUFkBWNM81nyRUMSkvLFnrCnkAeRg/Ckg6HLx5szdz7woZdvLxhJ1kC6IEojlkk09OOM9DGPTfM5/ZFs5h1SfmjAYmdGrTlYfSRjsxNL2zcydq3D2MHSpF8EUxbQpUdnHQvNSGF266ayZVTR2yPSTxXKUn/8EEVRb/mHO20FRLVNTUzLduiqbkZw3KQ9QCWUPCHwgwmkzQca6CspDxRHgt7fQoHNIm20pC3cdzIuqnl8TD9vb20tbeBohMIRVG8Ps60ttHS3o7PFxwWjoSnZhRphinLiT64rSXDn72yaY/v+XXbKUgBfKE4jlHEyvSR0C1uv3IG18++jKqQ/H+GsnN9D9zd77Bsd0PX0mfXbqahPYk3nMAyDPKDXVR54ZPXL2TuhOqXRsosDwg3rsjFxRVGLi7nI44EW3S/2h2Oli7tG0xxqrkVzRdAUjUcIXO68SRVldXx6vLQQFzw9JC5HYIDIdhQVh4ZiCbKlrS0d9Ha0YXuDSAkBUnz0HimmWQ6TUnlsNlKQBndk+W2tw42jXt5w3be3H0UQz3XpNY2iqS7zlIZlLnvrmXcctXMlrqE7xEdTuOAKShtSfO5lzbs5OUNu3F8JWjBUrJFG0VWEEaWYl87i+sncvtVl7WUqDxeLoamd9zvg4jMKsknJcoS5TOLxTyNpxopOOfWUNFUJEmhp6eb9rZOykvKysvjwYJX5nitxJc1j2ivqkzoVVXVI5PpJCdPNaH7/HiCIUwh093XT2d3D6iaL1ySGG+r1HYXqV+1ZQ+vbt5NxtHxhUsw8znsXJKQXOCWRfXcduWs/bVB+a/K4ftDea8DcF1Dd/H+X67dxK7jTfiiVRimg13MoeT6ueOa2dw0d9JLY1Ruct9uFxdXGLm4XLDroAT1hKIHZrb3DtDR3Yek+fB4g2QyKXq7Ohg5vG5cOKQPDEURwP829w5PLDgynqiY0tXdxakzTfgDYWxFxVF1Trd0kS4KfJGa+P4Tzfzi9fUcOduNHCwBWaWQS1PobaF+TBV/fteNXDNr1A/iKs9Uwt/nYJIlCPUW+fgbbzdE1+44RE4JYWthhKJjGSYSBoqVw+ukWTJ7KtPrYo8OZdbU700cwSrZryRqy8tmmmaRk80tFGywbYFX96N7/PT1DXD2bDORWMmY8pKwUSLzpB92G5JTVpHwHhk5alS9aZnsO3CArG3ii8QwJY2+VIHm9k4KqEjBmG/X0SZWbdpNT9pC9YTBNDBSPQSkPHdeN5/r507rLffyvVLBvw/lPXY7LG/sK/zL6u17WL1tPyJQStGSKBZzmKkull05izsX1RuTvdIE9612cXGFkYvLxX2xClZ5SoIzBMqYU2eayBQcJE1H03R6urso5NOMGDVqia6JZj/sG8q5LUEkEvV7w+H4yL6+XtraO9EDYVRvGEPItHYP0Nmb5K29R+hJGyi+EKYjY+TSiGwv186+lD+5+RqmjUp8c5jgwXdKDPTDjd0FPrvjaOewp1/fTNNAASlYQtFRMAwLn09Hcmx0p4jXyVI/cRTjKmPbI+L86yh9UJ6h4lelRCIxv7c/ycnGM8iKjqJ5kDUPtizo7Oyku6eT2sraMd6YtzYqeDlnm5OEJNlhn3xo5Kjh9R5vgB179mDKMqo3iOTx0ZvK0tE/SHv3AAePn6EzaaD7I9iOg5kdxGeluWvpAm6Yd1lLhY9vV4ihzwJrzvNPmw401j2zdgtpR0fyBBAIsgNdTKqJ8+f33MyosPQXv6+q5C4urjBycfmIUyLxZCgWvsoy8sMON57BcGRUXccGWlra8Hl0qisrRssqyaFK4Qfww74SiSf8JcGJ8WhsfFdXF21dfSjeAI6sgqbTNZCkYEsIzYsiyeQH+hGZbu65dg6fXLqAsWXeh6oFX3vHWRgULOmy+Nz6g+3VP1u1gcbBIiKUwJb1Xx0xaaiyDFYRxcoj5VPMmzGZSypCLw1Va5I/BCHY4AnqdlVZ5cJkMsmZpjYcRSOPc65vmFenvauTjo4OqiqrpnpCvtpqWf5qATFcgcGwxsaaYRX1sXipvmvPHgxHRvZ4cVSNrAmdPWnSBVC8ITLZDIXMAIX+Vu5dtoiPLZqxuULnO0MZaP0Op+FHWw+33fbEqi305CQ8oShF0yCb7KUqqvG3n7uLCaXat6vgG+6b7OLiCiMXlyEjoUmPBcrK/ry5s9/X3tOHLSsITcO0LJqbmimLRxO1FfH2oW4+CueKF4ZLQxGvP1rf0NRK10ASFB2hexhMZ9A9PlQg39+N107z55+8mZvnTe2oCUp/p9m0v1OMMCWYn4Fpb+7vvOJHz6ykKVlACccxJRVV0bCsc01jZckG00S180hGijlTxjOmIrTuwyyMfiWONvnDWjoULl3c0d1Hc2s7ejCAKQQoCkJS6ezqor93gNqKyqneiEevgO/4YXcQttkK3uqqxNhwJB7YsWsXkqYj6z48gRCOpIJyLv7MKubI9pzlk7dcw8evm9VSovDkUMcUAbTA1450GV/8j+de40hTD5IviAUY+TRmspPP330r88aXPRuCjUMp2F1cXGHk4uICgORVCtGyyiW79+2nP5ND1r3o/hC9A/30dXVRUzN8pj/qfc8CjBdCEYYlKsKSFi0dc6allVS2gEDGH/DhmHnS7c1ERI4///hSbrhi7JoyjR+Ww/ffEUXN8K1euPO1Xa1X/uDxF+nMm2jhGAgBRpFUXy8eWULIMrIs45gmilNALqa4YuoljCsPrxzqOKo/BEHYFizx6pFExdyTp0/S3d+HkFWCwRJk2Yumejl66Cjp5CAjR4yaqwUU+52yCCHYIMnkKkoT08rKywI7d++mYFjkCzaSKmM7NvlCgdxAN8vmz+LTN82mROYlP+wdamHSYvG1DpMv/PCZNfqmAw0ESsqRPRpgke5s5pPXzuXmudM6SlSeLGVoY5pcXFxh5OLiAsBAwb4uHtMbA9HSqRve2o7k8WLLGkLW6Gxvo6e7mzGjxs21Nbk2KvPyUM6dgjkGVHriwfFnu7OcPNOChYRl5rHSfdQGFVbcfi03zRn7g5BgQyk88s7/dsAD/bDs1Z0np3zzB09g+mIEYqUgCWSrgGQZjKutJhoOMZjOgiSDZSHZBkpxgCsmj2NsRfT1j4IwAig61IZLvKHSYWPqjp06y2DGwBLauXpPso7X7+d4w0kGk2lqq4ctlDxKIiKfcwIDsFOomFVV8Yry0qry48dOYhgmsqoCEkWjgOZY3HTNQsZWeJJeOK7DkMafdVrcNwA3/GzltjFPr30Lb0k1qseDZeTJ9LSyuP5SPnvz1VR6xT9VSkPTkNbFxRVGLi4u/4OQIjZE4eWSinDlYIFpO/ceQGh+ZN2HonppbDyNJEFNde1U1ScVhvLoKQ31PQU+9frWo77VW3aQl1T8AR9kU4TsLJ+96Squnz3uqZBgfYL/19C1Ax5ot/nSS283jPvmj55ERKrRw3EKhoFTyGL0dXLFpRO4Y9l8CjmTE82tSLKGcBw0u4hcHOSKKZcwpiL6RhC2fRSeo1+wbwCu16P6+FNdJifPduH3hzEtG1kIhKph60EOHjvJQF8PY0aPmqn4ZanoGNU+IR8IwA5LIlKViOgVJWXDTp9spKd3EN3rRxUSZjHPzre3MXH8VL0mopxRHbqDYujWrl3w16/tPnvtD556BU+sCo8/gmNbZLs7uKQixJ9/Yhmj4to3a6QPXxahi4srjFxcPoTkYWxF7bDFrR3dnGw6i+oNoHvOpX4fbzhBPBqmPFE2VWhYQ/GF2AUrOnI8sH7P0Zqfv7KODDK6z0cu1YueG+T+j9/IDZePe3a0zJ2/fmTTDg+2G/z1G7tPVP7rM69DoAwtFAchkMwc5kAXcyaO4uPLFhMPwvHGFk60dICqIzmgOgZKfoArpoxjTGV0zUdFGLXA17ry/NkLb7zNqs07UQJRdN2LKiuYZgHDNFE8ASRV5/SpRpLpNLW1NfMDAb3ZoFjpR94XhC1CxiiJh6PRcKyuu2+QVDKDoqvIisLAQD/HjhxhVNXwcdUJ/+6iRa1fujjXqNMy7+uWpM8e7Src87V/eQzDE8MfKUGybQqpAaojOp+5aTFTRyReGiHxJ+6b6uLiCiMXl98LQdhmydQOHz5ianNLG2db2tH9ITRPENOGw4ePUFoS81WXl6hCwbqY+JIuWNFlsmLLkTOTfvrKOnpNBTUQI58aoNDbzufvuJ6b5k5cM1bmxv/8H9tZ0S/EjR1Fvrhy+6HSf39+DYOOH2+kFNuxMDMDMNDF3PF1/MmtSxhToW63TKp3HzhOY0cvQtORbQnNLiIVksyeMo6RldHtIYauwvcfiiaH75zqt/7m2TVbeG7NFiw9jOLxo8gyRiFLLp3Eq+s4AlRVQ/EEOHj0OAPpFMOGDa+P+vUjecccGxDSTh8csCX8NVWRTo83MrXx9BkG00V0XwBd9dLb209bSyslicq5iai/92KPV3uF9PHTyeL93/nZsxxrT+OPlSMjcDIpgk6G266azaLpY/aXavyHG2zt4uIKIxeX3ytRiZflgFIbCpVMbW3vYCCVP5eZpKoYhk3zmVNUVpbXVZWFThUtp9oviQtyC5pMvvPW0Zb6J19dR1NPFm+snFwqidnfyb23LuETS2ZsDsPaoDh3bNdjc7cliVBbnofe2HUs+ou1b9GRBV+kEsO0IJ/ESXYye9wwlt+0mKk1gW9q0JrOM/vw6SaOtfUiaX5kGxTHQs4PUH/pOEZXRjd+mIVRNyzvg4/ta0791dOvb2Dt9n2ooQR6KE46ncYpZJGKWSqjIbKD/ZimAZKMI8ug65w63cSZ001UV9fOLYn6z+RhdAB2BAQ7LUEoVhIcFo6UVjY2naW3d5BQNIokFLp6euju7qKyonxqIOrXw+LCAvM74IG0YPbTa7aNXLP9AKGy4SBp6BjoZoqrZ0xk2fwZVAX5ezfY2sXFFUYuLn8YcSR4OVgSHKvr/kl79h/EsEHRAziqysDAAO3tHYwaOXp2JKidNk074ZPFef2Kb3B4ZldD37VPrdrInoZ2fNEybLNIrruVT1wzl48vnmNUavz9r7fp6DJZ0ZHlC6+8dTj07NptdKbBG0rgSCqSXSDb0cj8SSO5+9r5zBgZ/7bP4ZAsSA0W7BuONLVzrLUbofuRHRXVMZEKSS6fcgmjKiNv/S6y7X7X9Nj23f1CLBswuG7H8ZZP/3LtNjbvbQBfBMkXJm9aqNjYg93MnXIJ182ZQVCVOHbsKMgSkqaDouLzh2hqamWwv5+KypqZ0YjelrWZEhJs8sGBokxVaSIQ0XV/+fHGBjKFIt5QCFSd02fOksvkqCqrnBuInn+V9G5Y3pG1/3Ll1gMzX1y/m6Jyzp1UhE2mp4X6CXXcs3QetVH5m1XCrVfk4uIKIxeXPyAxieeUSOhPixaBI8dP4Cg6FgIUle6eHnp7exg/7pJ6v1ccCon357h0Oyxvd/jrI2dzdzy5agM7Dp8iXjkc23FItp1h0cyJ3HPtAmoiyr/8+hfhWfhGR9b54mtvHdSff3MXLf0Gqj+ComoUshnyPe1cMeFXTtHwxFN1En/qExzI2M60vJDGvn20OX68rR9H8yM7MpJjIYpJZk8Zy+jKyJYPozDqE+LW1rT1d+t3Hxr51KoNnOzM4PhieIJx8kWTfGoAkRvgqmnjuevaBUwc5u+tKS33FQo5Tp5qwFE0TGQsWxCKlNDa2kpndy+Jkoqp0agni0DKwmRhYYZU1pckolM9vkB018FD5EwLzRtEUXU62rvJZnMMq65Y4gtoje/3qKvbYnkSFm47evbKX67dQm9eRvIEETjk+7sYWxHm9kWXM7E6+uhwmQfcN9LF5eJQ3CVwcbl4LgsqFek5lzndPX2s3XMULV6F8AfJOw4b9h+ntGQjf3rb/MWSIPd+0qdNQaxlgLueXbeNrQcaCJVVYzky2b52xpSFuPPqKxhRqv9gmOAv3/mfU/Djtox57yub9vH82p3k5CjeWAJJsn/liHRRF9H5k1uWMnV48NGA8/9ci1JJPNIm+LJjA7ZAOGDj4AhwAAcJAcaH7bm0wNca+q2HV7+1k1Wbd5KyFPRIJY4hSGaKGOkBtHw3t149m1uvmUttWDyiw+mSKrVMuXrWFzSKvPT2ETzxGkxHwdF05JIaNh9uwpE28Ynr5y+dVBNWx6lc885uWuLlCWvGuJ7Gto74L9Zswu8PovuDFGzB6h37iYY07rp2zjfNgBovl9+7Ia8pE9t3oveeVzbu4nR3Fi1SiZAlMl1tlGgWt1xZz8yxVa+OUPiM+ya6uLiOkYvLB+dl8itSvKRsfld/Py3tnQjNg6zp+ANBjhw9gq56q8eOrMzEBU+/2zgd8EBzin/65ZrtrNmxDz1cStG2KWSSBMjzwD23Mn10xZpRCh+Hc8csPfCpthx/9uy67byyaR/9poLQIyBkMHIku84yIublq3/xWabWeh/xwaEy8V/bU7QU+Pq+k+360ZZu0AIIW0Z2DMSv0vVHV4Q/NDFGPQ53dwuW72sa/JuX1m9j7fYDZPFgqUFSeRPbsigm+5FSPfzF3cu445rpJyp94hEvHFWweysR3wqEPQOxeMmSVDZH46kmUDUcWSOZKxCIRGluaaajvY2aqoqR3rAv8esVzx0NvXrE8IX7Dx+lqaUdXzCC5PFiWhatLU2EAqFQTU2ZnlD46bvdR6fDfY099vdeWL+NbceaUcIJDEdCsoo4yS5unDeNm+ZNOzLBwxz3DXRxcYWRi8sHipBggy/ikby+8Pyms8109ydRdB9CVikWi7S3d1JRVj2utCzwW+sbdcADg3D1S5sPjfnZq29ieYIoPi+OWSDV2czdNy5iSf34lqiHV3I24wOCnZ3w5y05/uzx197mmbXbSVoqKD4cBKpskRvoJq5b/O1n7mD2qMDXh8GDvynGpdPg/p1HT4eOtfWD5kNCRsFELgwy+9IxjKmIrHunAvQHmTb4clpQv/1E7+d++uJqth9sRA6VUBA6RdtBCJt8fxfVHoe/XfEJls4c/myJyhOV8A9+2O3jXBxYAHZ4Al6pbtiw+b19fTQ0NaP6AtiSjmWDx+ehpaOFgf4UlZU1Mz1BLWJCwic4EIJNtkLtqJHjpr62bj2WIqN5/Ui6Siabp6u7mxEjx9R5olqtaRH/TWn87Q4Ptuf4q5e37Aut2rYXU48gdD+mlSPf1878iSP4zE3XMjwkvuhmoLm4uMLIxeWDKY5ggycemupI6rh9h44jNB0bGUX3k06n6OvpZvSwEYvqQurXftP/98OyrScH7v3+z5+noAXQw1EcyyTd3caNC2Zww7zpjIhp362GrwYEOxtMnklLzH7q9d3Rx1dtRItVIXv8qLoGZh4r209FWOF/3fdp6kdFnhou8ee/ad4uixUpg/kHGltDR1u6cTQ/wpFQHRO52M8VU8YxuiKy/oMsjLptlicFVw3ADa9sPX7DY8+/xqnuJEogBrKXdCaH4ljk+zuYVJvgoRV3Uz8m8tRohTv9sPs3Pk+JDT6/0j185Nil3QNJDp9oQPMGz2WqSQ7BYIjG0020d3RSXV1TXxLxHC861PoF+wxBeSik2bHymnEbtryF5PHiyBqq5qWnf4DBwSSTJ46ZGtTY/puEcrPFP63bc2r806s3k3Y8OHoI27bIDXTiN1P83y/8KaPi4ktl8CP3zXNxGTokdwlcXIaWMQo3XV0/6cT182dhpvqwLQPN50MNlLC/oYVXt+7gsPE/CyW2wZfbijz081fW0pbKo4ajKKpOId3PmNpSllwxjTGV/mc1aO2wjQda4Ss5hfFPrz5a9+Pn1qIES8haNplcFscqoJEn5jF48N6bmDHSv+bdAr9LZR6RJZK2ZQA2kgMCEI6F7DhI2Dgf4JjEbovlRYnq5gLf/unre+b+y5Mv05wBEazAlDzk80W8wsbu7+CW2VP4+n13M32499sR6b0b/pbBD0dExbfvv+tapg0vI9nVjOxYOLZM1pRQY5VsPNjIf7ywjoNt5kM5wfgW0/6aACMosXnh9NHG0nn1pHo7kSSwVA38MTbuO8wbu07SbfD/Z+/PgyW7yjNv9LeGPeZ4Tp6hqlRCVZKqBCWQgGIQSAwSQgwChC0wyC5si+5P/X3gDvxdu+91O8Ld0XZE23Htvm2+2zjafN3Qty0PbQYbG2RGCSNhECCEMBKSCqmEVNOZT04797TWun/szFOnSqWBQagQ542oyMqT086de631rOd93ue9fgHeswFSrbvhQfjvdx5au+TGmz7PQmZxjTYoRdJbw0t7/D9v+BV2dfjAdvhPWyNuK7ZiCxhtxVac8TEb8OGfu/IyXvbcPQwWj5InCSKKyfw6f/vF27nlrgcueQD+54Iz74HKxHEd3vh3t3ybux48Rnv7LoxT9LurqHzIm199CRefO3NHA26bgw9a6UVrcM3f/eM9+/70rz9JbW43KqwTeh6t2KPoLrItdvz2/36Al++Z/UQbbpqTJ3qnnS6UoBcEAc45nDMIaxDObjwuoDwTz/Vxw/uGiv0H19zv/rePfZ4P/tUnEM05oqntDAtDkgwYdRcI8nV+7Rffwq+943WHL5yW/yp23DUjuPHJfMaz4N+cV+eP/v17f5mr9u9jcPwQdtTD1wEqbFKfO4eb77yPD37sk9y3mP9mqWXHgVc6OrM+H37n1a/h3PkOyfoSUkpkFEN9mr++6QscWsn2DuCSyWeVUkwfWine/T8+cRMPrQ7RjWmcUOTDPqa7xLuvvZrX7n/WRyO4Z2ukbcVW/PhjK5W2FVvxFEQDbtORkFNTM686trjA4to6qtbAap+V7oDuYMCOue0Xz3ZqCynsGcDLv/HA6tUf/fxXWClDVNhCGku5tsDlzz+fN7zsYrY3gk9Ggnt7cPmy4V2fv/PoC/7rX98Eze3g13DW4buCJhn7tjX51TddziV7t312SvB3pwqtTwswSv4f37jv8Ox3Hl5CRw20Eiib45uEFz/vAs7f0f7qmVaufwR+pyd5zb0L2XV/9smb+eSXvk7UORvn1UmLktgDmXY5p+3xL9/6Wt7w0ud89aKYC2twRyx+MF1OCz4XhGR7zj3/ymF3jSOHj1Bai+fViOIGKgj53kOHOHZ8gfPOf/ZL4lBmoeSghpUg1h0/au6445vfxukQHdTwo5il5SVaccx552+/2Ejaq/ALRxP+zUe+8BX+4ev3IFtzaL+GMga7vsi1l7+U/+3nX3prbLk7cPbhWIgtbdFWbMUWMNqKrfjpiNyyc3Y6elDFUy//1t33sJ5bdNwgiOo8cPABAk9xzq5zX6BCmqs5b/jM7ffwle8+hAumCKMaWXeZHQ2Pt1z+Il7y7O0fjQT3GGguptzwxW99/8IP/c3nWDUeojaNQdDwFSJZY3tN8M43vIJXPW/XR6ckn5wTj88UTeJYyW9+874jU3c/slgZPAqQNsczKS993rPZs6N1RvkYHYf3rRT84re+v3bpjX//Ob74ze8Sz+zEqABjLKGGdO0458/E/OpbX8/lLzzvU88JeM2PCni9WMg9e/a+qtfrcvToMaxUCOUTxHWkDrjvge+xtrrG+eeeu69dUwcl5EJga/Wpi3vDlLvvO4QM6gjPQ2rNQw8+wIUXvoCppmwODftv+/ZD8V/cdAtp0CZszWDyjHRlgcsuPJdfefOVnBXzF8+S/NYWKNqKrdgCRluxFT9VEQu+XcD83PZW3craeXfdex86iAm9GC01Dz/yCH6jxdTOmZ33H0256cvf5HgvI25MYbIRDBZ4yb5zeNOrXkIjEHd5sLCS8c4v3vXghX/+D//IsaFB1qZIMkfsa9KVY+x7Voe3X3UJr7ho9x3Tmr+ZF/zXJ3u8xwp+8457H2nec3gJGdSQgLIFXjnikouezfnbzxxgtADvWS751dvve+QFf/53n+fOg0cJ29sp8EBCqB0kS7xk79m8642v4ZJnn/XZZ/u88cfx2alhbyvi69vPetblWZ5zdGmBpMjJS5A6wA9rfPd732NxcZFnnbvnJbWaKhQMg1CUQdTacfCRJVaTDC+qoX2Pbr+PxXHBvp2zh5eJP/i//oHFkUDUWhR5hh2sce5MzLuvuZLnnh19dLfif98aXVuxFU9dbBk8bsVWPIUxAzeW0Hnjpc+96uHlVT5xy+1sO+fZ1FrTLB0f8okvfYMyanF4YYFH1lN01AQNRXednVM1XvPyF9FpiFsFlIczfve2b97rfeRzX+PBlSHB1DYyJ6kFmtHqAttritdf+kJe/cJzvjoFn5jnidNnm8NaImsrTZFzrjJ2dA4AIcQZYfC4bDmQwMWLSXnDF7/13ebffOErfO/4gLCzHbwa0hRoV5CuHmP/+dv5hdddykvOnftQzZ2+6uyHiTlVMXDZtL/r2isvffewyPjsP32LcGonnj+FiOvUZ3fymdu/Q2Nqiute/+qrzpr2Djc8bn32rpn9L33+Pg5+8hbwfaJGk2hmB1+66yDPed5FHLz/Ae471qPWmUP7mmKY4LuEN13+Kp577vShluJzW6NqK7ZiCxhtxVb8VMc2eH8WsOvnLnvRrx8/foxvHz5G0NpObWY7S4Men/zHb5CWhlzVUL4iGw2g6PPKS1/M8/bMJgLKYxnv+tJdh/jEbXfyQC/Hm97BsASJJUtWmI/hna+/lMtfcM5KG27awRO7a58azuFtBkbWOZxzFSiqgNHTKr5eMu76TIld31vOfvOzt9/J579yB8cHBj09zwiPcjikFSqSxYd5zYv38Y7XXsrF50x9YBf82lNxPHXF7btn/ejnX/ni68hzvnz3w2TWIsImImwwtevZfO5r30Wg+IXXv2rnufNqbxRw//59u/d++/6D/PORNWRUx+KTipgPf+pLDHpDwpkdoBRF1icfLHPta17KKy8+n47PX83x5NKiW7EVW/HDx1ZV2lZsxU8gaoI7zpuPv/rLb7uadhxQFBkyjIk7O1js53RHDuXHlNZSZAlTzYjLLn0xUjM6mnD5LXc8xF987p/43mpOMLWdzEp8rWDUw60d5RevfjVXX7r3+A6P3z8Lfu8HZmIcByaMkRsDoglbNGGMnu5Ildjz3YXk333k5q/w0ZtvZznXyNo0BRJnS5qxYrR8hLe88iX8ypuu5AXnTP3RUwWKAOYEH4xL++3nndX5y3dc+Qouf8Fe/GyNPFnBYfBrLWjM8sVv3cvHP/9lHlrI9peWzp5dDfY/93wiDbYssNIjbM2wMnSUXr1q9ussWW+Fl154Ple89Llsa3m3KlxvayRtxVZsAaOt2IpnRFhr4prmjl3b6rzpta8iTfrkZYFTmrgxjRdEGONIkwHD3gpvevPraM9K1ks6n/3q/fzlZ27j+6sWXd/O2qBAClGBovVjvO+X38Lr9u8uZjUf/mF9bZzDO5Ux2gyOns5U2iLc8AD8zy/fd/zffvjvb+ZvvvRNhn4bF09jtYdyBq/sky88wLvf8mquv/qV7JsLf/9Z8G+e6mPb4ck/aCk+94LdU//uwGsv5bUv2IscLuLSdQC8WovUa3HzXffzd1/8OodXbUcoeN5zzmPPOdspB10C7VHkDt8PiPwALQX9teM8/7ztXPu6Szl3R6sXCb7rw+GtkbQVW/HUx1YqbSu24imKZWsPzEh54yLckAh1UQp7pILnPncX+w4+m28dPIavIhQKpMQYgxQwO9vhwot30ivgH//xn/nULXfQtxFBvU6alTSCAJ33GSw8xL96+xu45hUXHt7u8UfbeOKGpD9MPJ1s0RJcvw5vvOVbh6/5yD/czN1HltGt7eRSkVtHqCQi69GQJb964K1cuf85x88K+b0fVF/1o8Ss4sMAYr5WXPeGV/7+oEi45a4HKGUIUZtShiSl47O3/zOJKXjdFS9jaq7O8/ZdwPeOrjFYX8OvtxEIhsMhLk14zgV7eesbLuG83T4WohzOShF7jsFvOPAU9BT0ZnhyPkxbsRVbsQWMtmIrfrwgB3tgBnnjyX/jQAkdC5EDz4G2EBtoCiiMlM1leFfq2DPI2H18bcjh9ZT7j/UpSocXBhhncTi0VlhTMBqNeNPrXo/w4X/97Tf48lfuYORiRBjjnMOzOSpN6B35Hv/y56/kF67c35v3+MCPCopmJR/+vuKPpZRNa+0GlayUwpWVzsiB95M854fhPywVvPvTt9+38y8/dQvLiUW3d5AaibMGXzmK3jKzuuTXf+UdXHLBWZ+6wONNT9c1skPxB958beH/eNtbPpSOPsqnv/kA0fwuoqCJVZLuMOWWO+9jPc9405tfz95957P74CN898FllCmwgK89CqlJRgV33fMgK8t1trUb3nQtunq+4V8dSvAkRD73xIq7hrBfQU9AqWHlJwkIt2IrtoDRVmzFzwQA4gCAA6+E6QK2GWiCZB3eWFi2xZK7SuiMHPsGKfvXByXr3SHdwYAsy+j1ugySPuu9Lr1kRH+U0U0yusOMXuYQYYPCb6D9OoUVKARlWWDKglq9hVMBH/m7+7ntS3cQ+DE6niLPS3xpcaMuw+MP8S+vvZp3vu4lnBXyu8/EthBH4HcWDTd89Oavb/vIZ75Mn4CgvZ1RYRAmp+Y7spVjXHzuDq6/5rW8bO/sH/0kUmdPCDDhw3bKi973rrd/YG1wI1+590E6Z+3FSJ+g2aE/6vLlbx9kLXW84Q1v4MLnXcyhY7eSlyVIRVEUgOTosUWOHX6AUBt8IFCS2PdoBBpfGJq1YF+nPbWvM91mut1mpt1ipt2iEQUfaNX0oTDgoCdZEFAIKBX0JCQCyklKzkIkHKVwFLOyYr22Yiu2YgsYbcXPSCxg32OcbSIUFhEJKDczPBai0jGdGXY7hc5KdicpXn9kWe/3WV7vsrK+xjBJWVlZu7w/SFjsrrO81qM7HJGXFiEUSimstXieQvseXuATxnWisEPQCWhZR4lARnUyfNYHI4o0Q0mQfogUATd/6esM+128cA4dRXhegCzWKQfHEYMlfv2X38pbXvWCle0hf+QVdgHvmSMVXLYcGAr2H1zJf/3jt3yFv7jpC0QzO9HRFGlpCZSgrh3DhYd562Uv4pfe9Fp2TfG7O+HfnynfYR7+xE1p7w9/41d/6z/8X3++7UvfeYBgbieu1qLWniMdBnz97kMcWftbdu/egw4jet0RcatDWQ6JA01cj8gSiXUlubWgNMMsZ2VUgsmRSxlluUpRFBRlDtbhKYGnYee2bbvbzcbumXaDRrPOdLvF7FyHdrtJ5CnmGj6xT+JrDksYacHqOrxRw6qCnrVEStLTsKKgX/XIczicp5zrzQq1BaK2YgsYbcVW/HSBIN5jISpgW+rYUzjmLTIyTjZLS2eU00zSgmGSkiQJ3cGQ1W6P9d6QJC/o9hLW+n3W1gf0khFplpOVBocEJRHaQ2iF0h66NkOr5aOUQiEQ0iFxaE9hnaMoM7ACrMGUCbaE1BhsWjCwEvwIg8GZMU8F5HkBLkAHEVJKhquLuOEKbZ1w3bVv4E2XvSCZD/nADviDpwIUTcrz+QlXpR3N3G9lWuz+zuHBDR/5/K3c8s17aMw9CxU1We/2qUUxfpFRlwm/cM1ruPplLy52T/GvZjnz2I5t8H4V0Pt//W+/9KH6X32Sz995L0J7GCRCh7Rnz2a1P2T129+hMArl1yiMJY5jyIakowSbj8AUuKKgVBqkAymJotqGLg2pQCgMVX87ay3HhzmLSZ97Hlkky1KMLVBKoLXEE4JmIGlGcdxuNfY2anWa9TpTrSbT7TpxFLJjbpYo1DQiD60opGMkhUg8TyyEkoMp7NGwIqAUUGxpnbZiCxhtxVacAcDHQLN0dErLdGGYLxzbCst86ZheT4q4cJJhVrDWS1he77La7bHa7TIYjlhe7zJIRvSHCVmWUZSWwlaGhlJqwihGCIVBgmigGprmGKSU1mKkHYMFh3IWbUpkkSFMDs5gTI4VDl8Lmr6mEYbUazVa9Rpe2EI0t3Hf0WXuOvQIXlhDhz5FbhAGQt+nyC1SCaI4JO+v4JIlzp+p8XOvfAVXvuR5Kztq/L7nzAJC/UTO91MNihZLe0Mq5J7UE3u+ef/qNX/56Zv5+r0PEUxvQ3gBtijZVg8Zrh7jrJk6b7vyFbzh5c/9aN3y1TMRFE1iFj5s2jT/1dvf+MdhGPLxL36d2rZdBHGLUkqiep00M2g/pBa3KMucOKjai9Sk4KKzz2LKl9gkIR0l9AZdet0BZZmRpCXJKCW3DucFqCBAaR8pFPVGk9IaoI5UCicFhckprAEs/bxgfWQ4NOjj3DquNJSmoNKWOWpxSC3yaddrNGux16hF3nSz3pyamtrWqkcXz7YaBFoRhj71MCDyNYHmQxpWNKyGukrjBYJDWrC65b20FVvAaCu24oeMZccBC7EVRAaaDnTh2FYY5tOcPWla7slM4fXSjNLBKM83gM7SWpfVtT69Uc7i8hrDPGeQFIyKkqwwWEAqD+UHaC9AKA/pTSF8QaAUkaxK1E1ZIiUoBD4g7LhkPU+q9xCWbJQgsKixaLodhcy2a0w1OsSRx9R0kzjyaMQRrVqN6UadZr1GFAW90qO5UMCxTwwpyxLtHKUVWCHQAvI0QxiL1oK0u4QbLLJnJuTtr305V+2/4I7ZkA+psujNaO8p2aGfCoJ+EkzRELm/Z3n1nfct7v34F27j9nu+j27OkDkPRjltT5CtHePZ21pc98bLed3+8/7dWfB7qDP/mt4G70+bcs+vvPmK93qez2e+9s8MsoxwegYnFS7QGBdSliWeliTJEJsNmJ6t8bL9F7L/3BpBSY8Mkixvrq11GQxT+sOMtV6P9cGQ3iinl6T0koxklDPK+iSjjMxalPZAKwy2YgBVxTiVxmEFKO1jBZRlibEWJyAvc1JrWVrNcQsDXJEjrEFQ+bsIV6AVxKFPox7TaTWZbU95U63atnoYbNsx09lXDz1atZhGFBH58k99rXq+Vod9zeFQc1AKRkpU6ToJozMZ4G7FFjDaiq34iTA+DjwDTeNopiV7stzuSku7J7XE/SSjcJLMWJKsoNsfsrK2ztLKGt3BgMPL64yKgiQdMRxlZHmJE4D0EEqjvABHiI6bBJ5PIPWGH4+UGmtAagXWUZqcsszAWoQrECanKFKsK4m0pOb71EKPOAxoN+u06zXacUSoFWEtpl2v0Wm0mK7XaNa8436gjqhQ9kLFQR8OCyg01a75OLxvFa59YIVX3HfwXgCsk+RZAaZimFxZUvM0gcjJu4tsr1l+6Q2X8uoXXnBHS/DZefgTtPeMuRa+b/nPC4m94dZv38/f/+PX+f7qkNbO8+klGQpFTUO+eoznn7ud6978Kl727LP+3Q9jYPl0xi6PXws78uAvvv6yP9Za8bdfuoPhckFtdg4tfTwFRWkoCosfBhRmyHp3meWVBYLzz+3N+XzQExyXDX8kZmZLAUUJ0yV00pI9g4xLBsNs5/pgSJIW9IcJg2FKd5jQS0as9QesdNfpDvtkhWXYHSCtwCEopcJIjZUKozVOKpQfIYVEOFmlh50E68BarC0pRYHF0beWXlLwcK+LeXARl+dYU1ILfGqBplGv0WzUmKrXmWo1mu12e189CvZtn25cFUhFGHjUw4B66BP7+r+EHgc9wUI95KsKesJRKkFPOIoZsZWq24otYLQVP+XAZ5LqMoZmaZgurJ231sYlYvro8sruzArSrGAwGtEfJKwPRnSHQ4a5YaU7ZJAW9PpD+qOMvDCU4w2vFRoRxDjlIVSAbAoCKXESxLjI3BiDJyXCgTEWW2RIwJYlzhhEWWLyrNJe4PA9TbMe0plqMtWcZqbZoN0ImGm2aMYBjTigEYXUopBIC6bi+FOeZEFqRp5iwYfDT2bHqyw9T7KwsLzKwvIS0cw5IDS+EpQmw5YGLS3KjTCDVc5uKA5ccyVXvGDPrXMeH/zJ6DjspluJQ4Bwm/7+4wVFR4f8+qe/chcf/8JXWCskfmOWYWEQQhC4nNHqMa54wQX8wlWX8sJz27/501qBtw3eT0fyzte+7I89z+Pvv/w1+t1F/NYc4GPKEuH5uNKgtSYZJBw9epzh8NymjlnZ7j3G99awpLne1IKmmwu0A6+0dHLLWYVh26hwz0nSbFt/lJKkOXlRstZPGaUFq70+K/0+3SRlLUlZXe+zMujTX04R2kOqAKU8lNRIqSsdndQIv75xNTgMvhtfL666ToSDzJQMsoJHBn1cuYq1FgEoVxIpSeRLGrUa080GM9NNOu12PNWoX1zzFLPTrasCBbHvEYUB9djnSKB/Jww4GEgeCuCQgj4Vg5Vs6Zu2YgsYbcUZAXwy2A1goJkZdllHlJbsGY7KbaPcMMxKev0hvSQlzQuSNKXXG9AdJqwNEgZZxmA4pJqwU9K8xEmF9iOsVAjhIaSP9CKkr/GkRkqJEIrcWqRSCC1BWMoyx5Q51uWApUyH5M4g8gJX5EhnqYcBU40G7Thk99wMjcCn1awz1WxRb8Q04oha5BNqxXSrfo+Cni85rBWrgfrxaSW6CVfdff8hSuERSo0QjjJLcc4QxB4iS3GjPnWZcODqN3LFc8+/Y0qYT8ygnvLJX0ICrimEwwkwzlWiXiFAivHjP544Br/xwJr59b+79Rt8/PNfIddNmjM7GCYpUpbIsocbrfJzV76Ya694Oed3/H/3025LsA3ev21avl+96iIX6JK/+advsd5fRcYKz4vI8gLlKZQVSOdx8Lvf49hz97Jnz8zjvu+jQLkc/9NAIFiuhwcgBAdG0MxhZ27Zmedu5zDL9yejvDnMSpK8pDCC5fUea/2EhZV1FldXWev16Q16DJIRw9wycD5Oh3ieh5TjggQlUdJDal2xt36IFwh8IcZM04lWM1mRk2JYSx0PJ0M42keJw3gCtLAo56iHHlONOu1WnXa9QT2O9taiYG/kKaYbAaEniMOAei2mHUV/Vov1/TWPO3zNEUWVotvydNqKLWC0FT+2WIQbxnvAyIE20MwdO8uCTubYtTQsL+4mCWmaM0wzur0Ba/0hyShjOCpY7w/pDlO6/YRhmpHmJUVpkFIjPE1aVguv8j38oAWtDt5Y34BUaKHGlVFVpZczFmsMeZHjSgOuQIhqt2ryjNKkSAGR7xF6kh07Z2nVQ+baU8y0G7TqtQ29Q8MTdAJBTau7wsA76Gt5WCl6WrD6VDlHT6IQzKeG5n0PPkwQt7EGylGKrySmLCjTPr4dkq0+wr9+9zu58iXn37pP80p+gmIaAQgsDsb/ZPW7/BjjCPzOd46NfvcjX/gnPvXlO3D1edA11npDPEqkHaCydX7l51/PFfsv5JyW/KOftvTZ48W5nfC91175sj8UUS3+yBdupztcw295CBzOafLCIUrBSi9lbZgycuzjR/gNNhgVcQp4CgWEAbQCluB64ypdX1rO7E1L9iQlF2XGdkbGMEozesmIQeb4/kKflcGIxaUVVtZW6faHDNIhaVYwshalfZAa4XloP0BJD6EkQkiMAxXWq6pOpUBYXGmw1mCxWAGmNCwVKccXB3BkrbKyQCCcQ5icKJBEgaYeR7RqMe16zFQz3tuu1/fWQo/pZo1a4NFuRB9o1mvU4uCu0OOgVpUdgXQkvuDI2OOp2GKctmILGG3FButjXKXxcRLPQlQ45nPY2R1ySW+Ys7LWZbXXp59UACcZZSS5YbGb0k8ykmHKKM8YpRlFYTBOYBEgFE5UpcSWCJRC+AqlKtbHV3Ks+XEYKTDWYWyBcwYhCrK8D8ZSFhmmyMGWSARaSnwMU7FkuhExN92hM7WDTqvJTLvFXHuKdiMiDnxCz6MeikO+x2EpGUnBSAqSAB7yDAvb1FMLgk4XieCixaFluTvC8xvkBkZ5RhgHCFeiywHdIwf519f9PG+69Py7mo5bfpLHJ6B8NEiqMmmySlSOfpT3X4YDXbjq6wdX3/VXn76FW+78Lo35Z+F0nWQ4ohlKXLLGznbEL7z9Wl7+vF1Jx+evzgTjxh9nqDzvzUf+n7zmhRf+5vcfPsbNd96H0T615jxOBiTGIHTM8nDAA0dWWNmz8531Gl99KhmQWfjwBnDyqn9LcL1DeiAp8OZTV9+TFux5+bPnvLRkT5rTzPKSUZaz2h2yuLrOSr/P4WPLrA2HLK52WemtM0gzSuuwCIzQeGEDlI+UcoNxmvzfSIl04FSAjAJkXBmgApiixBiDlTA0lqV1i1lax5SLSByBp4g8jacFse/RjEMa9ZhWLb64Wa9d3KzXCAPFbKtBsxbSbNapxZrDPr/raw5rwaqGlUDw0KTlypYofAsYbcUzCPRYqsquideIAy+HnbnhrO6Iq/qj3Ov2+vQGQ3qDlPXBgO6g0vas9xP6o5TeYEQvSRgVZVXSbhzGCvzaVKVBkBLwwY9QkUIDhTXo8aTnRKX3mdjhWOcoTEGZjpBYnLGUZUGZp5gyR2FQ0tGu14hCj3anwexMm/nZObbNzdKZbtMIPGYaHnUtCH1NoDjkORY0rISSg77ksLSMlKT3mILNp6Ga6RH4j0cTrvvEzbexnhbIZkA5KiuQWIzQNmFw/AEOXH05P3/5C5mBP9sufrKpI+cefz44FTj9QCyR4XcGkpd+9usPXn3jJz/PoeUB9blzMDLAliX1UFB2F9jRUPxv176Ol+7bcUtDceuZZNz444oZ378RuDFr612/+tbXv01qny99+3uUSYANGgRBgHExJou57c67uXD3Dq+9b/YqAeVPsvT9UaBAwJJnrhdCFUbTdCGeQTctOirm4/m0nN2TW3YaRTMt6Axy6GcZ3cGIlfUuS6trrA8S1vsZq70ei4vLrK6tkWQ51gkQEicVUVzHCokUHlIrlPQAibUWa0FEEVIqZCCRgLIG4SqPpwxHagoGuWVhlGGO9bBljnCWwFN4WtCMA5QUxIFPvRYQhcHuWqB3d9p1Oq0GM+0G7UaNuXaLhVi/15cclpD4miM+HDbQHLdhKRT0cLAlDt8CRltxhsQyHDBUmoHCMV845g00R4Z9/YTOynrCam/AWj9hvdtneW2N3jChl2T0koR+b8goyymMqYziXLWjA4nSPsrzkV4N51VCZp9Kgltag9YSS1XiLph0ZDeAIx0Nq53d2BvF5Bl5nuOcQylDIEs6jZD5mVnmO9uYn5pi++wMO2an6dRrTDditILI437f44hS9ISgmDAWEdyzCeM8upnmGVbG/Qj8xzW45sOf+Ec++eVvIptnAQLf10gMZdKjt/Qg/+ItV/LLb3olOzx+XxfFKt7TU31WmTuOmSI3lqw4fiiN0bK1B3Ipdx4r+M3PfO27zb/+7K18f2VEc/4cRpmhTHNCYShHa+w/b45fveYqLnrWzCfakpue6f43Tcct57UZvfcXrnhX4Hl85AtfIdp2LjJuIbWHbLQ5tLjAf//YTfjBm6950XnTuoRpWWSjbV7w/qfjmB/L9XpJmOvPDdW/gIppKjzmi4h5IYMSEeBo65JzOmM9YlxY5rNK40S3N+ToyhpHjy+x0h3w0JEF1voJS2srDNYyUidBaQQK4yDzwqr6VCl04ON7IcrTOCconcMhkMpDeyEyihHWVFV1QClh2TmyJMP2EryVDJyhLDKUMwSeohFHhFoS+R6+kvuDINjfbtaZ7cww1aozVQ+YatToTLdpNlgJFA+twDt9wZEADjnwnmxBxlZsAaOt+AFjyXG9ETQNNEuYzh07S0OnN+LyooRRVtAbDFle77KwssLKep9+knN0cZn1wZClbo9+kuNQKD9AKgVSEUQNrAPnQkRYw/M8lFIIoSqBpJ1w6mN9iXMIazHGYExBkfcwlNjSIKzBOYc1JThD6Gmm203iekCrPk27UafdajA11WZ2ukOzGdCKNe1aRLumiBT3+HDYh8MR3KNhVViKGfnM2IEdg99YhWv/4wc/uffTX7ub5lnnYbw6WZ6hBYgyoVg9yjtf9yoOvHEMirJsZTYInrZJVTowm0CScPzQEpeRlPsODdy//btbv87HPvMVhjJm+lnns7LapRlGSJczWDjK5S9+Dr/ylit4zlnNvzxf8Is/C+N7XvMn8/AnfsThX7nmFf92eX2NL9/zEBaImh1KFyBrbb57+BH+y40f5X3Xv+3qFzxrmrYX3HSmfZdZdQIwzcKHeSxDdgXLzhyY0epGfMFyPThQdoJOsXt6vuC8+YJqc5cYLh6OaHYHsNYbsrS6xtLyCt3+kEeOLtAfjej3hwxGqxSJpbBQWIuxEEQ1KgKqSt1rrZFe5U7vEJSADmJEWDm8KymJEFhb4oxlvShwqcGatNrg2TWEcxhzL87mSJNRD30ajRrNetxp1eNOZ6rB9tlpplp1ts/M0KpHdBrxf4lDvi0dIwU9X3M4hIMwrlLcii1gtBUnWJ4C5i3EkxRXCdM57CwK5gvLfGnppCWdQWJYHaQs9wYcX1ljcXWN7jDlyNElsrxkmKaMRiOK0mKcQGoPITW1Wg3j6tBo0GhLpFbjii4BTuKc2KgQwTqEdFhrUM6M8ymOsijIshGmrCq9tJBopYikYaqliTxNHDZoNevMTU8x3W7RabeYbjWZaTephR61gHs8wYKS9HzB4Qn97MDzYOExc/jPgNZfx4ryN5ynve/1+f0/+Zsv8Ok778WfOwdVm66qj7QjEJZisMovX3Ml77hyPzsDfv9s+G2C4Gk7brepDUj1Q/zwZfqH4E/vX8lv+MgtX+Ojn70V3dhG2Jim109o1SL8dIjtH+ddV7+Cn3vNJZwzpT9Qc9zxszYnnA2/bWo0//UvveW9yYc+yt3HE8osAuVD2CCaexb3HP0+f/xnn+C97/r5q19wVmubUTR3wB/8NH7fGXGiwvKxhM/LigPUoazTMdtqTWNrTdiJlUS5ZWdm2DUccXF/OGB1vcfi0irHl1dYHySs9YYM0ozuIGOQZoyKhDw1pMaSGYtTCq3CSgogFFr7+L6PlIrCOIKgVs2VUmyMBytsBaIQFFkKQtBzjtVBQbbSxXxvETiIFA5XFMSRx3S9HrebjUumGw1mp6fYNjdDp11jtlOnFqg/roc+gUcvEBzSsBop7vEkC8pVLLhgy79pCxg9k8CP4YAVxAYaJXSsq4TNTuCV0BnkvDQtXZxmBcM8ZZCmrHcr5qfbT1hbH7DeHXB8ucviWpckN5RCIf0AdIDUAVJqpNdGBtMEUiGE3OhxpVXVEwksxhSUJqcoCoRzaAmitGBLrDE4WyKsQQrQUqCVo1GLaTRD6rU2ceQThz7Neo1Op8N0I2KmEdCuB8RRlARaPBT5FesDMAE8Y+ZhNCt+9ujkY0X+G5n2dz/c470f/Nhn+Pyd9zL1rGeTGZ9+koMUlKOEUbLCS87bwesueSHzPh89G377TPoeleu15IcpS3vQ8d//+Wj/3R+5+Z+46avfIZo7B+sC8rKkHvqYzfsjrgABAABJREFU/jIq63Lg6it46xUvPDQf8gEPtzAjxM/kQuDlbmFnS3z256965VX//H//Nc6vgfIoncT3a9S37+buww/zn//HX/N//tJb9j//nHntaRaeqemaRwEmecr/ZTXZLDXr17vtdS9/zo6zSkOncMyX0BlkvHR9kMX9YUZ3mFSAqdujl4wYjirH/G63z2A4IisKUpOSDkryPIcwxggJoqqmQ6pqc+lprNR4QQxOYnB4AlTcRsiqpZAQgiKv7DeWjWF5eYRb6CHMYWQlPycOoBb7TLUadJqtZqfdunh2qs3cVPPyVq1GPfTwhMPTEPr6Q6GnDnqeWPA1h8eNfSfAqdwAUFuVdVvA6Olje9yBGaqJewmuLyzz1hEJQVk45nPLztywM7ecNcjdtuGoZJgVDNKMXn/ESrdHL0lYXF5hmOXjATtgkGakhaW0DickWoVorVEqglaNmpIoz6uqvJzDWjCuKl8FsNYhXEHVwsuSJTkSA64CPtaWKAGekvjK0vQl9Sig1WhRi8INa//pRpNmLaDTblELPJr1mEbNu6Pmc8e4aWSBg53iSQpixc/eNbJozQ1D7e9/aC277i9uupVbv/Mg8fROCueTl7bapUqB52vyXsLzn72L+VgkbcHTnh4RglIIgUDhnKhM+ZRAKIl7smPEcWCh4L3fenj9kv950y18/d7vE7a2oVTMcJQS+5py7Qi7piOuu+qtvPbF535ir+StP7MXzDjO8sXvPQx/eMHuuavmZ1oslhYnBFZKcgOBX6O141weOP4Q/58PfYx/feBtF7/42XPvywU7n0lWBj9onAQM1ckr21ItuN4ReIZmw0I8th/xkpyL0pw9w1G6u9cfstYfsNbv0x/lpKVlpTcpQhmy2hvSHSQMRznF0OEs6LiFdQIrqjZD2tdINE4KrHMoJRDCwwtDxNgfVYzZebDkpiTDsbZmuXfxGHn6IFhTzc+eQuPwJTQbNeamp7xOq7Wv3Wzsm5+dZdt0m3ak0KKqwvOUJNTi/mXFu0LNQS1ZmWxOt8DSFjD6sccCvKeA+XGqq1M45vNc7Hy4MH9onGzmpY3zwlT9ukbpxq5kkGYcXVplkOZ0ewkrG7sSV+l6pKoaO2qNVB7oBrbWwpcaX2mEEEgHWIccsz7CjX0+ikrHowBZGooioywKXFngSYHve0SeJgwltSCg1Wgw1WzQqtdp1GPqcUjkK9qRpBUFTLVa1OPwkO9x2JMseIqFAA45hycFo9PmwcXWtfF4MZLqOQePJ9d9/Jbb+fTt/0zQOZtURPT7Kc45wjgCAdJZmqFHp+bT9LhlVp45O/+JxMyesmW3ED/RmFkuedc/3X/skv/28U/z3eM9otY2hPYRztIOPbL1BZ57zhTvuOoyXv28sz90LvyLraumCh8OBw6mm3UOPbJGq9ZBBR7pcFRtnApH1DmLh5aO8of//X/xa7/88xdfduFZkRGu+Swp/s3WGXwc0HTKicYH6iGLs+ENhk6jhM743/SwYH9asLufFKwPRqwPEnr9IcNRRlE4ji8sMxyMKiuC4YB0VJIZS+4MpXH4YQxj6wGlPJTWoDRSgBES61QlrteKkAaqXmKtGY89x6goSUzB+sBxpL+CLRZwZYGvNHGgacU+9dCj1ajTbNRp16O9083G3ql286pGFBD7Hko6Yt/7syjwkigQ39WSFSkrrVNd8lUBpXAUAD+LrP4WMHqiHT7cYKCRluwd5TwnM273yLidSV4wGGUMs5wkL0hGKf1kRJIZji2sM8wKusOE/nDAMMvJS0thLaUQOKFQykNICUSIMELGksDz0VpTmHLMHFSGZ0VZUpYlGIPAYkpDkWVgsqp5oy0RziAlBFrQqcU06iHtVodWo0azXqPVqNGqxzSiEF86Yt+nFoc0opAo8O6PAr7r60rk7DkWHncwbIGfHziOl8X7Rtrbd++x4Q0fuflr3PKt+4lmzyMpJf1RShjFWAHWWrT2wcB0vc5cq0XNOwN1NWONhaVyvzY4LESP9fQj8DuPZPzuzd+8jz//h1s5NiipzZyF9gJ8wKUDstXjvHr/c3j7lS/h+c+a/sAu+LWtK+ekyXjFFy6JQj/GldgyxUmQUuCcxA9qeFqhZ2MW1o7x3z7yaax97d7XPP9ZL12C67eqoH7wOF3l45LH9XjgYs9zM542NJsldHLDWcbS7Pbzq4Zp4Q3GbP8oHxvdDiubk7V+5ejf7Y/oDQckI0NRVvqmwoH0Y0rpVWNMaYSUCK2Qyqs2xqFf3VIZ3WLHWidjybEs5DnHUku5so4tl8BYlAStBN64lUq9VlXOtRr1uFGL9reajWqdiHymQvWuSEmiMCQMPY4F/KYvOawlK8rR91WlB9Ww8rPKOj1jgdECvKcwla5HSApjaCapuzhJs4tyZCfLLcNRSlaUJHlBf5Cw0u2yniSs9ROSrKSXjOiNRqRZQWYMxoJxispxR8MY3EhdQ3galEQJhR23rNCiwhjOVD268jKnKHKcKbC2pCgK8iyjLHO0gCis0P50s4bfjGhELabbDabbdVr1GvVaRC0ImAp8Yl9Tr0XEoZ/4WhzWitVQVz4+kxz0YxrCbQGfH3vk2tt5cCm74W+/9A0+97W70c1tjApJVjq01piyILeWerMBUlKUOXOdJjONGp5g4Uz8TkIInHAVOLIWA83TPe8h+C/f72Xv/cSXv8nHPv9VEt0g6syjUHg4yv4qYrDKz73mZbz5sv1cuM3/3WeiP9GPGjNw4xEhfify5F4twZqSskzRKsQ5h7EZpRPosEFtVvHAke/ykc9+iWbtNa948fnbt3b+TzXTpMb/pn2O47/PuZqmcrbwSkdnVPCcUWH2jdJs96iwjApLVpaMCsswy+kPhgyzkqXVKm231l1nrdtnMBqSjkpy6zBOIj2/AkkqQCiFpwOEroBUXla/vwD8saYUwNiSIi8YlTmJE6wODIfWVxF2ibLI8KRAKkEoYXu7QewrGvUajUaNVi3eVw+DfaGn0dIx06zje5Ja4NOIwj+LI/9QFKh7PMWCFqxOmmNLx0iIZ6a+6acWGC07DkxcmwEKmE8L9qQle7qD8uJeltIfpBWiTwv6wyHd/oD+KKWflgyzkiRJyPKCwjryomCY5aR5gQ5DEGqM5kPQdfBF5eYMCGPxhR7b3Iux8VhVvu5cSZlnlbkhFlvkmKwyMBTOoYRjx+wUtThkujHNVKsyE+u060w36zQin8hTBJ6o0mK+IvK8+0NfH/QUCxJGPhz2BAtborsz4Docuznfv5y/62++9DVu/uY96MYsJZqytGjpGKQ9pPLwwybWWnytyYucudYszSg4Y76LA12pINyJdJqojDlLZzGO5mZQvQwH1g1vvG95dN3fffnrfOb2u8jDFkHYRAmJj2W4fJS6HfKOq1/N6y59ETvr4gNboOixw5ccadfre4t0RH1K4oxDOYsfaJJRgclThF8VW9Tmz+aew0f4y3+4Df3mK17h7+78Rc1xx0/aGPRnMbbB+0/aYArGKToFtSrjvAg3WIgmZruZYdeoYF9u3M7M2E6elyRpzjDN6fZHrPWG9NKcY0srDJKchfUuK+tdRrnZYJYKJymkh1N+xTJJWTFOSqN9Dy+qQLRUIMw4PVdkGKCwJaWA+3ol1ua4owOcLVGumqc8KVDC0I5r+J6gHgY0azUa9Xh3ox7vjoOqifZcPaQeeDTiGnEtJPS9Pw0DfTDyq6o6j2pt2tzodwL8t4DRj8L2WN7jBN4YjesNnU/BfGbYlWRcPMyLZn8woDcc0h9ULM/6YMAwLVhe65OUhkFakKQZWekojBlb0guMDDDjknUhRNU12gvQoVcpqe0mdYWs6MzK36cCQFJYXDkkT3LyPMWWOcpWVKaWktl6jTjUNGsNGrWAZqPG7PQ0c7MdOq0mNV8SeZrIkwQafFmZhIWa+7VkVTpGnuB4ZWjoUIgtId0ZGgXMH1xx77rxH77El751L8RT+GEDV1hkmZKPEvY8axu79+zh5q98i1rQAGuR1jDVrFMLNMJRnnEsnqwagjjAjLunWUc0Oc6j8Fsj2HfHoZXr/ua2r/OVux8k1Q3i9izSQdbvkY3W2VEX/MKVr+c1L3nuyrZQvP9nWSj8pCZkxUoQBJU3mCtxRlG6jB3zU0yfM829B+9nmHUJwjpWhATtee56aIHo81/Bu/LS6164e2rrJJ4h8ag03ZhxWkC8x6Iii4oFQeHAK2C+Ak2cleTsLRwMc+iOq+q6w4T1bo/1wZDjy+sM04z13oD+MCHNc5yUlDoA7ZHlecU6eR5S+1iqdc4KjZMSEQYI5IYxr3LgsBTOUDrHYlliM4NbT3B2gHMGhUBJ8IQjko5GIKnHNWpxRC0K4nocXdxuRBfHYUi7HlGLAtqNBlONmFqk7gk8Dq0L3qigr1xl3yJhJCGZgRuX4cCZtMY9LcBowbr3IAUCykmT0oKqT1dhmR9m7B+mLu4PE9YHQ9a6fbr9Pt3egEFasNSrqgdGoxHJKGOU5mS2xCJwSKz0EEqD1iCbyEghpK50P0piyrIqrQSkc1jnqBIGDiWgNAW2yCnynCIdURQFzla6IC0dvihpxj5ndzrMzZ7Njk6H2ekWc60W9TigGUUEniQMNFqBdCRSMfI1hwPJQx4seHBcQU9SCeImFwecai+/lfc6E2PRcEOiuOg7C8V7/3+fupXb/vkgYWsbhBHDLGeU9BGjIRecexbvePtV9DPH52/9ClYYlCtRQtBqREShd8+cOHMcnq04Ib4WKJwwjGsBMNBcgPeMYF8XXvulux7c+3df/Br3HeuR+i2iRocsLVBFQtld5NzpkOuuvpyr9u/91AWSN21dNU8cQlKEYVRpEYsCEJRZTuwJLnnhPtp1wa1f/RaD/pBGawZUC2cFt3/nITzriN/06uvkjsboXLElaj9T47EkDoseN1iPqAyYRoCFuJgJ5p0LdGGnthXlWfOpsXuGufFy6yiNJSsLklHB8nqX48urrPSHHF9aZXWQsLK+xvpaSukqywGkxjqBF1QpOq19PM8D5VXmvlLhnET5GqylsrWr/O5KwAhFIRxDW7LkLK5XYFYTbL6KtAZfOrRwNGKfyNM0ooBWLaTZqO9rNer7Wo0atUBz1swUjSik2Yiohdy/oHivJ1gYwCU+HJ743E1A0zMGGC3Aeww0xzRi7EAbR3Ps4zOdC7EzLdiTjIjXej2WV7osrKyxvN6ln+QsLK+S5IYkzRnlJaWt6H3jBAZN6jxUEBMEMcKrY5XFWLtBN1qxqSP4uEt76SpRs81LyjKnLHNMkWFNiTNltVg5h6JkulljptlkbmYHs1NtmpWIjVajSS32mZmShBpiHzwJPhQeLPhweEIjCirF/+bGmxJGAgoNq1AtNM5VDVyPC943ec3kHFqIJr3OrCPSgtXHyn8vWa4X4oQh2DIccFU7SGbhw0twPYC1RPPy5IG5bDnwTHGafipjGQ5Myn6Hiv33LLt3/ef/+bfceWiBuLODTAbY3CGkAluw+1lzXPe2N3P2drjj7h6mzMnThFBKfOWIfY/IO9He5OkOJ/BOuY8TihJFKj0SyUUO9KLhun/85r389af/kWMDC7UOUoaVsLwcMVx4iJddeC7XX3MlLzxn6oM/i6aNPzQwEpTtdhuMRQuN9gN6gyHDQZeppuY1r3oeILnl1m+QpiOUFyOjNkp53HznfRTW8C9//nXv7rfCy+ZC8cHt8J+WHQe2jAKr8QuVJki4xzZPnMyVjyVVOA7vc6BF1WFktJkZWnJcv1nrtQwHnMOzYtNcvqmIYdJ/cJIZcaADwUMOPAMNJeg5gY4k33Ua7ZBeUZPzk/ScI/QMNA3TzZzdO3NLs5SQlZBa6I2gP4LjS12WV9dYW+9V6bk0ozdI6A2GDHoFWVlinKqIBaqqOc8P0X6I8nyU9LACHBKnx474wiGFQzuHsyWlKTEmJytLRFogkwK3mEC5gMThaYmvBfVAE/uaOIyIAm9v5Gua9ZiZdoNmLWLH3Cz10GOqGXM85tdDyf2T8yRhFMNdE6+8pwo4/dDAaLJwW4gLx3whmLcQ5bCzgPnMsm2Uw2AEy+tDjh1fZGFxmd5wyOGFZYZZzmAwZDAckeYWA0gvRKoAL4pwwgMRIrTaADxSaqysWlcYJAkgnESOzb8mCTDjLE64cfrLIDFoJYiiiEAr4lARh7oSnjVrTDcbtOsRrbqm5sP2merE+OMTpKkQhpywTJCMB0UypgNHY5+fcgJ4NoMhNz7Pk3Jnt/m8byKEJiCqC1dtLE7jAUPVjJ4VeKeS1UVx0iI21lqtwtsc6M2l1VWXbDwBBRKW4V2CE73HhKBYhbeddrHcdOyTXPHEXOzU55w62E/32Klg8TGZizEofKzHJqDvdP27Jq+buGw/JhAYn9vNz3us509Aq4FmHy773vEy/v3/ciMPrSTUZndhgojSmsrcLR+yd/e5/NK1r+as+SorJWSAM4JA+lCOUBgiX+NxBgmv3YmLqSgMntYYBLkKWTWaw46L11a5+Obbvs6td97N8kji1WdwOsSUBWX3OPni9znw+su47g2v4vym/5vb4T9tkZ4/wIQsWPGFxBMSmxVYp/EEaGnRGtoxXPuGC9lz3gV8/HO3cmylT1zrUCofMbebz3zrIQbmc1x/7dV71XZ13RD2a8HqGlyjYdVCNFlUHucy8CxEEkaTWwd6cl9A+XgVips3eKebEx7vtZP5YfPnPylAuWkMb54fTveZEkaIE3Pl5vlt0nh709z57lPnsDGA8SZz6Cpcu3kuXYc3bnqetqIiBzafi8lvMDlXm8/ZqfPeqetHBYhOPiYFvRAO+pLIgTa6aiU14xOXLXjOthaWFqZ6PYYKOA2zKmXXT2C1B+v9IccWlknzgt4wZThKGWWGtDSYsirCcKhqqnACiQRhUSJAqgClYpy2SFdlYE700YTCWXIM62WGSApMP8PZIa4oEKaEMkPYkjj0iX1FvRYy3Wzs70y39891OnRmpmjWQjrtGu04YKrOyhK824Pj0jHyBYd9OIKDH5WFf0JgtATXlzBdQie37MwtO5WmN8h56Si325K0ZKXb5+jSGg8dW+DwwgrdQcX6LK31yIxBSF11S1YeyguQgQdKoVUTNTVLqHyE9EBpHBpjHVZIqlrVCorYjV2soBzP4NJJGBtondjlVpbvzlmkhkCHNOKI6XaL6fYUjVpAu+kReOBXh4FyIAyMRiV5UrJwbISkRFoDxoCxVesM63AYsC4GEI6m3BhsbsOcteo6bxFufDxObMA2KyRGbBqiWIR1jzXYT7TugI3nmVOciE81Js6yrEL3k/YOrmLQJseDqI5lct4UYtPxgBzf3/y+k/SKdCdeJ53ECvuoW1e6k+4LK06+L9T4fMjT3lrLSfdPff7kfJ769yd630nvN3FKl9mT22Bs3r0/ekUvpWDoLN85+AhHBiWN+V0YLyZ3cizYt9TqHvX2FP9872Hu/Z5Aq4AHHj5OGNRRouoSLirt2JnIWSCExNNBRb8rSVp4PLg0pPsNy6c+9SmWu0P8Wgu/2SEtS7Qpsb1l9GCJ/+MdV/OLV77k/h2aP9gqH/9hzj6l73nY0oCt2G4dRqz0Ej7/j99iut0i8iN03GZ2Zp7F9ZTeMEFKjfJbNHb4/NO9j7D6Pz7Oy593wf525O+nzIhiD+MMUkrK3FZeaU9y/P0g4+vU1wvhHvW4lI/f8+eJHnfGbsxPm8eo3ZQl2Dy27SnDzJPexuuEEFhOdA2Y/O3EfLkJWiFxwo5TnBbhKlAg3Ph7OXnS393kfIiTW+uo8fyzMf9u+NWN7ys1/lx70vdyohKA2OKx5//KdLIyaK0KgBzGjs8DlVa2MCVOaaz0cFLjvBAdxnh+SLtTo9WpYYCygLSAbt+wstplcXWN/qCyJNi0QuGcrOQoDoxw1XUy/jIba7OYrC4Wq+Nxw/Fq3RRUQEpgUc4yzBISa1gelDywtk75vYWqiMkWSFviK+i0a2zvdDqzzebl040aM8062zpTTDdrTDVqNGL/TxuR/mrkc490jCqakAUl6G0TT9yn7lHA6Eha/k6O2Dkq3XMGub2knxXe+jBjtTdkeX2dbpJxrNtjpT9gda3LWrdPf5RhncIpj8JJPD9C+9NEZ20nGl+EUugNkGME2Mnia6FwY1xZSpyQiA0gJLFmDEYmIIHK82HzguY2Lh6LE1XaDeEQxlCYkuFwyNGjx7FFiSkzsrSLELbqa+Nc1QzVGbBmfJG66gcVdjwhiJN+ZFe68WAYO5puuqiFM+PnV2DKic0TR3WhnvC3nwyo008Mk4vn0Yu35PEailVCO04ajJsH+mQimHyuGL9GPo69sT3NGi6txEr7A98KVHVuxxPI490K6R7199O9/nTPO+0tIITiVCz6WODoVIBkBThPEdYbNOd3Ugqf3GhKoCgKPOWR2YJvffd7fOn2b+CFPmVp0CqkHjU3wK4UVY86IR69u37aFmVHIV11fH4YkeaG1IAfTXHbN+9hlPQpjIdqzuDFMdZJVJlhVhfY1Qr4xbf+HG+59NmfaMFnt0DRDxcKerEXICdjVfk4qTne7XLoi9+sXOy1jxCaIGoQRnVCP6jmVlMRDfH0Nh5eT/ne576CMCWasRmscEgpkUY8LjCSUv9IwOh0z9sMkIwxP+J1esrcJ08BClKcdly7U8bziY3jZPNpT6wpjwGMNm8cNzZqnDzPWMNpAdOJYxKnMGTipMcnwOwEIDr5CCTV77fxOBIn1cb/hVYbL3LidHNbVcmG0hgBpTUYY3CiWnt87WFttTYL6aO8CM+PkDpEKFV1CRrPt0I6BAolXLUxxG5Ub58aEygkhBpfI1XFK8JSbhyjxWs0KqJBOILxd8WUmKIct7LKSZ3leys53z2yiMkyMDm+lnha4AnLVLPGtpnWJds6U5fMT00xN91idmqKVj3i4cj7Q19xOPB4KNQc9OC4cvQ8ycJEUqK/f+zYfz66uPTr64OEtXFH9sMLq6wmI5a7I9ZGGakRlFJjUGRSQdxi5CpXT12bI2pqlA6w6HH1V0XBGzROVr4+1oBwAqnVBgMkXAV5xpcPQgoQitKYE1exlBsDS4wvemvtphN94qp3QmCx1f+dxTmLlpUvhKc1wrNY5xHVfaQENe4vdhIrI040DhSnIIVqPInqQndyY5HDOpwzG8BiArgmX2Lj4pwwNVaeSh1vnI9HJY1OeaZz1eT2eP2rrLUbKO500xdSVjsLWw3kyUB/FDDaRMXZk86DfAKdxKOPbfOEM9nFPRZwUk5t3HfKnfT4BBjJU3aip9uZnv6W8Q5KPCYwOt2OdfKdrIDC5CitsZ4mS0uQAm0FwvdRwuJJhYwDVK2B53lkRU7oRZRJhjFjEM4kT3/6dOHTlEnzqkpNRZqmCBliXGVMlxcSI2uE8RSFSRkmKb5wiGGXF513Fu+44hJe9ZzZvzwffnEL3vxIjFFRjXFdVdE6yIxDBk3acROHwUoFTuJLDU4ilcA4SzIaEfoaP2ySC4+43qoWKmsIta7KS5xDu6ricLLwP94t8uTnTRiNH1w7tWm8mcdvTPx4m5RqfhUnA5xTx6i11fwyBg+bQUT1/va085QS1bzkSrPxupPnYnkKMJv4fJ08HW+sH278inErEDE5Vqk23u1Rc+W4FY8VmwCROAHsBODJE0DMiqrgyFWLY6Wv3bSWPdac7JxDSIlSCiugLHOEM5XNhpZV2yljwGmc0AjpYzcIC7Pp+4oT69yEBdo4cVU/uZNnX3C2+iZu/HKBPun3yZ2oCAZXraWeVFUxFRZbGnTYwFmLNBYvLvFNWX22KzGuwFnDUpmz/Mgqdz94BFmW+MIRSgi0Y7YRerVI756Zbu6en5q6fLpRoxn6TNUiWlHwZ2fNzf6uHo1G+xaOHeeRheMsrvVYWFsnKaBflPRTS24B7aF1pfFx0kPFDUxZlZQVFV9X/UAajNB4fowxhtIYrLNjRXxFt5XWjRexMVIW43SZq06UcwLrxAa16URVajihR6UQGJGfvHZPGIHx4h6GIWVZUBo3BlEGgTjxgwofN96qW2PHzxEI6ZBCorQ6cTGPQVMFgMx4YhgDFHcCGFUldm4ictpEfW4e6GPKlBMgyjn3qInn1EX7RMqluggLWz4WfjnxeePz4TZdumK8ozDCjHdVckxhnjKINuzpT91rVceplH7SDMtpd25CnZiArX3UbTFm2iQKZ6qd1+Q+2DER/YPvZDfIXPvYk7BzrqrUeEzmzIJylK5ElJLCWAJdXRMVIBU4KlsHXwpMPsKzAilzjM2xUiHP0EXZCTyL3mC+clOgtE8Q+gyzFOWF5MYgnI8ncoJ0nUufdz5vfeV+Xrir/qkWfG4L2vwYfgfnKrNY7WOpetcpQI/nUKklxlkkDqxFS3CmmletcKBU5W0jKsdsK6CsqOKx1mPMLZwCHE57a8fznDzBKOdF/qRTYaebC+wTMEane83Ge49LJDfmtFOeO/GVOx3QmwAc68xpP/O0wPAUYCQcqE2MvxXVZ7nxRGw3H5OwuIn0YDIfW0Fp7Envf/JGU26aceV4Dt70N2GrtJWo1kw7TieeyJ24caqPE+vseA2tfkeH9j2MNZhSIK2sJA7WoqRCaI0px+DSjgkMVZl22E3pscrA4+RjtpuXqcnhSIFz4Cq7j4pYEHIMesSJdVucOCFSgjMSS4lz48Iq6zDGYK0lSQyeVChZqX4F1blQQqKUD2WBlgLf85DGQ+Y55BmmzEjLnGPDFbQsWDrucySKaEYB7VrIfLNJp9kgH57z7/Szzz33dc8+91yWk9GBbpJe1Uuyy3tptjMpLL00pzvK6CYpa/2Etf6AXlbywNE1sqzq3VVaV8EOVXko5BZsWEMFAUpqCmNBKLQfVvltWyFd404YIxp3ghLcGBhujE5N5bGwOZWh1KbBIOT4Sh6nV1DkeV5pjMZqEmcNpSmxRT42tCqr8nxXnWw3pqCVFkgpyIsS5xxqgrw3BqUdMwZm44KQbrzgbsrNbDR3nQyGzWzEeKAYYRFGPKa2aPMEYZw8aQKQWjwuMKqo6hNaHLeJ8nXilJz0ZLKRboP6tWNaeZJTf1Q6Teonvbs73fMqzdlja5Skkzg5zl2fch8sZhNF7aR73Pd59O0pk+kpxy94tOJ78/OdAOsJhB8iojahHyIosc5SFnlV06HA2hGyzHBpQuiHlLnC80K8QG5oBAzutOL0p5MyckiE1BVYto48G+EHNXzfp3CQl7bqKO7gVZe8hLdceiEXdDjUgNu20mc/JtZIV+JWpRRCKaR0jPpdBut9jM0xyqGCEB038YIGRVFQWksYh2hhMOkAWY7Ie0ml4RCCoixRVqC03DQ/yLEG8uRbUDhhsU7CeNxN7jvBE6bClFKPCW6E43FT9k8c9kTqSfAYzM8pn23dyUBn07y8wWRvSqtVjZQ38nKP2shIIU/KIthNc6ScMPYb04s5qQFzpXGUG2BKjBmfDdDnqk33hpnw5lza+KaU7qT5ePJ+FaBzSMSGzEpwooJsY2utK1DhjSu4MdU6aIQC5SGlHKfkNJ72kVJhpaMwRbVWTxgzOSEwqs9QE+beyY21ZUOPWlFDSFcBGTGReoyzO5Umi0o2YxzCVfxUpT8Slf5IVNpV47IqHWwcrqysdVyZYcuSkpJQCcLQo1WPaDZimuE0rThkqlGnGXnEQUnsCRq1iGYc0QxD6r53VzMKb4l9/e3ZWvzhjUl5Jo5unImjR5W+HYPfSEv2jtLyOcM02z/KTbw+LOgOq95hgzSlO0xZ6w9YXOuz1O3THaySpCWj0o4RZ0Dp+WjlIZWPC2IUGi0EKHlCbzSmelF6I+/rxuh48n/lwBuDIIeslhYkVjpAYUW1QCkh8DREUUizNj4pjYiGr5huSALlCLXC0wrpLNIVlTO1s1hTjP/Go1NMwlaQdrytkGMuRm4S0rrSVEzQpsG1mR06VR+0wR6Nk4O2NCcJAeVY51QJBU/os55oAtnI6TtxksbGbKKSN08WaszIVKmuExyTOyXXjX182rssy8cER45qYn48YORJ7yRAtPlxISa8+MlMkhMn7j/R7QkNlzsteNs8sZ0KjkopGVjDXQ88wp3fWyScmsfJEFsWSKqqtCD0ePHFF3LB2R10OSIOa3z3+0f41FfuRHotlDxxbZ/qJv10hhVV5Y6UkixL8fxgvAiMpyzniOOYNBuS2QIVeiDHVT6OLcutH8dvAFHpbAWax7oRihENbdj/0gvZNtskqIc4HXHH3Q9y34NHwauj/ABnC0ZJDy/tcsH2GV723BfSCDWmKIl9D2Hshv7x8caHLd3J4+Wk8fUkxNFPsFnSUj1qM/coKcDjMVKee1yW6VEskqu2hRufacxJLLng5I2n26TP4VQ9k7CISQGLO/15KEvzKD3UZilBQVnZyJyGscJJtNY8lobUCUjL4hQlhT0BeoRFecGj9Fdu0/sV1m04ZptxSssJgRGSEoHnR+RGkZaWwcjQHWasrA9ZWa/0xFnhNt7vZGApxhtNMdHLPSrjIJxDWlP5B04A6ljLO1YLoyRgc2xRYIoMk1eEhkSghSV0GQpDoCSN0GdmpsHM1Bwz7RaNyCf2FM04YrpZoxnHhJ4m1Cqp+f4dgc9DvuKwLzk8rx+jZRZPYre6Hf4TGqjr6h+VN0Nm2G2gOTFkHOV2X1pakrKkm2QMs4LF9XWOLa2y3u3RS0as9fqs95ZZXE0px8hUKg/p+SgdoKSHUxotgspPQcixaWPlWM1Yn6I20kSienysP7ITtCwVWgq0cEhrsXlGOnIEyuEZgfEDVCiJ/YB2I6IeedQiiLzK0T2Q1Y8qqxPUk5BsLlE/tfRzbH/em5TwT/wqBBTCnSAgRFWx6J2GHh5t3hE4g55oT4SgkOJEKeg4U9d8vDJ0KU8uYT+1x5UxNIWoet2MJ45y8/s7h+fEuER0vFhulMIKorKkMzluK4hOvRWWwgpi6ary10c9/gS6mtMJkk/6m6n8XoSjcKLyJKHCqhv3H+/20RP5yX97LEG0EBSlpNMrueRFF+7l//2hj/Dw+jGi6e1oHeKcwirFKBmQDvvs3n4ez5ptoyQIX/O3t9xG3GydYESryhHvTFucpZSEcURZVCnX0lkKa/D8kMIalFIEUcwtX76dIO3TvOwF++ozcs8WrPmxAKPYimpBM64STqejAfVYcemLnsvus32GJdzzwBprK6sY5wh8r9KI5D3M+jHOafu8/YoX8cJztxNJViKPe6RlFHg8BFBaph8f2DzxNXlqOf9J5fW2elwJepMy+M12H5sAS+mqafqkWwmjxxu/kznpdGNVCErnqrlL2LGj/CY9gYDCk5XX3Mb3PWVOlrKaF51A4x5N5xtz+s3Mxjy6+b3do7zB9Ljc3nuc71A83vWx0QP0lOdZUdkUOLnhieRNrAsmt27MiBsgLyEroChhVEI3yeglKcOspMgzkrRkkBT0+ymj4Yg8G1HmZQWcx6BdbJK4TNKz4E5kUDazaa76BoGUOJtjrcXYDGdKjKlMlHElo2SIJ2zleeRpGnHIVLPF9FSbZhww1w5pREFlsxPHNEKfZuhRC7x7ooB7NKx6kuOeYOEx+4U+QfxQNP4M3LgBBxUbjjJLyOsd2isI5wvLfF7O7MwKt2uUFfuyovTysiBzkoeXV1kZDFheXmF5vUu3l7A+6LPaHdFLUkZ4CB0gvBCUDzpASQXSH+csNU5XHI0Yy/cFEqWq9h4WXbEszlHmOetpzvp6wWGqVgwNX6FxeMoRhR6NOKLRCKgFmlBLGnFAPQyoBT61IGw2641mPYy2RQHUIqhp7tls4DjxMZr8fwySCgGFFqxu+Pa4asLQipXNA+bU5o/L8nQO2D/G+FGTN35l4zAxjvxBbifA+jGvq8d5fCO8k5//k4wluL6tuKk247/zX1772n1/8lefZLG7jG5tR2oPJcCUI77xzTuouyFvvvJSts2y4WRsioqZtDhyaxll7OMMaZdWlbU6rygKTJKA1vg6pCgNpXAoY4iiAGsEzhpGJuBvb76dbJjw1stf9G63I/Ja8Nmt9jU/GmOUFylOOpSsZANRFIJLiGOfrIRbv3yQz//THQyMhx81EUIQioKyv8QLd7R5x2tfykvP7Ryfr/EnIi+KHdr7g5NzTc/sc7jkuF5IimqBeBLzxOMRYOIpmD+fYH6Z+B9t8mobjfeDDQuxk5W55MS7qYB542hacaIvWwkdA15p6SR5ZfI4SEYkmWG5N6x8BPtV6X2SpvRHKeuDEYNRTloaclOJ/o0TCOlVJo9K4YTC8/0NAftGmoyqIptxxa3UEkUllynzgtLkYy2uYZT1sWaEMBaNJZKSZi1grtOi0+qwrTNFux4x024y1YyJAp8w8KvCAk/0Yo+7tGDVgwUl6QWCQz8sAHqqlsiT4iSNgWTcVE9AzR/fqX74fTsb+1PDnrxkZ27tzqK0zUFasN5P6Y4yFld6LK/3ObK4ykq3zzBNK/TaTxikBfh+lQ+VGqV9tB+gVVBpX6TCk1XJolIKFJRC4FzVqEZ5PmlZgDFYV8IgA9dFuAJnCygLlDAEWuNLga80jbhGPYqpRTGNyGeq4e+LfUmjXqfVajDdaNGsx8SRIFAcCjUHNawo6BtXGYZJQaIEPa1YnYEblwUHjK2cr5fUCdDwlAKip+C3/kFvnwygOZMX1sn3sI7osr1zI/lLb93/f/3F33N87Sj+1HakFBCEeMrx5a99i+FwxC++80r8mk8YRGjpVboEJylKy+bd79MdwlGARSmBjgMQGuMMeZbgeQpRjnAyGhdhSAjrRGHEzd/4LouLi1z3xkvfddkF29gCRj/CbwCFsZayrISnDkNqCubm5ji+nnD7Xd/nC7d9g0IG6KiJ54dQZhTdJc5p+vzClS/niot3n2jB4ns/c+dwVo7nmp/C1O5kflmEGzYMIiu2R0+8BJWkV8K0dcTG0kxL9iQjdnaHQwZpRi/JGIxGrPaGrA+GDIYpvWREb5gwTDO6owLjJKWzlUbYTVppVZY7XhBihER4Ai1kldmRcux0bbAmqdKdzo5tblxVTm8KhDHkRYa0pqruKwuUhEZcY6rdptUI6UydTbsRMjc1xdz0FO1aTM3TlSO2EoknWQg1ByOfe7RkVUKCq9hADSs/iTVCPx0//Cx8eNJQbxl5wCE919BeMRtV7tlu2860rIBT4ZgvLV4yKlhf79Edpqz0EtYGIxZWKsZpbTiiO1yn18tIsgKnfJzSSB0gtIdQHkIplPQolMP3vXFntKriSwlZXQCTMnvrkFKQGcOwLFnpW8z6AGwfLcF3RdU+RDg8T1GPQlqNOo1aSC30ds9OtXc3Ip9WvUajFlIPA+IwoBZragF39RSXSxiN9RmJgPIw/IdNhMwRC5Fytjcr5Jag9QyMszW/7cPhS86bjrK3vWHfB/7qE6z2jhNOzZOLECM1siH48l0PIOuz7N6zlzBuVro05ZE5KsraMX/GNFCceIFJhylLtAZlStqB5Pn7zmNt8Qj3PfAgfmsO5cWVg64KEI15vv3wCit/fhPdN7/6XVc+/9xd0x4f28YTG6ltxaPIi5FEEQchypOgFdbz6RnBzXfex0OHHibxatQbU2g/ZNRdxQ3W2R4K3vqqS3jNC3d/qg03bZ3Jn65YhgMFzJdUMoUC5icptxKm05w9vUGxbTDKOLrcpZ+k4x6iA/pJxjDJ6acpSZ6TZIbCWNLCUhiLpbLWkVqBDCgIkL5Ga40vqlS5tbaqVhSA5+PKkqIoqmo1Ki9BW+RYU5Inw4olsiXC5HhC0IgDtk+3mWrGTNWmmG7EzE1PMdNu0q7XaNVimvWIOGIF44g8cY+vOKygr6CnoOfBwqMa7z4ec/dMAkZPih0Q43TJeLOzCDfYuhcx22HScDZz7MoMuwvHfFLSWRuULK11WesnPHJkgbX+kIWVdZbXewyGA4b9gjQzVbNZUSJU5eEQ+gFBEOG8YNw0E7QKMEqBCtBBWO2Qx/omIQSiKLDWYW1JZkt6g5JHumsIU+JsjhubquEMyjl8rWg363Sm2jQb8cVz7drF9VrIVLtJu9GkXotoxDH1mioin3skjDxY0EKuDGH/RMPkwHMWL5QcrPxO8DYLoaUg2ep59pOLefgTB94rnzP3HvWL1+z9vz/2GR5ZfITm/DmkaKRsMRU1ue2Ou7n/kUWUjjCOqu+Q9OgOR6QlHROcrAF7uiPLMqIpObYcsAR2xGUXnc85M/v4+0/dzE23fYNwajth1CZPDZ4XUZvZwfG1Y/x//+xvGQ6ueMW1lz9/tXDMny347a0r5clHCZ1BklBaUBakUEg/YmVUsPL9RaSOqTUjTFlQDFYRaRfRX+Ktr30DV73kgpXY8u1TeyFuxdMLeCYAZ1KBOmmpUpEA7MxKdueWs3LDzsIRH13ssT4YsriyxtLKWlUNPhjS7w0YZiWDvKCwk5otgZAaqT2QVSbF92OclshI4Y+LPISoZCZSSmKlSPOMPBvhnEHJyjeIPCfPRiRlOa4Os7giRwpLLfCZajVptSPmzt/OTLvFtvlZZqZbNOKIZhzQqimaEYUoKEKPg7Hk25NmsJM2KBpWrLLxnFQfPJN/N/3TcHGdFkUKOK6rZn7OwyPSmNlO09KJ7P6z4xKm85KdacmeYUFnrZ+ystajOxiysLzEIB3R7fZZ7/bpDxKG2YhRYSlKR4kic+OyZenjlELoE2WMnhdUJZLSB+mNKcdNFR+lGbcOsWRlyajMWekW3LeyBLYkG1UaRGdLoKqOm2o1mOtMee1mfPH22Rnqtaqp3vRUg+l2i2bdI/CrBj2R4/5QclAJekKdaK7nwfEFeM8gKy/RkhUtxaqnxMIccuP8LTtzAGOZ0d4WgPoxxDZ4/zZ4v3/B3M3RO994+Qc/+mkOLT5CfXYnw6IgLx2N6XkOL6zgRSGNRqPKz0tVNU0e5ZQ1v3PGfCFh8fzKTM2ZAukKml5BR+Y8d8q/f+91V+y86Pxd8V996gus9Y8T1ToU1jG0jrA9gytj/uRjX+DB42vXvP3KS6/JOv6uluRzW6X8Ty6GJftX+wlZ6VCAMBYjJE4o8DRaK6S05KM+Llkjznq8682v5m2XX3DHtOSjO+APts7iUwx2yuKAk8KblfqkZrHWVn1DURXjUzjmS0encMwnOfuS1JLkhsW1If0kZ3V1lePLyywurbHS69EbpqSlYaXbpzQOIyrjZC+M8IMIKause1CLqg26lHjqhIt0VfXsEKqqeJNCoMYlSmVZUKQjiiInSRI8VWnYPGHwpMP3BPV6QDAd0azFtFs1dszNsW2mw0yzznSrTrPuJ3WP28ceIytKVEzPpABpQ28bsPK4DLg880Vu+qf5An1Cql7Dkub6MmS6bIQduyOMAAy7mxaiEjp5yc5Byr7uYMRaP6E/yjh8bKmiJkcZ/UHC+iAhyXLyLCctDMPhWpWDnRhPKlk5c0oJUiKUh3NVWb30IvyoQSh1ZVLlLLEdp+xcVRovrWFkMh5aL7ErS+T3fL9C80WB7wniwKdRrzM11aZdj5iqh3tnp5p7d2yfZ26mQ6MWEwZqUlVXCKEL5eh5jgVtWe1KXqthVUFPCdVDKxbgPQp6M3DjVvftHz2arrzlVed2DqlrX//uD3/iFu47/n0asztZyUc4FRM0WgglMWM7fOUHrKz26PWHmI7fPHP0EJUpqlJq3PqmwKUJKh1Qp367r/jYtZece9HZ0+2r//5LX+X2ux9C1abQYZPMGAK/iT9zDp/+6j088NARDlz9muteedF2LEQ/boHkMy0W4YbVxO5fWOui4hrai8jt2FBQSaSSlEWKyFLkaBU/Xectl72Ya1/z/MOzkg9tnd8fE/CxHHDgTSpGJxW6k+quXHs7HXg9x+WFZT4v2Dkq2JflhtxCkhccX17lkaMLLCytsD4Y0h0MWF1dZ3UwYpC5SiMrBFJ7SO2jghAvqCN8j6n2TpyQOKFR0kOoqvuDc67y3LN5Vas9LvmX1uBsiStynMkpTFH5AAmLlALfEzTDgHgqIvQj5mbOpxZoplt1ppsR040a7XpILQ4JNb1myC1j7qHwYCGAQxpWZ+HDS85e/7Mg79DP9C/4RDvVZcUB6uDqkWe2RU0DzfKiHdOFZd4ImoVhW3fA/u5gQK/Xo9sfsdwfkJWO/iih2x/SHSSVyC1NK++HQUHpBMZVVualF6JV5WJbWov2/crNE9BKoQKPQNY26Mtay6Jk5UZq8oyyLBlaR2+55ODCCsN0WAnhqNxvA0/TbtSZnWoy1Wh47Xrk1UM/nmrVtnXaLaZbdepxROD7+NJR147Il/cEHoe6cJUUjAaOS7RgxYOFyjvNlXNSfHBrmnxycZbQv3fc2Pe97LzOR4urLnvb337xa9y3tMpUs0O/LClV5SXiSa8CHn7AeneF3jDB2KnmGVEptNEbsHKoV36AyAsUHloqlKM3SY2Fe6b/87ap1/z6dOOf+NJd38OKACF9klFOqzaFmos4uHSU//b3XyC1V1z3iuft2GcV0Xb4T1tXy+kjh7PWRikPHDmKCms44SGdQAkqbzVyVDFAZ31Cm3DdG6/kmsuee7wtuGkLFP2QIAgOlNCxrqrmMo6mlUSlpVMaptOSPXnBttw4SmMpnGShP2SYlqz3+iyvrHJ8eYWFlVW6/QFJmrG8skZpJUJU7uVBEOF5HlK2oNam3YkrDaysAO/EuXqz4aTEgStwZY7NKw2QHDtOa1MiXYkSFesTeYpG5NOY8oj8iFYjohH5tJs1WvWIei2kWY9p1OrEkV80fG4bd6I/vLma+smwuj8rmlf9sz4wHpMpkZtYpzbX064jqBc57MxgdwnThWV+kHJJb5B5K71BVe6YF3QHKcM0Z30wYn2QMOinDIYj+klCmhWkQ7PBODmpMVJSSLnhYKq1Tz7uAq+UjxdEOAGeEARKIfJ0PKAAW2KKnJUiZ/l4H3Wsi8kShDUIa/GUIww8GrWqqi72FefunKNdD/d1pqb2tZsNGlFIFPrEvk+oFfVQ3CMRozXBW5Sk5ykWJgK5yc5ha0o9DYOp5PuVo/eq524rPO/S6/7np7/EPccexp/ezgiHdZqysCgNSvv0BgXD3JILzjqTvodSCiUgz3MipRBOUGY5geDQ5DnnCP5PORuMfvENr/q3jUaDz3zlWwwzjRe0SNMULwwIOzs40l/iv/71J+kOr7j4sueef3HRYtuz4N9sXS2PjhT29HPHsZUu1LfhGHd8tyXaZWgMZbJOmHV5x1Wv4J2vee4tDbh1J/z7rbP32LEE1xtoOoc2gqaFOINdRcl8XrJzVNjdWWHIjaNwkpVun1Ga0+2PWFldZ3ltjZXVVXqDIcOsZKE3pERi7NhrViikV1VIS1kjmG8RS42nFFLojZ6azjmEFZTjfolOlrii6rM56cDgTInEoqXA0xJfKwJPE8chtVpEHPjMNuoV8KnXqdcqm5lmHDLVqtGqeb3A45AnWfAlh8d2MRveegp6WyB6Cxg9pazTkuT6TsxfuTjwzFzQLGHaQDNz7M4Mu4YjdveTEYPBkN4gYZSlZIVjaT1hVBiGwyG9/vjfMGGUZmQllKmjNI6sMCAV2gtQXuXhZITEaR+MRKrKhtKTHs7Xld2+AhG3qgUOUd13sF4WLK0X2DLjnqOHwJZIXDX4fI965DE71aLTqjM33d5XizxatZB66BMGHpFXVcpEvkfb937HEyz4msOeYkErVrRgdWJoOSmv/FkUgs8KPpwZdr34gs4tqbvk8r/8h1v47rFHmJnfTb+QpOWoMs21JTjJ8qigZ7j8Ecl/PJunWagsqpSwdOCMwZO6cp61BcITjzIKPRt+m6bkna950Q3bppudj3/hqxxeXcBrzNNfTwjrDZrzz2J96Qj//W8+w9L6gCte+rzfLGbUfA3u2KpaexRjtPN7x1fopwUytCiv6g2lhUXakmxtlVre419ccwVvuOR590zDR7cWOViyXG9s5ePjFJ51RLllZ2GYT0v2JLndPUpz0iInN46VQU5SWvrDEWu9HivdHqvrA7qDhCQvWB8k5IWhKAxSaHw/xPd9hIgxDnSrjTduwAqTvmJ2o3PBpEsB1lGYUdWqoiyrEndroCzwpcDzKtBTiwIaUyFTjRnqoUc9GoOdekg9iohDTS0OadZq1MKATs27yxcclpKRJ1nQkhUNq1vjaQsYndGACQGLmhvKBtO2EUV2PoodaONoWojSgr2ZYVee00lGKcNRzjDNSPKSvLQMRvnYcCuhP0iq1ivD6jbJMtaGPQxi3NMMkBNaVmOEqHrbuMotXGgPrTXC9/D9yu7eOEsQBEgEWTaiV2b0U8Pi0XXsw8ep+nqXeM6hBARa0GrUaDdbNOOY6djfXY/C3e1Gk2ajTj0KiQJFoDWBktRrUc+X7vCqlm/zdFWVoCWrUpBocYJxWrYceCaCp52Kf38c3nfZs7frQL72FR/86Kd58PgjBFM7EDqk6kcnyazim/c/wrPP3h7XdkaXLcmT/ax+0mEFkdjkdiewJznXni4ia+/ZFsj3v/Gley+fajYu//jnv8ydBx+hNr0dJyyDNMerTZE6x5/fdAsPHTvG2698+bsu2tXaY6AZWHtoRsqfeX3bYfgPSyWvuPuhw8ighheElGXF+iqZ45UjGmS8/Q2Xc+ULnrOy3eePflaY2yXH9WM76fncsNMImplhV1G4+Swvd2dF6SVpyWBYAZthVpIXlmFWzaO9/pCV9XVW17r0koz1YYbzPITSOCQFUCKQykcojarNIZ3FN5ULvKd01ZTXOaQtcabAWUtZFBUzjwNbVmmvsiAdDasmploRBR61OKQxU6fVaFKLAuanWtSCgHotqvzvxmbCYaAJFDQiXfiKw4HmIS1ZUY6eEvR8yWEPFoAtr7AtYPTTGY9VSQew7I+drSNuXGqF11vCqIROacemXYJGVrB7VLAvK0wzLwxZlpFkGWluWRtmDPKSfr9PtzdgrddjvT9grZ8wSFP6wxxjLGnpKACpPJQXoH0PpMIiKPLKx0JKie/7492PxZm4AlKu6mhsrSUxltHAcKw/QjCkyFOEq3rX+FoSBT5x5FeDWwvmpqeb9cjb14zjffV47CAehzTqMbUgINZ8KAq8e2qxvCOBiyetAqSrqhsm7NNP8+CfVKupXbOfjN557dV/+vF/4BuPfJ949iw8r0YhI2rTO/jmfY8QupL6G1/1Cm+bXigs8zvk01tZ9HjdzU+NCahRgt4rLti+MtN4/ds++U938umvfgtb6+B0CE7iRS10EPKVb3+PXjfhmle/5JJXP//sqC3lTcvOHJgR6md2oj8Kv7UKb/vqwRXuuO/7BPVpIKg2OFmXYrRMy89515tezeXPO59tsXj/MwkULcB7Jo7NDrzSVHNhWrInze2eJC/iNCsYjBL6ac7qMCfJDf3hiP5wQH8wpDtM6Q0S0qxkmOUUpSMfNzBX2kdrHyECjPOh3sbzvI1mvaY0SGM2+n1Za3HWYsqc0hRkpqowxlYpMEyJsAYpIAo8GvWQqUaNRq1NHGjO3j5H5EnqcUA9qlj3OAoI/WAsVQiOh1oc9H0Oe5IFzYl0l4SRcFXXhK2CmC1g9DMVmxf8R7mFTyKoAJQTynMoD3yMbTRyy85xKei2vOCsvGRnWph4lBuSLGdkHWtjy/e13pCVbo/13pDVXpdef8Aoz1gfDBml1XO15yG0VzWHFBrlB3g6wAmBlBKtfHw/rKojhKieZ0tKV4I1FK7qUTfISkx/gMkzgiNraAlKWjRV08g48Gk2GtRin7ovqUf+vnajuS+Oo0oDFfk06jXqYcB0M7rf0yz0PV6hYWXSfmVSGvrTlD64wOdNPCv+5K9e87qru3/1cR7pLkBrB0L4FHjouMltd92LtAW/cvWr33bB9pDN7VOeVnDkOKmZ8RMBQeEoXnB2/WD9qkv/bbvV4G++8E+MyggVNnHSwxAim3Pc/cgqix/5NMPhKy5+5fMvuHh7XX3wSbVueAbGI47/uCa45rb7Fvb9j499mrVM4TcjlPIoBgNkNmBHw+PnXnUJVzx/L+fU+PWftpTJROC8WeNTOOaLgvkkdxcN0mzbIM1I84K0LFlbH1StKkY5o6JkkKSs97oMBpWNQS+z9DNDmqZVQUPgV010URRGIsMY40TlASXGbLqQVcGLsSAMuSmxRU5ZVo7NG2kua8hGQzzpCLUkCjziKKBRq9FqVPPTzu3zxKFPoxbTrMfUo5Ba5FMLNL4SeIIiUByKA749Bj4rkz6aytGX7gn85raaMW8Bo614HAB16o5BngKeJgaYRt1Qoqat9CMhKJOicVHhmC8M87llZ2mJs8KQFyV5aTi+2mWYpqx2e6yudasce2/A+mBIMhpRlClpVpAUJcY6lB8RBjF+GFRWBBqQAikrL42qW45Cez5+3ECiEMJhgRxIraVn4OhqgVhOcbYyDdNSInH4WhIHXuUQ7iumGo29ceTtbddrr2g1a5VzaqNGo1YjDGAl5J1asqqpcusTD42JQNxaojPJ5K4Gd7z4/Lr3G+/6+av+60dv4u6FJbzWNowBgYfXnOe2bx9ES8UvveWKtz17RhVnIiMwaaL8WDHpVm3asvmOy5//zrPmpjp/8cmbObR6HK89T4HGqZD6bJPV3gof+NgXOHR8jTdf+rwbLthWn3YKz1njnenmbz+uOA7vWxVc+9WDS3tv/LsvsNgriTqzZNZg7RBpB2yvS95+xUt5/f7zjs8objyTQNGkp+EM3DgxMtyo8HI0c8PO3LIzNezpD/LmWq9ybD6y2GVkHKNRRi8ZMhgmDNKMpCgorKM/GpGkOaVxY22lwjmBlBpPB1Wpe+QRRJWo2eAwwqGUR6gF2ShHSVf5+5iCIi0oigJXVsBnlKxXIEhYfK1p1WJmp9vMTrdoxyGdVoN2zWem3WS6VaMeBUSextcSJSgCXx1SSvY9xXEl6AlRMT1asKKg5yyeLzi80ZrkVNCzBXy2gNFWPPUxp05J221qj7RkuR4JDuVZVNVk8Ky4aajy9KOCfZlhd2YgyUqGWUlWWnrJiJXugOWVVRZX11heW2d9rcdguEovyyhdJeqWWuF5AUpqhFAYBLW4gXG2akCoVJWa8zxwAusMQtRxVWMunClJSsN6kqOGI6QwuEeWEc6iJXhaEngetSigFsWEvqQRylfUayFTrUb1tzGommo0aMYRrZq8Y13wxkDw0AQ0CUcx6bb8k2Zkdmr+/VH4refvqnu/8tbXXf6Hf/kp1lyGViFFblF+jfr28/jcN+9GaPgX11x5nWsIb4/k7U87a/RDxC7Br0mP0eteeM5FU403X3XjP3yROx84CrU5VFinl+Y0mrNYP+JTX/4W3W6Xq1/9orc9b9fM/ilPfWIRbnjM1gDPkDgKv3XM8ps33f6dzsdv/jqruU88PU8+NrMXNsel61z20hfz6uedx7zPn5wFv/eTOr4luH7i9TZxbN7cFT6DXWnGntLSOeT401FO3O0NGAxHrKx3SfKc/iClO6x0kt3hkOFwSJIbVoc5ZuxP4WSVzkIqnBT8/9n78yi7rvrMG//sfeZzz53r1q1JVSqVJssaLMuWZdmWkC0bDBgzOAQHk8Q0L0mc0NBNul/oftOZ+oW8abKS/q2ETtMhJIEACSFg8DxblkdZtizLmqWa5+nWnc/8+6NsOukAsWUZ7OR+1qq1tLSks+8+p845z/3u736eUICRyBCqIUTilXZmiOKXq9gakVj29CGMCEOfMFhOG4ii5d7IwG0iXq7+EIUYmkIu4ZAv5kg5Fis6N5BKOrTlsuQyy4ntCQ1MFQy5XO3RFcZtlRdeMTFkOQKqIhH1NsSPr2wqrXdSSxi1eFPzQ7+1/MMbWPmH5W41H6KmlgML7XxAPhfSl3ID+htNNjQaPg0/ZHKxzFK1wdzCAqVyhcVKlYVymbnSEuVKg8WlKbxoOZhQUTU001oud7/8UJO6gXzZxyMGYiGIX3YY1xQFYS2v87thRCOKiIOYaCmChSoxEW6ziqEKdG15Jx5RgCIhYWjYukYhm9qWdBIUspllb6dMikwqRdpRGLP4HVUwPy/4kMGycIrAEhGBJpl65e/O97KOGsULjhRPre1N77ls2wV8++EDZNp6EVIjiKAWgdXRzwPPHadSXuQzH/3gTY7Np3+Svj8KlAXYgmXR+0O+7Pqv9li9cnlLvrGm7X9mE+/6+NfufoQHDx5FbetF0RPMl5bIpRKomXb2HR/n1OQsH7h6R/+1l635eEbhLi8Kuk3CU22q8S9ueW0o5o9nI2696+AZ+6t3P04pMDCzeaRm06zVsFNJoppL1tZY25mly+FPzqcomo25dbnRfrkC+Epq+8tZXblX/uzF9LgRPXUPKrWIUrlCteYyv1RlqVxhdmGepXKVhufj+SGu5+MGIY2mtxxMKgRRLIhjQSyW4yiQBmamgJTKckzFy+WTKAqI45ggDohfzmuP4pAo9Alcj8D3UWNBoEkqpSUgIo4CRBhiKJJM0qajLUculaarkCVp6+TTSbIZh2wySTJh49iGb+gMGpIhXTKmQJnl3/VAxPiGZOhHZ3W1Sj0tYdTiXx0/TgjMqtwaOqTihKaGaKkLusx8ALmYPu2VkMNGwIaaS77uwUK1TqnaYHZu2fxsfnGRxaUK1WqVputTWQxw4+UvdMhl2wFF0QikQhOJqqpESISiIBQNRVGRqrLsGxJFqHqCkIhmDMQhcbz8zbDciBB1j9Pz08g4WP5GGXmIaNnLKZGwSFpWvquQyWcce217LksmnVy2wE8lyCVNUgnGTMGpBbhJQl1huSdAChqviAONZV+nf+68/aOqnhRfmoJPpnSO9hVzG5KmQkxArGo0GyGNOCZlJUn3rObZUyf471+7nV/70I1fcB36HcFTb9VGzEQQHLyoy/p88qbrP5vLJLlz//PUYouuzl5K5TKaoaNnOxgrzfLVOx9loVyx37/34pvSUn1KKGrwL+0+m4JPTjb51XsPnuAv7n6UppVDSabxVQPPDzASDkIIpPDpzCcopA1kEDZQz70MMQ23BZCPwPKhWIctryS2ez49tXpsl6pVFqtVas2AiZk5SpX6cqW4VKZWb9JwfVzfx/VjwlgSohBGyzFIUtNRNQ3V0FEUHeEkX/btWfbEUl/uTwzDZb+eV/p74iAkDDwIAgiX87niOMT3XQLfQxBgGRo6koSqkEulactlyV7QQ9pxaG/L0dGWJZ9Jk3E0UibzpsYpHcYUsRxK+rJ54fJ9DPUfmc3Z0jwtWsKoxWuqOr2y7CR+/G/SnMotYYJUmLVTIXYqIm8FrMk3YEPdZXOj6WteEDI7V6be8Jc9RBZKLC6VWarVqTV9vCim0vBwfZ9GYznxOVIUhFwOTQwjSawsByb+wC8EBaSKqqvL5oSa+gNvEfFy7EoziqgGAZNLHofGh1Di4GWL/WX7fFPXSNoWCUPt6e3p7GnLpugsFMinHdIph0wqgW2CqYANZUfnKQXKi3CjCadeeQCrsLB8qmL//yy5d8B/X4APdLfl0CUsuR6haeGrynJcjKISaTpO93r2Hz+L/9e382sfvvFX16aWRdhPglfOqRACEQvkKyaD50i7qn4JwEgzdNv7rrxtbXdxyzfu3s/YxGmShQ6qvocXKpiZApVmgy9//1FG5hb4uet377igoM2Ph+FvdCvK7/5LuI/O+vGXZwLx0fueO8lffO8h6lYBM9NFuRkAKqppoOkqkVujUS6xduMG+rvbsFSO/nNiK2TZCiSKsSKx3NwcxOQaIRvqLvmlZki54VLzQibnS8yVlhifnmFmdpZSedm1v9ZwafgBumEihEIsFBRFQVd0FMVAmhJpLed3RUiklC9ndsXAsjMzIkLEMVEYQugTeE3CKFze3h54xIEP0bKPj6EqaFJi6Sop2yKbzOAkLJykiWOZZDNJ2vJZCtkMacfGNpjXJWMJhYOv9BO+Ek4qwG95OrVoCaMWb6mq05zBLaGhpUK0FHkTgJhuzYdi3WNzrcm2atOzG37IYqVKtelRqlRZqtUp1xvU6k0q9Rp1L6BaD2kGAW7To+H5BGFILCSeUIikgpVIECGJxHJunVQkqAJFCRGaQSaZAZadaGX8cgNn5FPxPZY8j9ETk8h4hND3IPTQpCDp2GRSSdKWRXc2k2rPJq/LZmzSjkFbxiGbtNG15egMQ1XmDV0MLQmuU1luyHzFbdeFfstKUCx0UFr0UXQTRRUEno8bS3R00JIobX3sPz5I6u79fHDP9s+67fpKy+VYt8FbUiS0w5faJV9SL1nzUD6V2fP3Dz7O0ycHUZ08aiJPM4iIpIGeW8GjL5ymUq3yc9de+a5LB9q0N8MuvdfLKHxuJhQfvf/gcf767n3E6XYUPUfNEyiahReHCLG8tBxFAW2ZNLlsFlRowIZpuO2VVHY3YKVUaLgxKysuV9V8evwoXk5erzep1GosVqpMziwwtbDAXKnMQmW5z6fuBkjdJkAQSQVFVRF6ApwUwgYjjjB14+WqlUDGoEQsx1G8LJjjeHmpOwzcZbETBsRRgIxCRORj6BqmFBi6im2qmHoCy9AwNBVNgZSjk3ESFLJZ2jJpsokE6YRNylbGTINTqlw2jH0ljV2A/4pz86uNrmjRoiWMWrylRRP68s9sSr81gJwfWx0xy1t7A8gHMbl6M9pSqVVTtYZPrRFQbwbLTZ3VKuXay02edZe657NUc3GDkLq3LKACFBAKqlh+GUjDWu51Qnl5d52CUFUUzSSOY5SXvUx4+ScOAxqhT70cM11pcnR4ePmlENXQ1Qjb0EgYKplUimw6Q2exI59O2vlCJrktaRnkHAfL1IlFBIZGoEqKXf0cXxomiCWoCrqqoQlJpEi8ZohhZUl0a9x/8ARBEPDh63fffEFOfOmnIRIEyy/G88EFKlebGwr/s5h7x8dTdz3Mk0fPUi9DMtuOG8T4ikAxO3j65ASV8gPU3rnruu2riptdW67skeItGX0xDr8x6fHr+46O8hd3PEhVOjjJPEgb34+IAV1VCONoefeU72JaFnY6T03CUINf14AYKFV93EChVG8yM19ifHaWqYUSc4tlSuU6tUaDesNddsiXAqlooKgIaYBuInS5vOz1cvC1UJbvgZjlbMY4jgl8F0XGqCEQBkS+TxxGqMRIGUHQxGA5p8vUNZykRcZJknEcEoZOoS2DpakkbAPH1klYNgnbwrFNTIMxQ2FQU5g2YEiDKQkNGdMoiJbgadESRi1a/CN+2JLdHPEtbUJ8DUsya6VufcUILmJ5S7Ab0u/6rKy78ZZKo0k9CJlbrNDwQ8r1xrLxW61Gpdag1mjS8ANKtWUBVau71N3lbcFC0VB1HamqSMMkCpbTq1VdQ9XsHzSHCqGg2yqRiIiEByIk9H3mvSZzcz5idpbGiyPLAY+xjyoisskkhXyWVDaFk8mj2nkqXoyqm8RSEsQClGVxFgOxoi4nZGsJtFwXz5yewHrkKT6w++KPr84auR/bUH8+hJB4Yxsu+uGXjA5z8N+87+2fH+g7xvcfO8jU3ASxYZPKttFwXbIdK5moLPLFb97BxK6LO9555db/4iaU/rTgvreS39EY/PZszEcfOjSkfeO+x2jqOaxsAU9oeF5ALGIC30NBBSSxjAljQYDK0GyV4BAsTk3QrNUp18pMzsyzVPYoN10aTQ8XidB0VMNA12zURALMGFVVkOrLDc8AUYgSg4yjZUdzljO6AtfF933CMIQ4RBIR1mtYhkHStknZFkkzRTJhkrYdbFOSMlUMVeBYNulEgnTKJuMkcEy1bGqcsgyOamLZ8f4fZnS9Uu2ZiX/IrsNWj0+LljBq0eLVVprEDzfDfOVhqi7/zJriVj9tFSOw4hWOFkDei+n2QzqaHmvqTTdVrTdpej5V16fadKlUG5Rr9eXlukqDhXKZSsOj2lig5vo0/ABfKvhSAbn8khGKQRwbBEIh0pfN5VTTwjazaChIIbBdlzgMieIAIULKUcD8gk+wOIfrT6FqForpIFQLWzPwpUIQLTel1pt1ROBiK+pyAreZItI17nv2OAKP91xxyU1GMfHfNJ+pTu2tm1TfBb+nZGU5e+WFv5pPpzZ879GnODo8hZaykKqGkCpRMk+1ofHlux9nKZS8Y/uGj6wtmISQeiv0k4zC52Yjbn3whYmOP/vOPfhWnmRnF9UmhJGg0ayhaApCkcQEKKqBKnVizaHUDLjnySN4lSWiZhNVCiIlRlVVDDWB4mRIpFQcRSJV7Qd9dX4UYmsaYRwSRj5B6C47NXsugedC4CJFgK6ApqgkNZVk0ibnpGnLpEnbJrlU4mW3egPb1LEMHcvUsG2bhCnGTMkpTTClSaZfWfJSoPxqK5ntgi+1nmwtWsKoRYs3utr0Q8rws3BrrKBhA7ZBnDPUV4JQPZaN55puvKbp+f0116Pa9Gn6Ec0wpOYFVJs+1UaTcrXB/FKJpUqVesOnXPFZqlWo1V08KfBQkYqGZTrouokqVfwwBCFQDXs5S0kINM0AP8CyLPwwQpEGfhwQegFhDBAh4hBdiZB4RGFMPQyxLBuZ7eC+Z15CERJ711W/vjrPH/0k/X7eiCpSEb4YGVjXbF3xrlza3vPwwaPse+4IgeZgpNoIhYqZLdJE8K2Hn2Z8coKfuXrnR7b05YpSeXP3mozC5xbgA3c9c6bjr+58iLqRwcl3UG4ECEWytLhINu1g2hYLtRqgEno+sYxRhE6sqngRkFRJ5xSII7zARVNU1FAs2ynIGIgJ/TpeIyD0PWIiGmFIHPsgIgxFkLR0ivkUxUwnKVsnn01i6JKkZZG0TJKGQco0SZomCU0MphPcrwmmFCjHoBH/7y8iKiz8S/eYatGiJYxa/KsSS/8IBbAFs7Z+axDrOSEIYlBrIdtCQSqIyXsRPa5Pj+dDw/Vpeh5hGFJrNFlcqjA9O8vU7CJLdY/FpstcZYGK6+JFMRKFqGmC1AmlTmgECNWg7vn4Meh6uBzqG0QIIAx9NEI2rV/NxOggszPzGIkkXhijakmUVBf3PXEEI1J4x44tn1rTlfhGHMdqUYrzXj15JRLkjaYT/kAqNHasyQ/mUpd+VCHioeeOU6+W0bMdBEJFtZJEqsLjJyaoNR/jQ3suvm5zX+eG0FFTb8Z4jNGYz80FfOShI+M9X/7uvTTMLMlCN80QfN9FC32yiZjLt15Are5x6PRZAqERxhG6IiEE3w/wIw9N+DT9BrHXJPRC/DhGBj5h0EQqYJvLTc1pQyWXd8gnk7Rl0iRtm1w6RTZl4+gaSUPF0VRMXWIZylEpaWgqU7pk/JUm5x8pelrLXC1awqhFi39lAgq+8o8e/v/AMmZG4eOxhhqDFqFZQazlFUHZi1I9YdCedP2B/pobbGvGQqtHMSXfZaFSpea51JYazMyVmFkoMzlbZrIyi6uZRJqJopkEIcRCRRECXTNp1F1Cr4mlSz7wnqu54/b7mJiZQ3cUfCSakcQoqNz7zGGq9To3v/NtN6/Jq9PTYXBbUVHPmziKX34Xxi+fk1i8sQrpFTfyNQVT+/C7dn8kk8lx5+MHmZ8dw8i2YZomoa4S6iYnZxf467v3Mbvjop4rL7rwjzyHnl6WzSTfDEzDbaWIdz5w8EzPX979CKHThp0uMF+poUoFJWpCUGHnjktZv7qTp587QeiFhGpEHInlHZKBj4JP6NcxFJ8uRyWdc0jbSfLpNClTx7ZVkskkicRySLOlKaRe3gSgxGAolC2No6bklC4Y02HsleXHuZhbWgGlLVq0hFGLFufEj2wSlfxgN91cQv1BTlSMqnokeqIYKwK76bKm0gg3BIrCTKPJTCNkKTY5cGaUR58/SqQ6aJoFcYxpGPhBncPPPcu1O/q4+cZruOPOezg9Ok4i004Ya0RmiiXF4e6Dx6gFgl+84ZpPbW5TP/t65/lK1lUsYmK5vFOJSBC9Io7i8DU5X5+LOBUi9M2kcupDb9t068rObP+37n+Kk9MjyEwRxXYIUBBOG6eWFpi+/3mGFzzeceXWX29kuSAr+N5Pe4lnBj4+H/Ghe549u+Wr9+6jLGyMVB4/FJiaigyaRF6Zd73tEnbsWMuLJ8ucPnOGUJgYpoMXBARRgO83WFnMsHfHZazrSNCl+DiRh60lsDSOqhHzUkQNIaUfSzRdMvYPe31e2d7+o85HSxS1aNESRi1avKH8SDddABOmNOWTTcmarpRZnIabRprw1NEqUeyjaoIo8BFCQUYxlqGzMDXKC4dO8p7da0nfeC1/9/0HOHpmFMPppOYH2IUuwmaKRw+fplyu8p8+euPnXZv+pIgea5PynF96MqYB2MDyvqWX5xDBDwTSG3oehfI1AN1k7LotPVfm09d99Kt3PMDBU8Oo2SJGOke94aEn8tRCl7uePsLgxDQfvG7Xuy5eZXfUQzavVPi1n8bvwCzcuhjzngefH77qWw8+TVkmMDNtLNYaGIqCV1lANCv87A3XsmvHKmouHDt2jLrrYaXy+FGECAMQEZqp0fBqNKpLtDsJ+jTtaBvaV7vg9/7B1WrdeC1avEEov/Vbv9U6Cy1avIE4kqdLXvjOSJVOBTbc9dRp7n3qGRQzgVBUwjAmigJMXSeKPGJ8qgtTXHrBJgbaFPq6+pgdn2JuZhaEBqpJJBSEqjAxPsHgyDgbLrhgW8YSB5Kw/1w+ow2Hp10+8dzxkdTJqQWk6RAjUCMfM26wY9M61hSS9yXhyTf6fCXgUBa+l8wYzoXrLtjpNpscP3YMRTeIFZUIkIpGrFoMTszw/PETYKS6Ojoz22sROyOJnRAc/Elc22nXva2iqrtmIj5+3wtDV/31vfuZDUz0fAdLzSZCiVH8GrI+xy1vv4q3X7EeQ4UXXhrjsWeP4AkTVTOI/IBaqYRj2xi2SbmyxMTQMF25dvrzdiIpedKNw4GEkIdad1SLFi1h1KLFW566KjdP+vzbbz/8PN+450GMVA6hSBRiDEKUOCTyPRRNommS2tI8hl9n67o+OpIK/b0DLC2WmJqZwUchQsGwLBTNYGh4mInJSdavu2CvYiJT8Mi5fMYZl18+eGokf3xqgdiyIZbIeFkYXX7hegbanf0p2PeTOmdpuN8wKW3euDJhJ7J9hw+/SBiG2Akb1/fR7CSKYVJp+hx47nlmF8usXTcwYOvM+tDRiKILbCEOv6HCKOQTM8hf2n98uO+v7nyYGVfFyHZQbngQB/i1BSy/xE3X7uTGXVtIqjA85XLf/gMMz9WwkzkMVSeoV8kmNPxamabfwNR1qktVSjPTrMjntWLerltCHktASxi1aNESRi1avLWZjPn0TMivPHRsPPu/vnMPZlsXMSrSq9OeNLh+56WoYZOJ8TF0XQNVgSjCXVxgZecKVmStqS5HnujuWtFVLi0xN19C002CCHTLQTMtxienWCjN09m1YrdMqF0+UVcC8ZqqJtMun3j25LIwwkpALFEiHytucvnGdaxudx7+SQojAAeeFuD39xWc9mzXwPTkJHNzc2imhRv4SE1D0Sw02+Hk4ChDE7MUV/Rt1Sxlqy7FZBoefKM+2wj8t7lI/sJ9h087f3HnPiqag5Yp4MUSGYdQL5MIKnzkhiu54YotmAK/GaAcODnBo88fIzLTWE4a4TexhceN1+7Erc6wVCpjmTamZTM5OUG1XKGro3ttPqlNZ+GO1h3VokVLGLVo8ZZmQvCf9x+b3P7//eW3iBLtaHYKJQowvCp7t23i7Zf1kdISDA8PUq7WMKwkmqKxtDCLJWMu6FvpJDWOZB2l1NnR1bW4UGJ8YgJFt3CDEDQD3TI5PXSGaqNGR0fntnxCP/JaRcGUx78/cHIse2x6EWE4xEKgRD521GTHxnWsLjgPp8RPVhjB8jKfH1FctSI11Ne9alupUmZ8YhwpQUqVWGrEUgXVZHBslGPHj9Ozoj+VSZs9jYgNWXn+xcRYzG9P+XzymcEJ+2v3PM5cqCOtNH4siT0PtzRDMqzx8zdczdsvW08SjgpBcHy8nPr7h55hpikwUnkgojwxxK6L13PDlT10ZNs5c/IUrutiJByCMGZ8dAxFCrq6urZhit4sfK91V7Vo0RJGLVq8pZjzwlvmI/GhCSH+84sTleu+fPsDzAYWyUI3GoJgcZaL+9p531WX0pNQBgtJM1uvNxgZnSBSTNxw+aXfqNboTFv0dmRnbTiStlS3q9jVU6ssMTw6TiKVxYsivAgsJ83I6DhRGJBMp6+yk6b0oqjn1S4nTfh85tmTo84rFSMRLwsj66csjACSkiezcEcmq1V7V/ReR+izMDtHvVJDM2wiIZCaipVIUao0OHzkGKqZymbbstsija7zWWmZgk/Ohtz66NHJjr++dz/jTVCcLELqKFFMWJqhTfH4hXdewTt3rJ3KC74TgTNZY8PDzx1j30vDGJlOIlXiVRfoSkT8/PVvY2VCTq3I6FVixZmcnqbqhRiJDLFQGRodJ2En6OvJr5MS9yfR69WiRUsYtWjR4vxVORR5eEERHzw159701/c8ygtD0ySLK1FVA7c0w6qczY07L+Li/uzDSXjCVhnJZNs2nD47zEypjqLbaGaCcqmE4jdYv3JVT9qUz+uSyWxKmUqnCmvHZ6aYmZtHMRPEUieIIYoFQ2fOAlAoFHenHO2sG9P/apqRxwJ+57lTY9rxyQWEmYBYoIXLFaPLNq1joN157Fz7l86bQIInjYQS9fX07hExLJYWmV1YQDFMdMMmjEE1bKoNl+MnTyFVg7Z8+7YGXFNQz49T9lmXP3/q1Pz6v7zzISYaAi1dQCoaQaNJsDBLXmny4bfv4t2XrzuYFXwviCg0Y9a8MLSQ/fbDT+FqGTTbIY5cwvI077l8M9dt7Dyag29n4fZ8e9u7pqbnGZmYRWomupWk6QWcPH2KfK6g9XemGm7EyqQ4t0b7Fi1atIRRixY/cV5eavn3391/iEdfOIVd6AGpETWWcPwlbrh8C2/b2D+VUbhXI5zWhJxL2cq8oiU3HHjxJXyhoFtJhKKwMDdLyrHoKxYSpuSUIqjls/p8Nt82MDU7zcxCGTOZQkidOFIwVJPB4VEavk+2UNyZSqizXhT3OEIc+HGfeTriE8+dnnSOTy0S6wk0oWKIEN2vcemG1awpJh/9aQsjgBTsUw1KncWOS3Ntadv1PeYXFgiiCISKUFWkqiF1i9Onh6iUa+Tb2vuw1Z2BJO/A0+cy7kQUfWZKiE/ef3h099fv2898qKM6WUIkIgiWK0Wqy0eu28X1l605mlP4toCwKVh/cjbY+rcPPcHgbBXVziAAWVvgyg19vP+Ki+jQlAf6Jb/swAEPeguF4ta5UoWJqVkUwwFFpVZ3mZ+fJZ8trO8u2CONmA0tcdSiRUsYtWjxpmcm4uPzETc/cGiw656nX6AcqyQyOaTXpDE3zt6L1/OOSzeyJq3+2y4hfj8p5P4U7GvC+lQufdn4XFk7MTiMkcqgWTaVaoXqUpnejs58e86cVKAWhFGhPZ9o5NraC8dPnWapWkPVTISqE0kVoWkMjY3hBSE9nV1bLUsu+FHc+ePE0UiTLxw6M87xyXnQbRQkahSiB1W2b1rN6mLqiTeymfm14MDTusFEsZg28vn2tZ7XZHpyiiCGWEpCJJFQl3ftjYwwt1jCTqYHkhl7lSfpc+Nmf0Kor6o5fTaMb52X4sOeED0PvDj84a/c8TCTrkBPF0DVkUGAV5ohG9f4yPVv49qL14xlFb6vS8Y86CvBu+999pR25xPPY+Q6MAwbmhUKusv7d13CpmLyqfUq73xlvADypqmqlp1eOzgyRiMQaHaCII6ZnZ2nVq3Ss2JgayYhJt2YVUnRWlZr0aIljFq0eLOKIvj4QswHDpyZver2x55jqhmhJrP4nke0NMtFq4p86OrLWddu/dE/NuxbroSEKtlUW9fOIydOMF2t48YxqWyO+YVFosCno71rfZstDypSlBUot2Uttb1QyJ8dPEup1kCxLUJFoxELhKYzOTNLpbxEsdi1JZlQpgPI/6gt32NNfuvQ4CgnJheJdRshJFoULAujjWtYXUztf7MII1huyg4EhWLGGOlf0bctCJucPH2SSKholkMsFKJYQeoGQ1OTTMyWiBUjn8+nd5qqeiYD976acRaleF8DNtx3dOTmv3noSaZcAy1bxA0ipIjwl2aw3EU+8o7d7N26rt5l8vkehd+swaVluGb/YH31X971CIGRB8NCRi7+4jjXX3wB12wcoNcUn7XhB31gCcGhNoWvx5b1C1LRsodPniJAAV1DqhqjE5NU6y5r1q7YklQ5+mrn0aJFi5YwatHiJy6KSjHvPD7bfNffPfwEL43PoaULeL6HtzRPlwU//+6rubQ38wU7DI8k5D8166vD5oSjpqTu9Dx/4hTCsFANC003mZwYI+FYrOhuu8CQjEjihoEY6mxz3FxboefY6dPUXB8znaERBKiGSbPR5OzgMM2GS0dHz9akLaf9mK4f1nM04fOfnzsxrJyYLhHqDgoKKj5auCyMBoqpg2+2l7ADTze9aF3OFg93dHXttS2TF186ShiBYdgEAoIY0C1mFpaYmplDCEk2m98R6vRmxY/f4TUdcVtDsOmpofIHv/XQkwyWXHzNwY0EMg4Jq/PkFY8PXruTay/ZQG+Cz3YK/mA6jG5rSLHhxCI3/dn3HmKo1MRMF9A1Fb88xUV9RW7adSlrctoXOuEPftjYQsM3k9l3NbyA06OjKKaNNEyaXsz4+ASOkWBlb36lG9OfkdzVugNbtGgJoxYt3lTMwS3DVX7xu48e4OkTg8h0O24QIL0GsjzP//Xe67jqgu77BgQ//8NEEYAbMaBJ5tK53J7x+RKj09NIxUCqKrEUjE9M0Fns0Ao5O2UhjqlQMuFMKmlv6ezpMU6ePcNCuYKdTBKFEUJR0Y0EZ4ZGmJ0rsWrtqm22QcmHTgd+sKw2F3PLTD286djYDEcn5on0BFJIlDjEDKtsv3A1q4upp96M1YmkIp50YWVOF/eu7u8w1gysHjh86DnmlsrodhIhdPwQjIRDpdFgcHSChaUKfb0rtgqdjB/RlRD/tIo2BZ+sCbY/dXbpI9+49zGOTldRU0UWS3U0ERPXFkiLBj973U6uv+yCepfBF7rhvwIsSfGOafjEn377Ie3AqXHMfAeaZiCaZezmPB+8ZicXrcgdTQvucwQHfoToO6CaIkrn2/eMz0wyMTePaiUQ0iQIYqYnJ7DNlDPQky4hlitorbuwRYuWMGrR4k3BGPz2lMe/v+/ZY8odTz6HTOaRuoVXq1GdGuGDe3fywbdtfPgCwbU/7ji24HAK9oUaXbqT2/bCiy9RawSg6QjNYHFpiUq5xMreVamsJedlRMMQ0ZClyqO5nN2TybZljx47TrPpYtkOrhciVROpGQyOjTE/X2b1QP8W06DsQc8rjci24PCckL/8xEtnnBMzS8SGA0KiEaKHFXZsXMNA+5tTGMGyKEjAwTb4WiJnr+vq6tl05swgiwslFFVDajoBEqHpeEHI2ZExpmfKpHNdOzIZxfeg140ZsAWH5+CWRbixDNfsPz73/q/e8Qhn5uv4ZoZyM8QxDVS/hh1U+Nlrr+Cdl11Qb1P4Wh/8u1niW8uIa+bhQ998+KUVf//oAcxCNyg6ahzgLUzw/qu2cu3WdfSa/D9FwZ/+uHmlYB+2XBcr2qbBsXEqdRehWSiqQa1eY252hp6u3oG2jF5q+Ru1aNESRi1avGkqRfNw8/2Hzvb93cNPUpEJItVCBCFLU2Ns6snzqZ9/J0XJl15tllk9YGsua6ZSybauA88fAcUg1nR0O8nQ6BiNZoOB3r6BnMFB/EhaijxqwqmuNsfo6lzRN3jmDHOLZZx0jiAWSMNCMxOcOHWKSqXCwED/JktntgEbU7BvMubTs/Xg/S+NzXB0coHQtBEoqAToQY3LNq5mbXvq4TdTj9GPIgffdnLOussuumhTbanM8RPHUVQV1bCXzSAViTQshiZmePzZ58i19W1o67BXxmA2BeuqETtK8M59x+e3/6+/v4/BcoCSaqfuR6gCFL+J0VziI9dfxQ1XXDDfpfB7vfCZGfyPhyiZBbjprgNnLvnKHftQ8iswnSxKGFCfHeeSgU5+dvel9Dnqn/dIfvPVzKcG2wrtmbwXiMLZoVF8RceXAlU3qNRrlEolip3dWzVbGXADd1VSUVvN2C1atIRRixY/HWbg44tw4+HRpb1/dccjLAYqdrYd3wvxFmdYmbX49K0fojel3OmE4YEftYT2TyoFkn1eRHc2k94ZoSpnhkcIpIZq2yiayfDwMCnboqezsC2hy4NxGJtKLGqGZCiXsQvZbKFjbHKKucUymmkSRhAKidR0RoaHqFQbdPes2JI0xVgDNiJgthntPXh6mOPTS0RGAsSyMDKCKts3rmZ14c3XY/SjiCKsNot7161duTOZytpTkxNUaw0MwyKIIyJVJVYNvFBy6MUjCJnO5wvZLYHK+nLEVY+/NJH/yvcfZKwaoSTbqHgRmgQ9dlGbJW5+5y5u2LG2XlT5ohr5JUcoTy8hr60irnjqzMzev33oaRalA1YKEYcIt8LKlMbNe3dyYUfysbUq73u1c/HjsFMRstLR2X5pveErg+NToOqoukUQxUzPzGCbOqtWtK9J6OrBN4OlQosWLWHUosW/UhbhPScWvF/6xn37OTwyj53thkAQlBdJBTV+6QPvZMfq9DeycEdBytdkMJiSPBIqpPp6O3dWqk1ODI/gC2U5KiKGM2fP0F7spKPgFDUp5kTshZoUMwqiWmhzUoX2jsLExBiLpRKmnaDRDNDMBGEsGRmbwPWbdHV3bXEMOeVBTzWSGw6dnuDMQo1YX/bOIXQxwhqXru9ndTF99K2yXGPL5aU1qeKuWdkWtrd1rJ2bnGZyehJF15GGCYqBYWcIY53nXjxGI1AxC+2p4cWQv7n3Ic6WPBLtK0C1UESEEtUJ5sf54N7LeO+uDbRrfNUI/ZFORfvDObilgdjw0oz7kW898jRHphfRckVUQ6c2N0mHHvPB3Zew64LOgxdqXP6a5iLkYS8Me1QpS2vWdHXOzdec0eFJVN1C1RI0g5ipqWnSpqF1FHKdUsVLwMHW3dmiRUsYtWjxE2UKPjlWj3/n7x99Vrn/mZdIdw0AGlGtQjJq8P7d23nbllXzbTpfL/Lje0l+FGnJ/ZGG42TyOyuNJnOlpeV+Fd2g2WwwNTVFz4oV2XRSz5lSOa0SL6gxJVuKI+m0tdIynfzc3BxzC4uYTooIiWYk8IKQsfFR3MCnvbNrkzRkz5KPcfjsNKdnlpa360sFJfIwgxqXbVjFmmL6+bdaH4sDT7sw0FFI1NtyxbW+5zGzOI8bBCBNkDo+GrFmMDYzx/B0iWePn2SsVMPMdFBzfUQUEjcruPMj3LT3cj507cUUVb5qw5FOqfzBbBzd6gnRN1Lj/77rmZd48uQovpkEVcetlsgpAe+4dBPvumT1VKfOH5yLaElIeSiIw7wQMspm27ecHRxmerGCME1U3aLRqLMwN01noS2fTyeivOSbrTu0RYuWMGrR4ifKGPzOHU8fXfs3Dz6Nnu9B1RMEjSqyMsO1l6znpqu3zncl+Hwn/OHrGScN95PULk1n8mtnZ6eZmFlA0U3sRJKpqWkqS2X6evuzhio6DUUMdgnx3xoxmyzJifZ8quAk0h1zCyUm5haxUxnCMEYzTEr1BoMT06CZmNl2IzTh2MgiZ6dLCNVc9jHyPeywzuUbBlhfTN/zVugx+ieVN9gXQqaQN8udxc5NDbfB6MgIoBCiEGoGbiyIFI2JuXmWvBDdSRMKDVURNJdmoTLDz169nfft2ka/Jb7gwIEifHEWbnWFWDla47cefnGQe58+TGCnQNUgchHVea6/dDPvuXIjnQZ/2Q2/e67zSEh5KBIkkkmlZiazWw6dPEPV9dFtnYRjMzs7i+f59BQ716uOWsjQ2sLfokVLGLVo8RPiDPzVvqNj7//G3ftomHkizSYOAqgtculAO+/bs51VWe0L3fC58zGeCwP5lF4ONWv9qeFx3FgidBNpmszMLVCr1+gsdGTzCWWkEbFRE8wWBV/0FToL7cmMlch0jE/PMjE1g+OkiYRCoBqEmsHg6ASetEDPMTpbYmR6cXnnk5Qo4SsVo9WsL6buT/HTCZE9D5WjA35EMZVUF7KZ3Bakwtj0HGXXA8shUFWEqqFYFrppARLiEK+0gOmXuWnPDj7wtm0MOOKP+uDTCTg0HcW31YXYMlqL/8ODL5zkwedPMR9rYCXx/CZBdYFt6/q48cpLWO3I2+2IF16vS7UNh0PIFAqO6kp77anhEYRugKqiGibTMzNEUUBPd/f2WCeTaZk/tmjREkYtWryRTHp8elrwiaEyH/6Tb36PmUBFSxeJogh3cZb1nWl+du8OLuxOfWOl5BPna1wXBgIoWMnUVleajM6UWGwESDNJqOoMj0zgN10ymeKWjKOUNcl0PQq3qEIsKEJU8m2JzrZsMTs6OsbUzDyYJmoyjSdU6kHE1HyJhUqNydklKm6M1EwkCkroYoQNLr1gDWuKzsE03P9WvXaO4EAQxYWEo8v2zu6187Umk6UybhQjVZOmH6CqOhKF0HUJ62XsoMbP7NrOTVdtpNfmTxJwqOFHG6uIHb4iOkfq/If7Dp3kgUMnGW3GKJk2qn5I4DVZWUzx4XfvpT8pyUru6RGvbhfaP1s5gkMuDOSKuT0L5SpnJyaJdBPVMGm4PiPjkzjJJJ2d2Q2hJPVWrPK1aPHTRLZOQYsWr46ZKP54oJMfr3Pz3z/8NCNLHqqdJYoipNegYEVce9mFbOzLPZZRzu8yRhDHOQGBZeHn83liAagazUjgqwlItfPY0TN866HHeXZo8ca5gI+EUknGCE2Jo3JWcPuOtemDv3jDXnoyGo3FadxaGc0wURNZ6sLk6OAEkwtVIqEjhPKDn1gqIBRiUN/q17Bdii9ZkmP5FPXLd1xMvi1J4Dfw/DqmriHiEHyXuLJIwq3w4euu4n1XXkCHyVdXwq8V4CtuJPtdhZVnK/yXe545xkOHTjLpQZRIU48VfASxVEinsiQToEj8OEY7n/Poht8taNz3riu2sKqQplmao9l0MTN5KsLirief58njo6kluG4ObmndvS1atCpGLVqcV+aIbwmEyE24fPaOJ49p33/8ObR0kViqSN9FqS/wzu0X8o7LLiwXdL5ShC+ez/FnhfhYBXYdHl5qv//pF5iuh4RCI5IakVDRbRuha4xMTTA1O0sile3K5hM9ACqipAjKMqLR0WaUu3tW9p8+e5pqw0XoGkIz8cIYFBVFM4kiFVXRkQJE6KIHdS7ZMMC69sSb1uDx1TIZhJ9uSrlupsnFJycXOTo6QdUHpIYBJJSYYGmWVFjhlqt38O5LV9W7bb6wUvBrsGzk2VRZ98Jk8Cvff/olHj1yhplAIbbTuEIhUiRSkSQsk0a5jBoqdKbSiq2KSEiiH5VTdy5EAttJaIaTzA0cfvEYdV9gJNJoVoLZ+UWWSiXaC4WufNKK8oJvte7iFi1awqhFi/PGEuLaRbjx8aNjq7/xwGNUMdDtNEocEy3NsmNdLzddfRl9Sfn/nq++olcYgj9eirnu4OmZ1d958HFeGp1HS2bxwhhBTBSHICKQEk3XmSuVODs8ClIvdHfnOk3BmSjG0QTTumAsm9GdvpUDXaeHBpmaW8BMJAlQqDd9NMMmikBTVAQxImyihjUu3TDA+sJbXxjVpdw6G/KxF4Zn7e8/9ixjC3UU20E3DGwpCEvTaPUFPrj3cm7cuW6qy+L3VT8u1aXYMi/4UBn2PHZ8/vrv7DvAgdPjeFYKJZGmGQTUaxWIfBzbQsQx9VqN6YlJtDhi9cpCURPMZeGO8zWXBBz0YnrSaXu9qtupF0+cJZQasdQRms7MzAzVcpmLNgxsCASFjGg1Y7do0RJGLVqcB6bhtjmPn39hbGnH3z20n5GlJkYyhyYkUX2JXkfjQ2+/is1d9u/0wG+fr3FnQvfjs0K9dVFw48Gzi31fu+NhTs9Wie0sQtWRIqReW8RtlNGVGF1ViYkx7RRzpTInh0ZYaggn1da+wzFFwxYcltAQEUEurdHR3dd15uwZZhfLmIkkqmnS8ANAEIYhcewvR4JEDTb2dbKhK334fL7Yf5LMxHx8Fm6dgV9+bqTU/vePHODsfB1XWphOBl0Iouo8Sm2OD+3Zxvuv3DTVbvKlbvivDUVsCAWZ0ZDfevDIRM/X73+MobKLTObxhMRr1JF+A1t4CK9G6PuoiopiOPhRxPTUJIqqK52duc2+oJg5j7vFkoL9KMhsOn9d3Q05dXYE1U5h2gnCWDAyOorveqxds2Iglhhv1eb5Fi1awqhFizcRZbhmqBp/5G8e2M+BU6OY2XaEqhJUS6iNRT78zt3surDjq4kwPpSQ4tD5GndBqh+oCHa/NO2t//Pv3s9I2cfIFtEtG9+tUZke5tKNa7jxmt00lmaZn5pc3kmmaCTSWXxUXjp5mrPDo2TbOvpzGTOhQEUXTERgpVNasaNrpX3y9ClqjSaRoiJVHc/zEFLBsgxk6KILn4vW97O23RmL4shKiPM3x58UC4IPVAS7nxtZWvvVu/dxcqaMli5iWA5qGOFXFmhOD3LtJeu5+e2XUzT5UxlHjYoQu2uw7USF//CtfYf47v4D1PUUWipHJFW8eoWwMs+2NSu45Ya9rMilGT57mlqtTirbhqLrlGtVzpw5i26YSnd3fn0M2vkUKEl4UjWpGk7+usHRMWaXqgjdQNUNVMPgzJmzJJNpe2V3ThXgt8JmW7RoCaMWLc6ZSfj0cI3f//4Tz7PvpbOEVhrFMNEiF9Ut8Y7LNvP+3ZsOZgT3FKX40/M17stRI+87Mutv/4s7HuGliRJKqoBQDYKgir80xds2r+YXbriSi9o1Nq9eSdBoUi7N43keUreIVRstkWFqboknnn2OWLP7cp1tO6WCI6Ehwc1m9J6u9iITE+NUak1UyyISGmEMhqYjIp+gUWFFMcvq3vx6XYixzFvMH2c45g8XBDc9cWpuw9888CSn5l1w2kgkMoRNF9WrYtbn+Zndl/Kh6y6nYPINBSq+EJ0lePfhKe/qv7j3Me545kUSXf2Emonr+YT1Mo5wuXbrWm688mI2FcT8hd2pIGmljMnxMUq1KrplEQtJM4wYHB4jQjM62tv2eNCblefPLDMJT0pH3WqaifVnR0aoNV00O4GiGXhIXjp2lL7+/r5cxsrGMUZCtJyxW7RoCaMWLV4js3DrjM/HH3j+dMf3Hn+Whp7CTKUJmw3chSkuW9fLR2/cQ1HlT7vg98/n2KPwuSPTzd1/dedDvDgyh5XvRjEs/EYFrzTJnovWcesNu+g3eDgBR3Ma4+sGuvstw2RiYoq5hQUUzcJOZlAMGzeMef7IS0zNLdHW3tNjJJT1UlDXYbqYsxPZXLt2dmSM2fklTCcFUiGOYjRNJQqaLC3OYykmhUJ6uyfp9eO4IyHEm/7lOgWfLAlueOLkzIZv3vc4R8dKqKkiqulA4BFWFkgEZd6353Ju3H1BPaPxcAzaUsw7Jutc9dDzQ/mv3fUoJ6crmMUeAhTUKMZbWsSJGrzjsk3ceMUmVifFnTn4dhKe6O1Mp2w71XXy7FkWSgskM1kUzaLS9Dh1ehAFQUdHcWukU/BCehLy/IiUQJDLZFNrwljkRyYm8CJJpOhIVaHpe0xNjjPQ39/fZqsn3sq2Cy1atIRRixY/BSZiPjMb8bH9xye33P7YQcZrPlaujcB1icrzrMyY/Py7rmFNzvzzPvj0eRsXPjMW8zuHx8t7//Rbd3JqpoKV7SRCIj0X3V1ie3+Rm6/byRpH/UYSnuiH2+IoMJJSPt9VyA4UcrlUvVKmVC5TqzVQdBMzkUIzEwxNznDk1Bki1cZ2nLyqyoIlGcxmrbyTKjA5O0upUsO0HWIhiBFomsrs3BzTs7PEQqOzPbfV1MSZZsh6R/L0m/UajsZ8bjbiY0+fXdjw9bv3c3q2gZHrRtFtRBjg1+ZIRBXeu/tSrr1sgLzCXSGk5kP2vjRedr677xD3HTxKJTKwcx3EQuDVKyi1JfozBu/eeRFvv3gNfSZfShPf34H47ynYF4HV2ZHOpFLpnjOnT1EuV9HMBJGwiIS67LotFdoK7dsNg1IQUjgf4siBA6FKti2f3VOrVTg1Nk2kaaiaQkhMpdakVquzasWKnaqOm4T9rTu9RYuWMGrR4p9lPOA3GgobDwyX937roSc4NV9BTWaJ4hi/usiKpMHPvWMP2wcKD6cFDzpw4HyMOw23LcE7nh8q7/0ff/M9JuoRvu6g6xZa7BOUZnjb5rXctGc769uM2zNwVwf8MUBCyIMpeESTzGazTteaVQM9zUaT+fl5Gg2XUAgiKTGdNPPVOi+dOMXU9ByqZuI4qbyt46fbLCWRbGdydppyvUYsVIRUQKiomk6lVmN8fIyE6ZDLZXZYOmcaQXhBUson32zXcBpuG3ej33jyxHj7V+/ax+Cih0y3o1hJAs8jbJRIqR7vuHIb11+xhqRkrB6xdbJC/8OHTvLdfQc4PD6PTBbQ7SSKlAS1JSgvsLk7z/t2X8LujT3zK3S+sOyE/b/7rhx4OgajWEh3ZLO5rjNDoyyUq+hOHqEauL7H2eFhVN2kvb1ti60zkjlPy5Mp2CcMGVlOes9cpcr03AIhoBkWPoLxsXF0IenuLG4XGr4bM2CLVs9RixYtYdSixY9gFm6tCba9ONX88PeePMTzw9No2SKxotMolyiYgg/s2cHuzSsG2wV/dj79ioY8/sehofJVf/vgU5yaqyLTBQzbAbeJg8tVG1byrss2s67duHOd4D0/zBOnHjY2W4p6wlIJ+jo61ju6xuzMDPML80jdoBHFKIaD0G2GJucZGpsliCSxtJWko9GWN5Z3tc3PUa656LqNHwoUzUQKSbVaZ3JiDF0xaC/mt9u6PNwM/TWOVA68Wa7hFHxyOuAT+46NdXz9/icZq0niVBuKnabpuYiwRsoIuP6qbVy7YxUqMLXopl4cmlO+v/9ZHnjhJIvCQibzqJaN7zZwF2dwwjp7Nq3mvVdu47KB7O15wd92C/7rj6reBCLOtbdlCqlsW8f41CwzCxXQDaRp4scwOjKMoqoUC4XtnmRdTvLt8zF/D3pTKbOUyrVtHRwdYb5aRzEdpGLgNX3KczMkLNvI5bObDY2hFDzSuvNbtGgJoxYt/glzxLc0EJuGa/zKtx58kkdfPIOW68CLBH6zihnU2LvtQt69/QK6NX7/9YbDvsJkHH96Uoj/+4kTM3u+/dDTnF6oo6TyoBrI2EdrlNg20MX7rrqEdW3636UF9zvih1epbKkddhAH8lJ8E01kervyqRVdKwpRFDA/P0u92URqBkIx0O0U9SDi1OlBZhYXaboxdjJLe7eNbueZnl2k0nCXc9WiGITAsm2WlipMz85gWQkKhcxFmqrMvFm28U/BJ2djbn3o8NCFf3nXPsZqoGaLxFoCL4bQr5HUIq7ddRlbN3bRdGF4qsJ9jz/Lfc88z0i5iZIpoFgOQeATNiuIyizrOtJcv30LN+zYxIXt+uedkAMdkv/+4z5LErFfCKK2QrJXM9MdQ6Nj+FGM0HQUw8T1XManJpFS0tnRvgkV43zEd9hwuAEbkkndMZ1sz6nBEapegG45aKqG57kslkq0F9qdfNaMIkHifFU9W7RoCaMWLf4FMR2JX51y+cT3njjK/c+eILSySNUk8Ou4i5O8fds63rdrGxc48lOd8AfnY8zxiN+YcMVnHzs+vuW7+w9xcqFOaKdRrAS+W0HWF7lyw0pu2LGZTUXzj1ZJ/s2PEkX/JxnBvVLSSCT0njV93V2FjMXizCQz84uEsUBTdaRuEBsWU5Uap0fHma3UcX2N3r4c+fZeKvU6C0slFE0jCEOkVJC6QbXRZHh8BNO2ta7ObHcA+XroXZSUyk9tWe0M/NV4yP99/wvDHX95zz5mfB2nYwWhNAmQRHFAwpRccckW+nsLjE3VeOrQae575iVOzCzh21nMTI5m4OM1KzTmJ8gJlxt2bODGyy/istUdJ4s6X+2V/MdX2xOUgIMe9LYXkmuyqbxz5sxp5koVNMPESKaoNFxODY2AZtDZ2XZVpJyf4Nck7PehK5t31kRSTx05cZxINZCWhRcJyvU61VqFYrGjP59Qx9+q/lQtWrSEUYsWbxDj8BsVwZUPHhrq+e4jB3G1JKG27GBMfZENXWl+5urL2NCeuL0P/t35GHMi5jOzIR978sRYxx1PHmK0GuKbDoppEXp1ZKPE9rUreO/Oi9nSYf/JSvjkax0jAYdCJUxmdHmwsz1bHOjvyxMJFubmiIOASIA0LFQ7STWImS9VGJ+colQOUK0kRsJhZnGJuuuhqhpCqghFRbcsSqUlRkbHSKcyTq4tvU2VykIgokKCn+xutemA22YlHxt1+ej3nz7O3z78FFU1hZJqI9QSxFLDDwMCQnK5DIYmGRuf5YWjpzg1PoMrLVQnSywloe8S1yoYzTKXr1vJz739St62oZ/+lPF3GxSxKyNfu2hJw4OxQLOdxN50Os3Y9AwL5QqqaaGZNg0vZGR0FFUx6O3Jr0Qsb79/veclBft8QVeyLb+z3vR46dQZ9ISD0C2iWDI/N4OmKHQVi9tinUKGljN2ixYtYdSiBcueQSW44cmh0lV/fe8+Fn0NPZ3Dj2Ia5Tku6Ejx4Xfs4pK+7MMp4keTiNe9m2cabluKecfTp6cu+f6TzzNcdiGRJlY1IreG0iixe+MqPnj15Qxk1IdT8OirrRT90+qBfNIj6jWEGCok9MGVK7q2bly9Er9WYXZyilrDxY8EppMlFCp1N2Z8rsz4bIlyw6PS8JGKBiIm8D2kgCiOMJ005VqNM2cH0VRd61/RZpmIsz9pd+XxgN8cKnPzfYdO870nDjEfastLoNLADUOkphGrEqEKQmBmrsLYzCKNUKAYCXQriVurElfLxAuzXJBLcMt1u3jPjo2sztlHV6jit3qF+I+vt4IjNGS+LbXVsBxjZn6WxcVFVMNCtR2qrs/U9DRCsZzOzuzmQJA/H8tqabjfV9na1dOzfnpukbMj46A5qKaD77tMTU2QSacpFtIDXfL8Wk60aNESRi1avEWZhE+fWGje8NW793F8fAG7rYgfRBA2ScYN3nflxVx5YedYTvDtbsTrzkGbjPj0YsR7nzgxufe7+57hzHwd33RA1Yl9l+bsGFdcsJJbrt9JX4I7c5JvFwWvyzwygTiUgn1Z+J7UMAoprdzfvWJtV0cnS40m85UqXiyRdnI5a8uwaLgB9YZHEIGUEohJJGzqjTqu6xMKgaZbeJ7P4NAgjp3Kd3dlU/WQzc3IX+NI5Q3byj8Xh7csheLa6Vh8YrTG++85+BJ3H3iJupHCyBVxhULD81FNA1XTQcaoqobnB/gBKIaFZpgEUUwURwi/STJ2uXbbJj587ZVcvMI52KnxZ1nB7e3w5fPxmVPwSCzR2jtSm2M0e2R0lLrrE2sGmp2g4QYMjoxArDkdnfkdKMtVn9c7rg9FVSPT1dvfc3pwmJmFGqqZwLRMlspVpiYnWdHTa+sJY7cfuJ1JRW1t42/REkYtWvxrZSzmt0eb/Npf37efg2cmsdo6iYWCWymh1Oa54YqtvHvHOro0vtANv/u6x4Pfrgp2Pn5y5rqv37uPsVpI5OQQukXcbFCZGGbXhlV87L176LeW/XHaEV8+n3NOw4Nt8PXYoLezaGe6Vq7I+kJnZG6BBhAgEIYOMYRxhBQSVVGIopggDJZFkoAIgaobJBJJfD/ixRdfxDCdrq7etl4plUYFdjVg4/lYFvrflbbotgpilyvk6qoUO4/ONd/7rUefZd/xIQInT2QliVWNIIqIoxAFSRxH+IGPFAJd15Gagh/6ywG8YZOgUWdlR4Zb3rOHqy8q0G3yQlHyp53wB+c7PuNln6NEV0duXcrJOMeOn6DmRSimg2I7VJo+g+NjqLqpdHXnNjdiNuYE33k9Y75iH2AYoqetrbPjxeNnqLsegVAwk0nmK1VGxye48IJ1/RlbPdvqN2rxrx21dQpa/GtlFm5dguvueeoIB44PEhopbMumMj+P6lXYub6P9165iV6Dz3bB772esaYC75OeqvcsxVx7cGhpy1fveZSpeoSeKRCEAuHW0Ztl9l68nl95/246NP68H34JxBs2f0MwJKHRkYa+FV0kR2fwPIgUDSElQpGIKEIVIKIQiIiiCMvQ8CV4QUTDjyAWWHYO3/X4yh0PEahqx86tAx9JqZRlRL0q2SFifFNwSoNpAQFABFYEloSGjGmwfChVSIIY1Bi0EFIRWCGkfCgGyLwLK+vQf2aiwb1PPc+BUxPEqTxaKoff8GhUaqiqiqEqCAExYKkaCEkURfhBgJSCMPRREAhVEgTe//62KCm/kb93PfCbqsLCdRf1figO37bjL+99jFplASWdx8gWWFqY4buPPwtRmH/H9rUfMQSDPfCbr2fMInwRARf3pX/9pj07+r/z2LNUQpdIOmipAoeHBvnq3Y/yf71798dNm5Pna3NBixYtYdSixVuESS/6dEmR73rs+NSOhw+dpCYcEk6aemkRK6izupjh/VdspdfiT16vKAIIVD03G3Hr88OL+W/c+wSjDVCcLH4k0EKf+twE77hsMx951yV+l+TzZhSdQso3bP4T8JkluHa0Em14/MQYDx06SdlVUAyHmBjiCEWRiFiBKCKMQuLQRSoQBj5CShRFRVUVSpUKoWWQ7eglqDh88+HnOT1XJ2VaqaQuU70d7TcVMgmSlkABDAVUCarKvBQ0FCgL8OMYLYxIuR49Qll+OoUxNH0o16FUc6l4HnNLFc6OTzM0s8j4YoUomcNIpJlfKoNQsCwLXdUIIx/P8wh8D0VR0AyTOI6XK0VRgCkFuqbjuzHzlQZ/+tVvsHfrBm68fMtVsYnmKxTPR5Xwh9EB/12A//Zt/fhhuOObD+5ncT5AT7ehJTPMl+b5/lPPoxk612xc+V9iDc0iPtqG+NrrEUeuoH/vlhW/Xq6UuPOpI/hSEmg2ye6VPPD8KQrZAre8bcNnFY1KO3yp9aRo0RJGLVr8K6GhyA3Hpmt77n36MONlD7vQSRyHSK9JR0LlfW/bztbe3JdWCn7t9Y41DbdVYceLY+X8V+96mNFqhJHtwPd9lMBHa5Z5365Lef+Vm+iSfL4HfvONFEXD8IezIR89PVtO3f3U8zx1YhQl2U7CtAlERK1eJZIC00oiVIVGw4PIw5Y+vttAkQoxClIaoFpkMmlqtRrVUMFOt9GomOw7Oga+i1sro8YBScsg4yQo5rOkHR1dVTFNK28YBqpUiOOYOAwI4gg/9PD8kFqjyVKtTqXqstRwqTY8mhHUvRA9kURLppHpDqSiUm96yChEUwS4NZRIJ3TraHGMrWn4UQC+wDBMNGJc30eGAUEcYhgWmmoQBEnuP/ACzUqZvRdv3rGhO12MVdTXW635cULFC+i5dtvqlQ230fG1ex7DExFKIo+dzrNUXeSuJ19Al4KrNvR9tqiJP4GINuQ5i6NewX+IDdQ9F6391MziEvuODWG2J/FjFSvfxZ2PPUtfPp2/dkv3rVKh3gZfaz0tWrSEUYsW/8IZ9KP/OdaIPvrA88c4Mj5PaKQJYpXYbSCaNfbsvJgda7oOJiWPvd6xZuHWClz5/Hj1uq/fs5/JGqipAqGQqHGA1lxi96bVvPeKTfTZ/JERBUPIN+62HIXPDdX41KGxKb73+AFGSk2UbBeR1IgbNYTX5KKBPkwnyQsnh5FGAhF5aLHPuo4s3W0rWZydY2p6nrlaHVdUiHSbtOPguQHVSJJIt+E2akSBj57KEQUB9RhqQcjwSJnYbxITEYQRaAqxiF9u7o7wfReJghACEUusRAIhVfw4gZHuREiJiQKKJJSCWAqCRm35XEYBQa2EoWnQWMQKPVb29tDRs4K5epNjw1MEfkzse3Q4Fqu7ehgaGqLuN9GNJA0rjWY6PH5inNnFOtftuKj/koHifwkM8it5/QL5h7FC5T8pUL7xik2/KoTo+drdj+CFEXqmAzNdZGphlu8/dhhDtbl8XeEjiipf9zKfQTS0Km/cee0lG941NTfPsblJrFwn0kgQWh5/88Bj9K/80A4jx2BLGLX410ir+brFvyqm4ba5WHzkwUOnsnc/ewzXzKDYSSLfg1qJHet6+MBV2+hPyP+nIPircx7H92+rK8rWBfjgwZHye7/1wBMcm66gpAsEQhB5Dcygxq6NA7zvyosZSPJHdhgeLijqV94wQQj/80yp8am7Dx7jO/ueYUkYxHaKIJIEtQqJsMGuzeu5ZvuFtKVSHDt5BhBEYYQWNtmxfiVXX7yKC3t66C9kSRkSv14mCprEQYCm6tQajWWvI83EFxI/lkjdJhAqodSwM1lUK4mwEujpPMJOE9sOJFPEpoXqZLDSWaxMDiuVQbEShJqNMJOEioVqJokUnRBJEEZEvktCiQgrCzh4XLpuFVv6u1hTSLNz4yp2br2QNSvTVKsup0cmUFQd2WzQ35bhhqvWs6q9g9LsFFPj40RIjEQSRTeZWyxzemiIhheSSDjbRUJfF0A+Aefdo8mNw5W2lEeSqdR12WyGwcEx6s2AQBpouo3nhYxNjKFpptHWlt4SKVivJ8bDQTwdQMFJWr2qbhXGpmdpeCFS1VB0nVKpTKm0QG9n5ybNVs+L4WSLFi1h1KLFm5BZuHUx5sZHT8xsv/3JQ8y6KoqdRioqlbkJehOSj95wDVsK+n/p4MfHPfxzlBXlmnn40KHR2u7vPHaQw2PzKOl2MAx0ESDri1y+dgXXb9/E6qx6+4Dg1oSUh96IeU/EfGZc8BvH5rwPfu2+J3noxbO42rIg9FwPb2mOFWmT9++8iD2bB1iRBQLJk8+9QCxVZCwIqyU2dGTYsbqdToOp9e2JA/0dHf0rO7L0dxch9BkZHca2Lfw4JiBCSBVN0wmCAKIIQxVUKwuEkYcf+fieD1JBaAaRFAihoGkSJQ5pVsv4vksYhvhhgB/FGLoJSCCEOECEHlpQR1Tn6U2qvPuKi9l1YT/bV+W5sCvPpp7M0XZHuESkjp8Z5tTYNEgFK/YYyDvsWt/BhoI231vosKulOaamp3HDANW0iRWdug+nh0aoNT2cdNsmI6kNuNCfhvvP5/WxhTychCdNUy11dxZWqZqZPz04jBtpoJkITaNSbzA6PobtOEZbPr0xlGRej8+RA08LSZDMZt7hNgNlbGIKPxJI3UboOqPj46gypqe3a4eq4CahtYW/RUsYtWjxL4mZmI9XYedLE7Wf/dZjz3N20UNP5wGBEjQxvDK3XLuTK9bmH07C/h8W0PqqhQh8ZiHmpoODpe3f2/cMR8ZmMXJF0EzioElcnWX72h7eedlFrG0zX8iEwT1JRZ73F89MEHx8QcoPjDf5rX1HRwduf+IFDo/NQaKA1C38Zg3RLLO6kOY9V2zjqgu66La43YBJN6T/mSMnaIQSqWhEzSq9aY2t/b10a/y+BUczujjYk02MrSimurqKXXZpcZHBoSE0yyJEEIYAktDzEcCKziIb160iZYElIyxdgzim4Ye4fkgUBxD66JFHR8Ymn7Lo6+3BSiZZLFdoNgJiAY1GDRm6mPjIWoksdT6w9wp2b+xmZVLemVe5q10X30xIDmowW3LZ/tTzRxhfqi/PpV7mghVFtq1sJ6dwV0dSPdVd7FiPIhkaHaHe8JCqidQspG4yNjbJ2OQUAUYhm0vv1FRmm3G4zhbyvG7ld+DpSODk29r26rrN0PgUDS9AajqoKtVGlbHJKWKp2Nlc/ipUnLQ4d5GWgIO+QjGTzW+fXVhkfHYBxUggdZNICuYX53Esi2w2vVdRRfV82i60aNESRi1a/BSZjrhtMeZ9w+Xopu89dZgDg/PgZJFSINwqVOd5z+UX8f7L1xwtCP6yHf7XuY41CZ9eiPnZ54fL2779yNMcn1okMpOYTgIlCgiXZrh0ZZEbr9zGpqJ1X0Zwb7ciP3e+5zwBn6lIeeWR6covfeeJQzx8+AyTrkqcyBJJBYIG7uwoF/UV+cDuy7i0v83v0vhDA4ZUWHBh55MvDjFTbSJVHb9ZpStlsXV1P+063+yAP07Dg0FMXoPZjC2izs6ennKlzPjkLKpmIRSDWqNBHEUQeegStq5bxZ5NRS5b38um9b1MTy8wsTCPNPXlBuygzhWbVnPNZZvZduFKertyDI/NMbNYJhY6iqZD5GFID625RDqu8jNX72DXhb106fyJHQdHVgj5Gw483YjZEAgKM3V27H/hOKUQhGYQBy6bBvq4aEV2Pi2534w5k3W0s21tbduSToLxsXEarg+KQRirmLbD5NwCQxOTRFIlkcm+yzAUN4TU6xHQP4ykYH+sYbS156/SNJPBkSGqzTqGbSIti9lymcGxCTTDorM9d2mokHo9FawgjnK2rczZdmrbxNwi5aZHKAWKYbBQqTK/tERbKklHW5IQUq2w2RYtYdSixb8ASoJ3TwV89M6njrDvpdM09SRSt1Ajj2BphktWdfDBvZex0uD/64D/37lWZ5akvHY+5sMHzy5uvX3/Ac4s1IjsDEJViQKXuDrHzvV9fPBtl7G+zbgzA/d2cX5jGGbj6NY5IX5hNuZjzw5Ob7/rwAs8fWqcsrQQiSw110X6dYLFKa68oJ/3vW0723ozT2UFd5hxfEqJqSAEvkrvsyem8tOVGqpt06zXKDo6m/p7KdjKE68srSQEBzOCuwAlYUtnRdeK/qVyjemZOYSqoZsmsQBVUSiXF5mdHGWgo43VHQaKDk8/f4qyB9Kw8aOYoFlhoJjiovWdZC04fHycp184hhsrJFJZwqCJITw0t0LKX+J9uy9h78Vradf58yTsLwr5xR9URASHSnDDaCnY/tSRU8z7AZFc7u+6autGNhSsw8mI/Z2SP8zCHZjKQFdH25bO9i6mpqeZnp5H000ioWGm0lSbPqeHhilXK+iWsymbtvCg+3xXUtLwoNCQTjqz27QMhkaHWKrV0ZwUaiJJpeFxZmgIx3KU7s5sbywwznWpyxbisBdGvcmMZWtWqv/0yAhLjSaqnSAQCqVyGa9WJZ/LDbSlzIUwJpMQ51cMtmjREkYtWvwEmYj5zFTIp/a/NGzf+cwhFiIVw8kQ+R6iuchAe4pfvH4Pq9LKnSsFnzjXcSpSXjkT8vFnBxcu/M5jz3B0qkTk5PGQaMR4izNs6+/g5muv4MK08vlV8G8cOK+RGbNhfGspku+chY/uPzrq3H3gJV4aXyBMZJF2kqYfoIcuenWKt13Yx89dt4sLC9Y3rDg+sVKITzpCHEgIcbAOm33oeHFkbuD0xDToFr7bIK0LLlzZQ0/aeOL/bP5NwEERESYN6XZ1dm6anBpnan6eWDMJhSRWdYSqsDA/z/jYGOn2PuyMypPPDTJVbqIYDkJVqZfLrO3tor8vz9GzJe5++HHKoYrhpAmjADVsImoL5ESdd126nndt31Tv1vldm/hIAfFPmuVL8M4z8/Xtjx85Rk1V0S0d6ktcsXEtF2Stx3oFn3nl3+bgO0ISFfO21Vvs6VmcW2BmZhqhGYRCRUtmqPkxw1OzzJXKSNVYn8mmNkQSx40ZOJ+CoeL5V2Vt5WA+l9uJIjg7MoKLhjAcYtUgRDIyfBZNNVJdxXyvGzNwLgG3AI4UB1zBqlzB7q02w+zJkXF8oWKkUoQRTE1NEYcxne3FLVlbOXo+MtxatGgJoxYtfgrMwq2zAR87ODzf/80HH2eyGWFlC8SERLUStlfh59+5h4tXOA+vl7z9XMcZh99YgA8+O1La9I379zG42CA0k2i2g1ev0Zwd59LVXXzsfdewKiG+0Q+3ne+5zsEtpVjcMC+56duPvMCdT73AdDMisjL4UUzk+1TmpggWxvjlG6/hZ/dsHew25dcTcLBbiP/6j16UcKAMe07Olre+eHYYdBuEwBIRG1f10Ze1ns+If/oStgWHc5Jvq7bs7ezu2To8Ns7U7DSmncQLA4SioxsGC4sLnDozTGffOibnqyzWPRQrQRDGqEJy4brVuKHGI48/zWytiWJnMEyLqFFD86uY9Xmuv/RC3rN9M12m+EIP4jcTiEM/XCxy67GpyoZnTpzC1w2aTZe0CHnbRRvoTRqHcvzjuI2XIzucXEqrbli3akOz6XHmzBliIRGqjp3KEKs6Y5PTjE9MIVU9lS/krjRVztZh8/mqHqUUZZ8XBT1pQz7V0VXcK6TO0RMnCWKJYidQdYNGo8HY2BiKYuR7VuRzQhA1I9bZ4rXHmKTgkSas6e0rrD8zOmecOD2I6aQwLYcoihmfmMTQdTqKhasMjck3YndeixYtYdSixRvIZMynq4Idp6tc9z+++wBnFl2MXCeRADXySEY1PvS2Hey5sPuFvOSb51q9GfTj/7mgiA88M1bZ8Od3PsxQxUdJ5ZGKjh4GhItTXNpf5N/cuJc1CfGlAbj1DRGAMR87sRRc/5W7HuOuA0dwjTRKIotUJMJr4M2Os7E9xac++B6u39D5pTbB17vhcz+qZ6QG2waXmrsff/5F9FQbCEncqLJ59SoGCvbRLHzvR32eAPIZW53v6e3ZOj89zfzsNFbCwYsFXiSw7AQV1+PFE6M0Y0k9iAiEAKkgpWRxcYnDx05R8mJUO41pOTSWllCaFWxvkfdu38h7d15Ej6V+fgXiP/0z5+ZjRyarA08fPYO0k8gopNsxeduWDXRa8uHMD9mK7sDTUYyT0nmhf2XXblPXmJwYoV6rESJQjASBYrLY8Hhp8CxLTV/JdnXuTGii0Yz8NSmh7Dsf1zUh5KEk7BcKsqu9fbcKjIwO0wwCpGmgmDYVN2B4fAahO/l8R/o6S3LUg55zyXjLwF0+FHv6Vu44eWqYcrWOopt4CJoBjM3OYSUyFAvJSxGQFK1m7BYtYdSixVuCOaJbakJsH2zwi1/+/sMcnS6jpdqIUTBFRFSe5pqL1vL2zRvoNcXvdsAfn8s4M/DxuVj8wuOnZ/q/du+jTHsCPdWGH0REtRpU5rlywyp+6QN76LPFN5JR+GRCyPP6TXsMfns65hP7T05u+cpdD3J4dB4z14ViJPA9j6C8QMItc/Xmdfybd1/L1k7zS/3wS/9c03AZ9gxX/d1PHTmOTGQRQqJ4Hhv6ullTTI7kBd/8kS90ONQg3ODYhtK7ord/bm6eqekZpGkTCZVYSFTDxg/AixXMhEMQxy9HjGhUK3WCWGA6SYgj3EqVBAEJr8x1F1/Ae6+6mH5D/no3/NcfK4ri8NZSJN/97NB0/vDgBKrtEHlNelMWl60foGCKh3/UslBCcKgZBGtNXZ5ZvbJdayu0d81Oz7C0WCISGprpYCSTNKOYk0NnmFlcIJlKr8+nHd+P42JSiPMmGlLwiKpR6uruvMa0TOXE2UGqDQ/dctATSaqNkLMjo+i6pRQ6M7s1wdy5BsEGUEgZTGbae7a/dOI0S9UGdiaPYpiU6w0mJyfpKHQ6HXnDD0Myjmw1Y7doCaMWLd70LCA+MBHwqe8/e5w7n3gOPZnHsCxMIZCNElu7c9x42cVszOufOldRNBLF/206EL/67Mh83599/34mmxHCSiGERHObJOMmu9av4iPX76Db4Ksp2Ncu5HnNnjoT8VfjTf7t3YfPZL98x0PMhBp6togQKiLwkLVFViUtfubKbbzvis1TAw6/tQL+06s59hJcNx8oVz1+6CiRnkQqCqJZY6CYY11Xm1tU+dMf9//dOFxpC+VI0lbrhULPpqWlMlNzc8SKgh8KYqFjGAmiSBKxnIkmpEIQhqhCQ1NVRBxiiAjVq6LXFtl70To+8LatdOn8uQUn/llxJ+Jr5tz45seOnuXM7CKKncBzq6wtZrlk7UryOven4EdWdxJSHszAvT4UO/NOvbu7Z23geYyOjeOHIUiJYhhI02JobIrZhUUUMzGQzqS2eYJeD3oS4vwsOTVCNjgaBwrtbbuFUJTpqWlcNyRCxUikqDY8JienUHWLTCa1LdJE17mIIxsOZ+AuI2vsFlqi/9TwMLGigdQQCCpLZarlMiu6V67NJMRCTvzjpcgWLVrCqEWLNxnTcNtMyK88cWIk+7cPP4VnpXAyOWS47I48kLX5wK5L2dyV+kav4D+eyxjj8BsVIXYdGJzd9OXb72UBHcXOoqgaUb2GVl9g14Vr+NlrLqXP5o/64ZfPV0/GtNu8raqqOydiPnu2FHzwbx95ku8+/jxRqg3MFIpUEW4TyvNs6sjxM1fvYM+FXbcXNb5YhC++2nGqsLMi1D2PHDyCJw2kqhHVqvTmM6zvLeYNXQz+uOUaWyiHE3DIhZVpR21kMoX1M/OzzC8sIjSbWKhIVIIgoul7xFISEyMiiSolse+R0AVKYwmtusDuTat5/xWX0GPxDRsOv5q5VJC7Z91w74OHTzJZd1EsE69e4aKVXWxd1UWbwjdfzXVJwT4PerOOXlu9qme978fMzc9RLi9h2jaxqqGaCWbnS5weGsM0kradTG+3DEqNmI2N0NvoSOV1VVYSkkNuxMqUysNdK9qvCrzYOH1maLnnyHSwkmnmSyWmZ6ZJJCyy2cw2RSFq+OFGR5GveWw/prOtmNnphVI7fmYIoelouoWi60xNTxGFPit7u7ZEGl1h7GdsoRxuPX1atIRRixZvQiZC/vOL05Ud33/iBUYqHnoqh6aZRPUyHUbEjTu3sn2g/ak2ha+/1j6Mudi/ZU6Ij5QQ7z40Wt7+F99/gGlPIp0CjSBCCwKcsMHVm9dy4xUXc0FSfKoHfvu8ib7Ivc3XzOK0x6++MFbe/jePPsNjx4aJk22EioEIIa5WKMqQPRcOcPPVO9jcnfjz1ZKfe61+Ow3YWJG8a//zJ1gKBIpmENRqdOUc1q9oU9os7cFX42mThCf9gGImrYe5bNvaWr3O5PQChuVArNL0A4SQSEWiCIkqBHHoY+ugNJZQa3PsWt/HTVdtZ11a/o4ZhKc7pfzDVzOHClw5UQ/3PnDoOJVYIHSdqF7jsjU9bOppH1stueXVno8k7I/jSHU0caSvp7gznUgoceAyNjlOKBW0RIpIsal5ESeGRqj7PolUZouTUFVQlKw4t6Wtfyw2OezAgVigdXUWr0RoyumREVxUIlVHMROUajXmFhawzQT5tuQ2Tcq5IPALCUV5Tdc/KdiPRHESqT21psvoxBSK5RBJlVBIpqZm0HSD7q7cNkMqI5lWbEiLljBq0eLNxyh8bnDJ+9j3nzzMCyOzaNl2gkgQ1qs4cYP37NjMrgtXzhc1vnguJo5loewpId55cHDhkq/f/SgjZR813YYXCaTnoTYW2XvRBt5z+UWsTos/MsJ4JCHFofMxtxn4eFWoO2c9Pvbo4eH8d/cd5Nj0ElquQKSayCgiKi3QnzZ5/5WXcP0la+qr0vK/nGtVrAnrKpJ3PHNsSJuu+kjNIPIatCUMNq7soOAYT/+4Zah/iCN5OhYYbWmznMm2b5menWdyahahqii6RiwEiqoi4whJiCFjjKgJ5RkuX9PLzddeyaqU/JIdxkeKqvzTVzuHRbhxeKmx88EXTtCQOggVxa1x5foB1ndmjrYLvvzahIk4nIJH/JjiQE96JJNp2+C6LtOzc3hhhKJbaHaSIIbTwyPMzS+Sa+voSybVnCfoOV9RIinYF6uoxe7C7hCdk4PD1DwfI+EQK5JKtcr8YomEmTSK7YmcoSgj55KtloJ9wlZ7nVRu6/TcAmNz82iOg6JZVBtN5hZmyKXzdLcliMFomT+2aAmjFi3eTJUi+MzJOfe3Hj8+yAMHj+PqSbxYQxMxan2Rqy7s4z2XXkiHGnyxWyq/+5qrNXDbPHz4yFh5x7ceeZZjU0sk2rsJYgFek2Tscu2WtVx/yQbWZ5XPm0Fwul1Vvvx65zUdNG+bl+rPVWHn8enKTQ8+f1q7/7kzTNYhthwCIGzUUOpLXNSZ5kO7LuWKte1PdVucc1M5LO9Kq8G2I0Mz2bOzSyi6hYwjbCVm05peiknzaAbuerXHS8ChMCbjmFqq2NHRPz42wlxpCUXXEdqyOBJEGEqM4pWRtTkuX7+CD+y+lIGU8o3lLLnXJjLnYz50Zqa89ZHDx4lUGyKwopBdGwZY0+Y8lhN8+1zOTUbhroYbbMynrWpXsW2trihMTU1SrzeQirEccit0xmfmGJ+ZQZF6NpVO73Ql63Ly3Mb8JxW9MNhganK8o9i2LYoFY+Oj1JsummVh2A4zi4uUSksYupPNpRPrpELjXIRLVvA9LaGt04zEpuGJKRpBTCB1YlWl0fCZm5unq9jd45hqvl3hy60nUYuWMGrR4k3AFHxyqsGnnjkzmbr7mSOUMFDsFJqmEdVKbCgm+NA1O7kgqf56j1Re89LWaMznlgTXHRkrXXX3U4c5NLaATOaJhIqMfKjMs3N9H+/deRFr89qX+uDfJeT52X1WlerOEtzw3Mji7nufeYknjw4zXQc9lSMiInIb6F6FXRtW8XNX72BrT+qr63Te/XqjKiqwuwbbjo3P5o+OzSDNBCKOMQjZtraXrrR15Mdt2f+h4khwCIlMOGquraOj7/TgCJWGizQTxFJi6Apa5EF1lguKad6/6xIuaLcezgjuea0v9bmIW6ohO05OL6197KUzRLqNjAV2HLLrwtX058wHf5gX06uupqjykTbJ17WEVugsFLdn02lKiyXmFxaJpYpmJ1BUjbnFJcYnxomRpNPpTYGpbPSh6/WaezpSHsjCHYHGQEdHYYsQktODZwiimFjTMRNJZuYXmJ1fIJfJOtmc1RFA7lwcsiOBZdr27lCq9unhUULFIFYNggjm5uaJA4/VK7t7hE4m01pSa9ESRi1a/HSZgY8vwo3PDs5svf3xFxgsLfsIhUJQL8/Spnr84vW72dxu375S8MnXevzhmD+sCK46NDJ/1V1PHObw2Bx+IkOgqhA0UJolrrqgn5+75jLWpOUfrYRfO19zG4XPzcEvPHFidtPt+w7y4vA8vpFCTSVpNOs0qiXi8gzvvXwLH756G2sz6udXKudn/CrsqMGlowvV/P4XT6M5KQQSNfTZ0F1goD31/GsVRq+II19QzKYNo6t3Td/Q5CRTlRpaIoHn1hFemZ3r+njfVZewJm2W2zXxZ+cS02ILDs/E/PLzg1N9z54Zw0zl8JsuxYTB2y5aR2dC2f96Alh/UD2Cu2KVTDGXWlnIZJ1mvcrk9NTyLjvVQDF06k2PsakplmpNrGRqg5M0Ek1Ycz4cpCNIpDROFAuFqyzTYnhkWWyqRgLNTjG1uMjY+ASJZK4r32b3+tD1Wse14TCakNlsbq/vxxwfGQXNRHeSSFVnYmwMVdHo627bIBT8Vthsi5YwatHip8hkzKePzjbf+70nX+DFsRJqtp1AKIjYx1sY5YN7d7J3Q+fBvHh1O5D+IUMxf1wTbH9uuLTj+/ue5eTkApGVQbESiDjAW5xi84o2PnLdVfTa4vZUHO5LSHno9c5pFm6divj3I1V+9f5nT+XveuIQZxdqCCdHrOmEoYsI6qhuiZvfvoubrryw3m3whRXi1W3FfzXUYJsL/SOL1b4nj55FdXKAQA1cNvUWGejI/Fgvox9HEvbXYbOSkDsGJ5cYmVsi0gwkIYpX5e1b13PJqozfpYnf64LfO9c5jIX8zoFT46mXxueQdhLhB3SkEly+dgUdjvLAufTd/FBxJLhXU5nOZOxCId/WVylXmJmdIRICoWqgalRcl7HpeWYXl4g12ZfOZba5goEQUudixvgPRYsfRZ0JQ5xNOamdhq5x6uwwkaKiJJJEQmF+qcT4xBR2IpcvtCX6hSB6rRWrpGA/OoZmOldNLiwxvbhEKFQU1aBebzI7M0VbNmO0FZI9sUA733E3LVr8JFFbp6DFW5WzIV8eqXHz3QeP88TJUUSqHaFqhL7L/OgZPnDlZt516QBJeKwdXpOH0Dj8RlWw46mzC9u+t+8ZRhZrYOVRbYtarUpjYZJLBzr56A3XsCopvrEafg6U1z2nabhtIeamk3P+nm/e+xjHx+aInRxmLosbRsjYo1mapC9nc/ONN7BtZVu9S+H3uuF3z+e5FRBoMJ12LDRFIoRASEHD96k1Grg+K9HP/fg6jCUkJ3URrY2DADUKCQMfJfQxRYwZc8qAQcS5j9EI6ZmaXwBFRYjlA6VTNroqkNA4n+erDb6GAnqXM5Z91+6b2596njufep56w8ZI5ZBOnoYf8dxElYnScyzWQvvqzas+igbE0Cb42jmPLeXXgK8pOb2sbd3wO14I9zz7IrMTTZxCB1ZbNyOLM3z9/v1U6lt7brxk5UcisPSIsTb56se1Io6uL1p/d8Plm2+au+dRxupLhIkMTrGbmdlx/v7Rp8hm9m4wu1N74iBUO1XlD1pPqRatilGLFj8B5rzwlkVF3jjW4N/vOzbEPQdeInRyCMPCD5bdnjf2ZLntA3voULg9RbzvR2Vp/dBKEfEfLyHe8dzo0tbvPPwEx6cXcVUbw0oi45CwNMXmnjy/8sG3M2CLr9qBeyQp1f2vd15DEX9cE1z6xOn56/70b7/HiZkqWraIlnDwAhe3ukBYm2fH2l4+8u69XNSVHOyU/GE3fO58n+MEHKzA7kqkbH/kxZNEmoVQdMJ6hTXFDGs7i7auibFzyeV6uSK1fcHjg08eOa2cnS6h2ykgRvfrXLyqkzWF9JmV8rUvfb7CDHx8rMkN9z1ziIVQQTMsgkaVC3uLXNSfp6DL7ziI87qLarl6ExRTlnJq7UBnUdHs7OnTZ2kGIagmkaqDZlJrNDl9eohqLaDY1bnV1HFDSL3evrAU7MMQme7O9h1NL2Rsaho3CJCahpAq5VqdyckppNS7Ojpz6w3JiBuG/a+2ymkLDrswkM+ZSijU/hNnhokUjUjViaSkUi7jNRsU2trWZxxj/lyb21u0aFWMWrR4jbi60j/p8evPjZX5+30H8MwUhp3C9T28xRnW5y3+7c+8ky6Vx9JwXwHxlVdz3NkwvNVVlJUVxJUHhua2fP3efUxUA/S2In4AbrNGvTTD1ZtWc8uyo/WXEjEH21XjdTlaT8Z8OhSkxn1+9a7HX+Cepw/TUBNYbRmEruM3aoj6AgUtYO9V27nmovWsNPmSBlOvZ6npVTwc5pO2ScZJMhNEaKqkKSTlhkctDFOhkKlzPXYUY0mVhqormohiJKBrKiBQVRUh8V/PZw8gV/Uj5msNFDW9XDEKXFK2ga5JBFFwPip8/ydFRf3iXBTdokk5/TM719/U19Wx7Zv37ef0zBzSaUMzE+iZDtxqibuffpG5Upmbrrni5oG8uiVQyKlxuFAQylfOdfxExMEugz+6Ze+Wm3LZdM+3H3mC8mIDO1vAzBWYnp/mu08eJFRFzw0XD9zoCOVpwpiC8urukS7J78WgvXPbQG6uVNly//Mn8VQNRTNQ0gX2vzRIWypF267NN6saCwk/PFjQz30+LVq0hFGLFv8MU2H0ySVFXntkspb6+8eeZMaXOOkEURThl+dZ4WjctGcH/WkGc4Jvvxa354aibJiHDz03vNDzjXsfZXixiZkv4guJLkPUoMZFF6zi5r07WGXw2S74vdez1DMXcUsDNlQFO87MR3tu3/cMjx0+gZ7vRNUNAi/EX1rAipusKjhcv+syNq/M0S75kk38QhHxxTfyXCtQtnX+/+z9eZBd1X33jX7Wns/c55yeuyV1S+pWa2xJrRFJCCEQg8CyA06MDbkRSZT3hecWybXzVpxbtm/semPfil2J7xv7Pg9VgfsEnuDY2BibUQwSktA8z3Nr6Hk+87CHdf9oiDFmkATYDPtTpaJacNberN8+q7/7N5KIRugfyCMsFVWzGCuWKLgSB5LXurYu6FcEeek6UeUNfeI4DioutlPC8UiiXPu921Azli+QL5dRQgrCczEERAImlqaevtrQ6tXwRmgLCfp1TRXDsT+6bc3TW3Zz6HwvmVQBrSKBHoxiuy47T18ilcvzR6uvm9E+Mfb1hKr+3IVoLfzw2q7N45XwuAKFtQuavqTgNP96+35GUyOooQRaOM6wk+OZ7YfQhNK+ek5zo1CELSV6tbiyPWmA72iC4c+vmPujnoFh9nYPIyJV2MKgrEfYfqKTRDTCrR3NdxmG2uWfWj6fNBR/C3w+SRQFLSdHiit+8foOTvWPEKqqwRMqbiFLrS75wnVzWTK1Kl0leFRx7SvOI+mHB/o8Htp2eqjxsee3cDFlo8WqEKqJ5rqUR/pY3jaJ/9ut1zE5zHc/qKdmULrr8wrtAx4btpwZWfX/ffpVXj3RTTZYQ8mIkC+5lNPDhOw0i5qr+cs7VrNqcuKJKoVHmuGvPmpRBP+VZ9RXEYniOB5IgaobpItlso6kJGm6Zo8RBJBg2+OOIVVVsR0HT0pQlA/sMSpD43Aqi+PKcW+R6xIydWJBE0Ol+/fxrDbAd2K4G2dVqs/+5e1LuXPBdBpMh9xQN6VSASMSxapp5ORojv/+9EY2HrmY7IMNgw7rL8sPFh6dAH9fDQ/fuWDqvlvmzySCTX4shRGIIINx+mx4dsdhthzvSQ7YbMgJOgZh/RWLZo90vcnDX7hhITWmpJwaQAiFYLKWvgJs3HeUveeHa0ckdw9INvgnl4/vMfLx+Si8RfBQTlE6Xj96hqNd/WiRBKqmUc5mMctZls+ZwspZzTRofLsOfoCqX9G6vfDVAdiw+9yo/h8vbmGoJLHi1biuxM1lsMizqmMWd3TMZlKYRwIexz/IK8UQ3JsW6qqerH3f1mPneWHvCS6nXWQkQdAM4pYKqIUMjVGDG+bOZOWcNmpDytMh2FcHv7eEVhWZ1hAjQVOvxbURgKoZ5G2X4gf0GNmeW6Mrar9lGLWe56EoCpqm/eZtTY4rsw8ivFL5EmWpYkjwpEPQUAmbKgb83rwYdag/0KHfsjhzz8rpS+orIks2HjrJyb5hbDeEMC3MiipS2RRPvLCFsfR8blk0s91TCAiB3QjfutZr18P3pET//PKZkUAw2vrUlj2MpochFMaKVTGYGebpbXuR3nx9+YzG9YpO/mo8U65DdHZd9Nl71ly/9n9u3MpoKQvBKCIYoSs7xst7jxGPLOkI1xpz/NPLxxdGPj4fMl3wDynJmhcPXl7y4s4jGOFKNCOAW8yhZIdYOK2J1XNbqbV4TLXJcGWaiF74aq/kazvPDtY+/sJWBgoCI5pAoCAKowTdPDfMa2Ht4rk0hcWPmuC/fRBR1O/xwKjCutMDpTUv7T3IjmPnGBMB9IoEQtPJj/QSsPPMnlDFHUvaWTi1emeFynOm53VWojz++9zzKsSjA7BhYnUlFqeRjoMQKpl8kXTeRgjrmr06hqJ2O5BEKqiKjm3bSCnRVQPhKQhwPsi9l6D5Qs8A0gwhrCBeMUMsHCARsAjCod/nPlYyHt5CQGxu4z80Vld881c79nKka4hs2YNABUY0SXEUXth5lMGhMVYtmNU6a0LsflcQtTzO1Chck4ewQfAdAfba+RPWBS11yX++9DojZQVPhNGDCfqyIzy98yCuoutLp9X8NQZMgr+5krVrtPHBxE5b9Y6hkVlLnti0C6mBFBZKKMGBCwOYr++nYvWSB+0wNTGcl6o17WH/NPP5uOOH0nw+9vRKvlqAGYe68kue3XmQohJCC0bBc/FyY8xsrOTWRbOYVm09EYad1fqV5Ur0wlf7JQ/uPN1f+9OXtjFQkOjROJ4LTiFHWJZYOWsqt3XM/o0o+gBcsvmnjMLyPRfSa365fT+bDp0hJUxEIIzExU4Po+dHWDFjEn9y42KWTat+MqHwZAN85828ld/7m5PCcNDQ0HBBukgUimWPbKGMI6/dYyTAViDvif/y8LzFQSRQ5JV7L96JsktjulgEzUAK8DyPSNDA0hV06P9DPcuN8K32+vC/fPH6Rdw4aypJxcFNDSPtMtFkDWUzxt7OPn726g5eO9rVeDHPXxcVWvq49gq9evheNTy8dGr98FduW0GN4VEeG0RVBGY4Tm/O5aktu9h85AKXSvx1J/yPq1k/AU8unzmFle0tKLlRhFfGQ0VaMY5eGuSV/SfoL3F3QdOm+6eZj+8x8vH5gAxK1ucEHWdG3Luf372fi2MZjKoGPM+DUo5KE26cN51pteG+CGy70jfrQVg/6HH/7jMDzc+8foC+nEMkWUOxbGNpHko+xeIZzdyxdAGTY+L7lifPoFxbbGfQY30Wlgw53HuwczD4692HOd07gohUYhom+XweWcyS0D1uvmEhq+dOpzWu/csk+JsPEk76MNChPxQMoioKjpQoiqBcLpPLFSi7NAxp8t5KxDWLtjf7C73bz9e037C+WJLRsVQaVR8/4lzXJRoOY+rGH/yZngR/41UFg5GlczfEgha/en0vQ6MFiNdgVcQplYIc7utn7PUDjBZsFk+u++vWSuuJIbi3kmvrd1QFjzoGiWVTa+9z3Y72pzbtoHe4Fz2aJBBN0J8e5RebdyOEYO38STefd/m3CO62KvX9K8p06J8a0767ZuGcr6dzRfacH8SM1yIDYfJ5j1cPHKUyESXY3vAlTTDyYffc8vHxPUY+nylyHh19Oe7ZeuQ0hy/2EKisBkUjnx6jQnFZvWA2C6c2UKfy/SutQBuCe/tKPHT4QnrG8zsPcmGkgBarxHY9hFPEGe1nxewW1i1fRHNM/MtE+NtqRVxzCKCgMKPPZcPGQ2eCj7+0lRMDKYglKbqSTCqNzI4yMWLyZ7fdwLrrZtMW1757peGM38MBUYhYFqamIaWLqgk8BNl8DsclyYeg3N4UQx+GKHrD+xTIl21G0xkUZbw5pXRsQkEL0/h4vAs2w19NCfLgrQvaOu//3M1MTQbJD/eSz6SxUTGTdfSVFJ7deYBf7zzAwa7UPRlY0QcPDcG913LNOvhBlcKjSyfX9X1x1RLqgipOZoRyuYweipFRg/xyy16e3XW2OaWwJi/UOf2l4gPvt24lPG5AV1tNaNMti+cwORGEXArHcTBCMcYcnV9t282hy+naEbirR/J3/snm4wsjH59roFfy1azKkl1ne3j95DnyehhphrFLeSiO0d5czw2zW6kyeeJKk5K74RsjcPexvlz709v2cn60ALFKbFVDumXs0UGWT5vIF66bz4yY+NoHESiDkvUX4F87S3ztlztO8OT2w3TbBm6wAkdREdJBzY+xqKmeP7vlepZNqeubYPLtCXx4oz0+DEKWRsjSQLpomoaqaaTzBYoOSQ+C1ySGwBbgfNii6E1hlCuUyeWLSKEiJKjSI2QamBp91+p1+bCpgR/P1Zm8srXmyT+/80Y6mmqQuWFK2VGEokEoxrCrsf30Zf7ztT28dKJ/Q1eZb6dgzbWKo1r44USTv106uf74H92wiCg2XikHqoZnxRiSJr/cvp9XDl9sHJPc7uhW8kr/X+Lw9Oz6ZNcd180j6BYwhIunqBBO0JVz+fnmHVzM054WrLqaCjgfH18Y+fgAfbZ8KCfoOHo51/HqwaOMugp6pIJisYidG2H2hGrWLJ7LxBDPRvE2X8maA7AhBx2HeorrfvX6Hs6OpFGjSaSmIO0ShaEels+cwlfWXM+ksHjsg1SADcCGMcHthwZyD/7P57by/O5DeJFKrHgtrgeF0VGUzAir50/nT25awnVTEs9ONPnbD1KF9FEgwA4aEAla4LlIIVANnVQuT7bk4ELkWteWb4Ty3yqOPgyBZEPtUDo93nEaZTypW1MIWyamxoWP27PeAl+cWxd57C+/cBO3dsxASQ1ip4eRrkMgFqdohjnSM8J/vLKDX+08ER2S3JeCNf0eD1zL9Srh8XqT7y5umTD8hdVLCbtFSqkhNF3BjCVISZMnX9nJq4c6W1MKN1+piKmFH1YZPLKotcG+sWMG5EZxi1msQBA9muRU3yjPbN1PSrLGhah/yvl8XPFzjHw+luRU0XFmyLnn+Z37OdM/Rrh+EkgFLz9MleawZsEMZiX1TWHYVY1yRWGuLCw+Plha9+TWXRy81IdWEcfQQHNKlMa6mVNXwf13rGCqyTfNstuJcW2dkc87/FtWY8mhS5kZP3vlNU70jRGra8JRQ5QyGUQ6RczNsfa6+axdOpuJAR6ZLPjzj+Wbk6QQ0iEeDCKHh8dzuxSVVDZPplCmhNb8cbtnG2oGRtN4EoSq4NkOYc0gEjDRxR8u8fq9iEpv0+SAon35+jn3VAZNXth5gN6hMZSKJEK3KAcU+jzBz3ceoTeV5gvXL7pvakxEBTjX0qyyEh4vmzSumd+8vmy7rf+5aTu5lCQUr6EUCDOUtXlq2z4Mw1hx46wGx4HElbwoNMK3pIm+fHrT17sHR9l/aRDFMgiGImSdAi/vPsTUmirUWRO+jTYupvzTzscXRj4+78Ml+KfuDPdt3HeMgxf7MBI1FB0Xr5jDKGf53KqFLJvW0BeBraZH5/v5PQckG1KCmw/3Z+9+4sVtHO1PoyeqkIoklxnGSQ2ztG0yG+68gUadxxrgO9ciigZgQx7m9Hrc//zmYzyzYx9pqRGtnUAZQXFsGJnN0hTV+fzKW1g+qypdCY81fcBqt4/0gBAMWyrpsKlFcT1c10UiyBZLZMs2ZWi8Vq9FN3wDwBOgCYGUv/n3nri2EN2bwmg0l8cV48Njpedg6QpBQ//YCqMqoTxaBY+GDXbdfd20uyY31q745ZbdHOkexLHCWKEYjqdgS5cX95/gQlcXf7Fu7bp59RYlaLqW8Gs9fE+DkTsWT/2qqtD689f20N/TSbiqHjVWyWBmlJ+8spNycd6qWxZM1gQ4VyJkAsjjbfXhxz63fP59+Zdf5/hgP4HKWsKxSvLS42cvbSEevjUamppcp0Dho+xC7uNzLfhDZH0+VlyGf+y3+b9vO9mt/2LLXsqhCkQgQCGXRckNc8OcFv5k5ex0UvKTiYL/4/2GmA7AhkGP9Yd6smv+5wubOTGQwohXI1UFXfUgN8a8SVXcv3Y1Uy3x/WauLTzRDd/o8/h/HOwt3PSTV/ez6cg58lYFRqyaYsnGyWeIeCVm1SX44qrFLJySGK5V+b8Ml+6wwq6Pqz0isGNY8qULg9naIxd70UNRVE3gFLLMam6gMRkq1Qj++7WIyLTkpl0nLkYvjORRrBACD6Wcp72pjsnVscFrWbcPHhqD25/ZfiTeW/Aww1EoFak0FeY31zE5EdoYg1c+rvsdhl2OJFFXYXXV1TfMc8tlhgcHyebyoGrowRBqMEz/WJpjJ08TiFa2VVaHW8rQWJLulLBQrmowbgj2eRBurE9UmbpVe/HSZRwPFCuIrRiMZAtc7OrGsCKTkonYQqlhRmHLe60ZRBxOwFNaxJinG4G2i13dZItlhBVEs0KkxtLk8wUqE5XN8ahRSsLP/JPPxxdGPj7vwLmS++95TZmz8/zI1Cc37yClhlDCcSQuSjFNa2WYr9y8nAmm+OlkwV++11qDpfL6UU39wrDknuM9xUWPPv0il/IeekUlgXAIO59BZkbomNLAl1dfT1NY2xTz5CshRRy8mnse9Fg/LPhKj83/c8eZgehPXtnO8d4x7EAcaQYplcp42VHCXpFl0yfzxdVLaE2ap6t0HtVd+ms1/vXjbpcxyR3n+8ZaD17shkAIRVVxChnaJtQxqSoaNBS6gry3QH07WVicgRW7T12KXhjOowTCCDxUu8Dc5nqm1MT6VUH2atdNwZpBjz/auPs4o46GZgaQpSJ1YZNFUxtojAU2RWHzx3m/I4IdRSlbokG90NTY2BY0A4yNjpHPZRGKCrqJGYiSymY5dvoMCCscS1QusXSl4AnCIbiqZzgC2zxBKBFPLDcMXT99/gLZkoMeqUALhskXbc6cPUsgEArGE/FVnk44Bi+937pJwU/0eOQLJZvazq5eilJF6CZWMER3by/Sdmie2DBD6lQVXa8lrIhd/ino83HAD6X5fCzo93jA1tWa472FFS/sOkhvUWJWV1O0yzijQ0xNWNy1aiHTouLJKfCn77eebRg1Y7D2WH+5499feI3LRYEXjiOFwMunCRTTzG9p4o6lHbRWGE8n4MlK9er68QxK1ucUOs6m5IM7z3fz7I5D9Oc99Fgt0pV4xQJGMU3S8Fg1dxa3LZ1FbYCnE4InK+HxT8q3z1DprogE0VUFx/NA03BQGcvmKTpEPe3aw15vR4rxP9eKC9FMCYYzORQjPv6Xjk0sHCdsmaiQ/iTseZ0QP9AkI4EQx63ZU75eFQ6w9chJDl3sphRIoIRiaNEqCuU8P9+6n1S+xM1zWu6eURNIV8FVT7Ovgx/UBcUP1AUzejXDrH3ilR2k02OY0UqcQIzhrMdTOw5RcF3WLmh5wFWJNiv81futO1tn7kh7m+wZSbOzsw9Pt/BUHWnF2HP6IsmKCHcsbntwoql8cwjv3t93d3cfH18Y+XxsKQpaBouseXnvEY53D2BW1iM0FSeVJqlJbl3SzvwJidMV8Nz7iix4IC1YtbdzrOOJF7fSW5CokTgeAsWxITfMyllTuX3JAhqCbIy6bKpUr76Ee0Ry14VRZ+3z+47z4p4jeJFKRDCAqqq4hTRWKUNrbYyb509nUWudXW3xcNPHOJ/o3dChLxYOYeoaZc9DKioIlbFsgZL7xkDYD0EQCfnB79WGmrwDY7kCWlUtAMJ1iAYDBCwDBQqflH2vEuMCRw2STs6qn1NTGbsnefA4O05dZiw9ihmN4+kmNhov7ztBMZsjP7f1/mJjsiWp85Mr7ev1WwLJ5Pu3LJyyoeTI1p9u3kfO9dDDFRgVlQykBnl+1xEsTQ0un9m8QQSF/X7P85Dj3Dsxpj186+K5G8YKuznUPYCZrCMcq6A4WmbLwRPUJWMEZtStrxaKn2vk4wsjH59Bh/UFjRlDHvdtPnievacvoobjoGg46RHCdo7Prejgusl1VMBz7/c2fNH1/rmgKjP2Xkqt+enL27mcKWEmakAouLkUEVFi6Ywmbpk/k2lRvn215fFDcK8HwQHJhkOXxjpe2nuEHacvo8Vq0KwAupSUxvqI4bKgrYEb502nvTGyMaqwSbXtNLr+ibORDv2xkEU4GCRle3hSgKaTKRRx3HEvzcflXj0IZEqSfNklKgS4DoqQRAIWAV1LX4tY+ENTL/jeIKyfURMKxpZ1rEtGK3hh1yEGhvoIVFQjgjFcRWPHqS6GxsYY7pi+YunMpkah4riOG6nT1CtuO6GX7f5KQ3/81vlT/07TjOBTm3eSzXt4ZhA9GGWsnOXnr+2i5Dqsmtv6oG1Q06LwxXdbr1LTHpegT68zEzfNb7u7p38zQ6ODBCurMSMVDA738sreI8Rj4WarMbJKgP37HJTs4+MLI5+PHY5GYgxu33W6P/nygaMU9PEDWOLipIdZNmsKK9uamGjy3fervBmE9VlVWbL37MCSZ3YcpLvg4AWiOIBmFwg6Ga6f28aauS20xgPf1m3Zj37lcZs+eCgDy/vz3H28e5inNm/nwnCOYFUjrqoh7TJ2epik5nHD3DZunDuDlrj6cBh2VsGjn0RRBKBCOmAYhEIB5GgZD4miamQLJYrOx08YjaSyOCh4AoTrYakK4WAQXafvk/o9qYJHqwSPahHl3wLzW+6vrqjgyVe2c3Gwm2h9E04ggoPkWO8wue2HGC2Um1fMav0f9SH1sT546ErL4isNfdxzasLq2RO/ETBU/aebtjOQKWLFq3H1KGNjZZ7Ztg9F0Vg9d/LdlsE/vtd3swoe9SCwaEpV8+CS9o7HX95JMW2iBIIooTgnewfZevAkFeasNbOqAsf74YFPooD1+fTgJ1/7/OG8RbB+1GPd7s7hJb/auZ/OVBEzWYvjSbxMivkTq7ljwSxmVxnfn8h7jxEYgnu7CvyfBzoHZ/x6xwHOjeQoG1HKioJTzKGX0qxdMJ21i2YxJWp+uxG+FVbFFVfw9MJXx1zuPDdcWvvSkfM8s+swFzM2RqIGVQ/glgq4Y/20VEf4wvULuLF9KpPCym9E0SeYvGTOiCP+aP/lIXrTRRTdQLplDKfIvJZJ1AbVcwnBU1ezZg4W/k7ytfRQnTeSr6tj/RHB9qtNvh6Ev3j9bG/zgfNdWJE40nUICpfF06fQVhPcCShXu+bHiTj8ytDorYgEp02b2pQsF/Jc7urG9jyMcAwRiDCYznOhZ4B0NkcoEm8PBXXTFtRFYNuVXicKW6SGFg4GVsbjcQaGRxhMZ9GsIFowjC0lnZ0XUIVKU0NVsuTK5pgq3jUhOwx7UKCqNrlwrOiFL/b246gmejCEIz36+3oI6jpVlTVLQjpnHKh6v4pTHx/fY+TzqaLftR/IqvqSrjxrfr19L0cvD6AmaxGqAtkMjRGDVbNbmF0XenYi/O37CawxuP3gxcHGZ17fx7mxPGUrhGKYGE4JShluWjiL2xbNotHi+1cbPrsA/5qRLD/Zl2nfcuQ0rx48S1bRSdTVUyqVyGeGMEo5Fk1p4Nbr5jGzPnw8Lnjakt6ZKqE8+km3lZToChDUVVRchAQpNXKlAnnbw5VX7zES4PzX+sID4eG9zXl3taM7BmG9C9HhVBahaONJ3K6DpQlClo4JF/A8UD7ZDf+r4WEsSdiyliduX3Zf7d6zvLDzIJmUhxqMYMWryeZSvHb0HIOjKW5fPHfVgqlJFChoMHyl+9oI3yKqE5rT+CVFU1v/8+XtDKVHUEMVCCNMznZ5YddBgpo646aO1qgC+ff6blXDw2WNhs+vnPfNkUyGvZcHEVoVRihGybZ57cAJkvEEsfaGVZ+kXDAfXxj5+HxwUeQUHyhpVvOlIvf9YtteDlwaRK2oJlJRQW5kkFg5wy1Ll7JwYlXnNJU73m+9YY8vbT/Vt+bXrx/iYtrGCSZxhURxi5QGL3HHopn80dJZNJj8y/uJrLdzVvIfgw73HLowxEu7D3G2fxQnUEHANJF2CS83jFFMc/2caaxbupAJUW3TdMGN47/9PyUTdwRoirRroyFdLRTQrAoUK0hmdIy+dJZSrdXEVfbDlKAhQEoXhAe8+QeUaxxMW4bGEjQNjmRQzQBCCBzPIRq1CBsKGgxXKp+OqqdqlIer4WFhYN+5cOp9VZGA/uz2A3Sl+lAqqtECIUqqyqHeNH0vbuPyyJxVNy1qXh6Hp12IXmmoqhG+pcHI9a11D1jektafvPgaFwe6qahtohSMkSlp/HLXYcaK+ca7Vs7d4AqiIeS+St65wrMRvmUHqL1r5fwNQ8+8SmdqkGC8AWnF6SuM8tTr+4gmIu3tjdFGS3Dmk+5t9flk4s9K8/m9U9Ks5lH43NYjZ9l29CwiGMcMRaCUxyiluH7mFBZNaaQxyDffU2DBA6clv9x3cXjN09v2cG4kT1E1EbqBISSjl89ww+wpfPmmRdSbPHw1A2H7XB46D//W73DP5mMXeWrbHo73jSHDCULxOIYmyA/1E6fEPTev4Cs3LWVKhfZYpeCxT5u9qgSPmobojFgGljqetyMlOAjSRRtbUnPtq/+2KBr/p4Iir95jYENNziGZKZTRdBMpJUJ6BC0TQ1d/y0v1aWGyyp83WnzzpjkNW79y83XMrIvjjPaDaxOMxtBiSfqKHk9t28djLx7Sz6a5Ow2r+uChK71GLfywWuPh66Y07PzS6uU0BnUKYwOYZgAlEGPQ0Xh+73Fe3HO6dsjjvownVrzXkNugax9qTYb2fX7FImosDTuXxQiGUENJOkez/GLTDi6l3WQKbvZPS58/BH6Okc/vlS74hyG4b8uJ3uZfbdnPUFEhXtuIqkgKvZdYOKmOu69bREtc+3Yt/H/ebZ0B2DAGd+zrTt35+IvbOZ8qQySJappQzjF6+TSfXz6Xv7pj+XBS8PPJXPkssh6Pv0urrDqb50+e33+GX7++n768QzhRh9B1Svkx8kM9NEYsvrLmBm6cOaGzXuOfJ8HfhMTVNdf7pJBWuOnSaKnt+IUebNUEVaNcytIQDzGnoSps6ly6msaCb+YY7Tl1MXphJPdGg0eB5hSZ19zIlOpoV7XCv13NPY5I7urOMG/jnqOUNQuhqkg7z7TaJHMnN1JvKU+H4VPXRDAC2zxJoK4y0D9pQtO8slOmv7+XdLaAYQUIRmNkiyXOXLxMd98QiWTNjGBQn+goJAsOs8IKe67gGjuqdf4tUhubF4gm2i5evszAaAo9GAYjRMmVnDp9Gl0zg/V1VdMtlfO2R9075QmFFXWPVIRWkQjP8IQaP33hMmVA00ysQJCe3kFGh0eYNa1ptqKifNwbcvp8+vBDaT6/N/rgobRk1fG+XOPGXUfoTbtEKuuQUmKnR5mSDHPborm0JPV/sTzOvJs/sx/vgQzK8gN96bX//twmLqQ9RCiOalrIYhYv1c/aJe382W1L80n4SdMV9g7qd8oPuJoRTSmsOT7krfr1zoPsOH4WAhGiiTilko1wiuiFNNMn1vLHq1eyoN58LAqbPu0ufw2GQ0ELTRVIKUEBoWiMpTKUHJBwVSV3AhwB9n/9LAS/NSzt2nxPgbFMmkKpiBaJ4AmBkBAKWIQt9RPT3PFaqFH48ZDk3ukJZSR68/yv1dUk2bjnCCO5MQpuEC0YRQtEONw1QO7ZV7ll6bwZHS0N307o7CuWZcskQ1yRN7UCnls5u77G8RYteeKVXaRzabRYEhmI4Qh4budRhFCDN89v/XqDybff9X7hx54gsGJ6y/d7hlLsPNuNo2gomoURrWLPyYv8YvNBvrx67oOuJDpJu3Jvr4+PL4x8PjGUoKk3K1e8tu84Z/vHCCTqQNPJp4aJyBy3LlnEnEnxnZPgb95NFPXBQ2mUVQf6Cuv+feN2LhYlMhTDDARQSjnsVC+r2lv4k1uWUAs/vNLhmoOwvqAZM4Y87tt3KRv92Ss76BzKEqpqRFF18vkcspAlKkqsnD2N25e0MyXCv1xNeO6TjAAnoGuYuoqQEqEoqLrGWCZNwXZw0SLXtK4Q46LoTXH0AZACPZ3JjXfnfkMqaQoEDQPLIP1pF6+VgseBxz2VwC3tk+6LWXp04+7DnBkYRokk0QIxlLjC2cwovRu3c26gjZsWze5oioiElOhN4v1fIKrh4YLrTb+pfaLtKcqKx57fwshQiYq6iXiGQSY7yrO7jiLRuHPx5PscSbJJfed16+AH2QBLbp7Xdnc+X+RoT56yrmEFowjP5bmdB6mMVyTvXNC0otuV32hQxXf8U9THF0Y+nxoGYX1/mQe3HT7FgbNdeGYU1bQoF7OQG2X54jbmT24gCT95tzV64aujsG7/5eyKX2zdS+dYETcQQ9csvGKWoJNh5fw27rxuHvUaj12pKLrslv+xoBozegreur3n+/jZpn305VyMSBKhGJQyabzsME1VUVbNmcOt8yd2xVw2flZEEbzRy0jXCVsW/XkHRYBQVdL5PJlSCRftqirTBNhv9Rj9lufog3iMslmkEEhFIF0PXVUIWya68sntYXS1hO3yTtMwOm+cUb8uGQ6ueG7nUQ5dGqDkCVzNJFQ9gZHBLl45fIqRfI6b589snt0Yuc+FaAw2vl/V2iRV+Zs+eGjFjMYZpfJ1yZ9t3sNofxdmLIFqRUhnXV7cdRRViubV85ofVAOk3+27GFHY1poMN97YPn1JOneUrlyZktRQQxEKdoFnd+yjIRHqWD6l6pB/ivr4wsjnU8MQ3DvosX7H8Yv6pgPHyXgGoUSSTC6NVk4xt6mKtYvm0hDk4XdrRNcHDw3DPQcupToef2kH3XkPx4yiaSZKuYBZGGP1vGncsnAmDSHlkSvJKRqQbCgLGjKqsfzsSHHFy/vP8Mr+E5SMCEoogqJp5FNDxLw8s1vqWTZrGgsnV56uh+9VGZ+tapnxJo8qFZEgXjqFkBIUhWzBJlMoUyLUfM3eqDe9Rh8wlGZLatOZAp4UaKqKa5cwVZVIwECDkc+KrSoN4/E3PTJGQ8V/xFcvvSex9xivHDyFY4bJC4hW1VPKjrL9xEXGsgVGOmZEF0ysuc8LEHBdJ1qjau9ZtVYLP1RUCl/oaLod11n3s1e3k0m5qNEkSriCwcwYz+46jKpr3DhnwkOYYLnyTJUqHn37OmiwcHKyMJqavOqZ3UfoL0uwQpjRSoZS/Ty/8xBRa/H9al0kPUnxQ2o+vjDy+RQwCut2n+1b8fK+YwyUJGo0hisdnPwYdWGNP169gikhHmnm3YdSDknu23thpONnr75O53AJraIa09ARdoGgk2XF3DZunNtCU0j57pV4igZhfU7QMWiz/njvmL5x92F2nerBtaJYoQpU16YwNkBCd7lhdgur5s1gcoW2KeaysUr97JUQq5C2tHGRgefgeR4eCrbjkSs72HyQyrQPzgBssD1qcqUyjgRLKJRcF9NUCJoGikvhalsKfBqYqvJlNalmlEWzN0QiEXacPE/n6BAlO4xmBtFiOid7U6Q27yU1r4Xl0yffPTWiXVEuVjU87EJk7aKpja5d7Hhm11FG0yMY8RrMaJzhsSGe2X4QgRe8YfakrzVa4pvvJrIcSCyaNmFV3+gor5zoIWfrqLqFDMY51jPE5sOnqQzN/Wstqo40KPghNR9fGPl8cjnj8LPD/em7N+4/zqmhDFZVAwXbw0uPkjRg3fJFtFUZO9/NwzME96ZgzcELox0/37ydS5kySjRBOBJB5lOoxTGWtE7k5jmtTK0wvn8loqhbet/IC2XOYJm7D14e5cnNezgzmMaK16NoGo7jUB7tpzmuceP8mSxva2VKTPlRE/y3z+IvVwAFCmEDu7IiqiO7QHgYVgAnp3F5YIh8S9Wcq9kbCboriSqKMp7MDUgpUa6x+aILkaJH41A6g6qNH2vCdTAUlYipE1LZ91n9DloOp2fExbdji5u/2VgZ57nXd3OmfxBZrkCYAfRAgp70GL/YtJ/+/jFuWzzr/mJVsCUs2TVRee++X3XwAxUyty2c9Q3DMBp/+sp2chkVJVSBEk3QNTLIU1v3UnZK+k1zW79LADS3NFKtmr81MNbyODMxxDdXzp3+7csjBY73psAIoIVj5O0i246fJxGwWLt45kMEoAFfHPl8pOedj89Hw2XJP15Ml+5+9chpDlwaQoYrKboKqnCR2RFWz5vFsrY63i0pdhDWj8K63Zey9z236yAX0gW8QAQrGKCcS2HZGW6Y08rnls6jJWk8ciXNG/vwHsoIZfnJ4eLdz+89xdPb9nF+rIxWUYM0LXLZFG66nzkTknxh+QJunddGS0z5fliy87Nsy2p4WFfoN1XGu1+L8eo0oWhkSiU8leB79a75qPEgmC9DrlRGVXUkLkiXsGURDhif6oq096NO4we6R3+1ysOLmyu6vrJ6KWsXzCLqFlDyOTShYEUSEEqy5cg5fvLydvZfTq0Y9Fh/Cf5pENa/37NRZfDI9bOm2F++5XoqlBJudhRVVQkmqxlxNF7cc4wX9x3jbKb83azQFr99jUqVxz1bBqYk9SfXLp1DY0SlmB5CCIERiVPQwmw52cnOcz3JIYd7u+Eb/gnr4wsjn08UAy4bRiXrXjtyhs2Hz+JFkqiBGNL1ENlhVrW3cPv8aUzS+Xo1PPz2z19w3H/tg4f2dGXu/vm23RwbSOMGE6jBMLpwEYURlrQ2cmvHTJqi6iMh235fj0CX4/zDKMq6/V2ZNb/YfohfbD/CpTxo8SSOKijkxgh4OZa31vHlVR3cNnvCsw0G354If/tGxc9nGkOhKxQw0BUFPBeBiqeopLIFbIj+IYfJehBIFzwyhTKKroEnEa5DRTBIImTxTonenyVqFH4ctN1D9TrfXTwx8qN1i2ex7rrZVOklRGEMr1ygLFXURC17zg/yP198nZePdiW7JV9Lw6pe+Op7rd8I35oUUP/6+lmT+/7o+oVEZBE3P4YUCmayjj5b58mt+3jlyHn6PfX+dxI2E3Tx9yHYN6cxsPOO6+YQN1wyYwMI3YBQjM6UzcZDpzkzWGrNwPIe+d7zE318rhU/lObzoTPkcW9a5YaX9p6fsfnIGcpmBN2K4HkuXm6MtvoEn1vWweQw36+H7/2OqIINeVWdc7Q30/7LbXs40TcKoRhWOEIpl6ZcGGX1nGncsWgOkwL8KOi5h6t1/eF3FWlvJFn3e9qDB88MJJ/bdYwT/SO4VgyMALZdQpbyeGMDrFgwm3tv7KDOYGccfvVOou2zLIzClklA17BdD0VTAIV0rkjBAU8j8Ie6Nxei6XyeouOgagEUCYorCQd0AgZ9/uwtqNHV/0qoNiN0BhZM/WZlIhp9eut+zg8O4VpRPC2MUVHDpbEUP9+0i1ypzMo5k++rDdAiQTc8r+vdxqrUwI9dnejy6c3fzeUL/Pz1I2RtFxmKE6iopjQmeeq18feXzy1pe0hRyNfBD966Rj18z/FILplWFb0w1DLjPzftxrMs9GAMmajmTP8wmw6eJBpqX9MUpdDj8Xf1yu+eIT4+vjDy+djQDw/kFDr2dxfueX7vcfqKHmYiisRB5HPUh1TuXDaPKXFt3zuFvvrgoRTcfGqwvOKp1/ZwtHsIJZRAt4K4+Szl4W5WzWvl9gUzmBTgR5bLmWpVfVfx0i35Rkpwc1+RFduPXeDl3UcYKqqokVpsaaN4Nna6H6OU4curlnLT3OlMsXj4vRLBP8vCKBIwCJkGadtDSIGiqGQKBTIFkJGra/L4oQlxuNeDQCZfwvXGG08iJRqSsGFiQLfwsH3/+G+ogx94BsGlLdVfCluLZvx6626OXR5CClACYbxwgrFcime2H2RoNMWKeW1LplQHOmJC2Wjj1tSh/uCd1q2H7zkWyRvb275WdCTP7zqC61igCsxwguyoy/N7TqJqweTt8yZ+U+g4ik2hWv/NC8hEhb/1IHDrotYZ5y+c48DlPkwzgB4IkS0Uef34eWKRMLcumrKu3iDvW9Pnw8YfCeLzoYqiEjSfLfDgj3/2PBczZSK1jXjSo5gaJYrNH61awnUtyb5KeDwKW96+xiX4p6M9xZue2LiZk/0ZZCCKqpkIt0R5tJc186dz702LaTKU70+Cvwkr7z7ioQf+btDjL87maH/ile28uPcIKQKIYByhG7ilHMXRPqp1j//2pXXcPmdi1wRTPNJ0hZ2yP2tk4bqRklx5rHuEkbwLioYiJLKUYm5LMxPC+tEKePFK1spBRxpW7T19Kdw5nEUNhEFKdLdE+6T6qxoJkpUsyQhWHLgw1HzsUi+YIaSUGHaReVOamF5fcalZ43/zLfjbRGELClRXBEbaWqa2u2WXixcvUbRdFN1ED4YoOS4Xurq43NdLIBJXK5KhVgNluAgtEdj2TuvG4CXFEEpdffXKUCDIuc5O8oUSgVAMPRAkV7S5ePkyQppmw4T4NEOlq+wx8a3jdCrgOVtlWl3DhNknz51jNJunJFSsUIRCuczA0CDRYJSJNWETUD+No158/nD471A+H44ocr0H8tB+yeFrP9t8kKM9YyixKkpSUM6niSll1iycyZKWShLw87dXlfTDA8dgx5Ge4oonXt3G6dEiXjCOZkaxVBWZGuGWOa382U0LhxsE332vROshz7v3osc/95T5+sHeQvP3/v0XbDnbRTlWDdEYUhfk0kOI7AiLm2r52z+5k5WT4vvq4PufpaaN13BYFAxNJWSa4L4x7FXRcFxJKpvFg+Af4r6kQLMlNalshpLtIhQVz3ExdJ1YNIymMuxb752pgR9PgT9tDvLdr9w8r+tPb7ueCWGV0lg/nl1GD4YRwThHLw3z2HObeWbnWU7nvHuG4Utd8A/vtq7hOd0TDb5+a8fkrtsXzaRSsymODhBQVQLBGKMFwbO7DvLUjrPN3UW+nhN0vINw2zw9aT1x760rqSCP6ZVQFIGZqGawLHhp9z4OX0q1Djt8ybekjy+MfD52uKoSHZSs33Swk61HzxBtbEYPRZDlMloxy4LWSVw/ZzINBo+93SPTC1/NwPKjvfklT7y8hdNDWdxgBUK3kE4RJzXILQtn8yc3LiIJP3mvkvwhuDctlFVjCrdvOdkf/b9+8msGygpqrArdCiFcBzvTT6Vhc8PMyfzpLStZ0BB9sgZ+9G7NJX3eIowUQcDU8NwyinijzF7o5PJFPD5IjpHylsPIu+r7sl1qcsUyJcdDKgIPD0NViAZNTIULvvXemwnw91UKj9zZMfGJ+z+3mraaCEpuBDuXIhAOUTNpCmO2zi837+SZ7Qc5n3Xb07Dq3cRRtaI9rMniSELhyc8vn376zmXzSCpFisM9WIZOuLKGIU/jV9v38fKhU/SWebDT438MSu+/KuCq4eEw7GqfWNm57vpFWHYGL5/G8zyMaJwLwxl+/foeuvNyyTn4d9+KPh8Wfo6RzwemDx4akGw4fGlMf/nAMQpGmEgwQimXh9Qgi5vrWLtgJq1h8UgQeRh+M/bhsuv9Y15V5pwe8dY+uWkfR3vSeNE4uqpjSBvLy7Jy9mTuWNhGo853A9I+jnjnVJYB2DAGt1/Ms27zoXP8csteymYEK1qBUEEUCmj5EZqiGjcvms2iGc1UqTwRhc2f9jlaHwbCk3Y4oKcrIlbU1CUeLh7gui79g6O4TLi6qjQJQqhv/BEoioKqKKiqihBXV0VmeyTzJRclEKDg2kjPJmAqVIRMTOj0rff+NAq+BaBMCBZin1t9/3M797Pn7AVyYzZKMEIgHMe1Q7yw+zhd/cN8btmCFTNq4iuUIIV3KqKoFtbDfdgPVaA/t3re5FrNKUWf2ryTfNZCqagiqNUyMtzLz7cfIGuXuGl2y4aWWCA/BPe+OZakFn7oqCRumD3l60Opgr7xwEnyrkMgFkck6jjUNcTzB85w5+LW+3SL/itp2eHj4wsjn49cFOWgo3Ok3PzyvmP05RzMWBW2bSOKGZoSIVZ3zKSl0toUhU2ViMffKmTyqjLnRL+z9qev7uBo9yhWsh4sk2J+FM3OsWLWFD63ZBaTLP4l4JSOV2rm71TEDHnevWVFaRyBu08OFDo2HzzNtqOd5LUIejCGiqA0NkzILTJnUjW3dLTRWhfP16j82IIzfuXZFQojcBTIB00tinSQuKiqitQMcsUyZWi8Ck2kvenvERLE26aBeOLKw3I21OSLklzJRigaiqbi4mHqKgFdQ4DjW+/KmQx/rlRbBWPZ3AeTsTCvHz/HQDYNgThWMIKnCI5dHiT13CbuWLEIZ2rjd3NBOqKwqQZ+a5RILfoPB5Hr63Tx/VsXT7/dsMwl/2vTXlKjHkaskmh1DSODl3l+92ECpoEyreWvJ4TUJyXob3aYb4RvZfBW3NjRtqpveJAd5/rQo1E8M4waE7yw6xBhwyC5tOlzGgy/k0jz8fGFkc/vhUHJ+jSs6szKda8eOsWxnjFcK44qwcumSIgSn1uxjI7mxL4KePatwyn74YFByf0XxtyOn762i72d/RiJeqSqY3klTCfLiumTuHPhTKZYfLMBvoNmvuN9lBWlsbvMN3af6w5uO3qeI5dHsI0Y4XAUzylRTg0QlQWun93C9e3TmF4T3hiFTSqkfVF0deiq6I+EArWKkNieh24YSN1gNJWi5NA0oLHh972nLkSz+Ry5Qh5NM0BRcIVHwAxgWcI32jUQ9NzDbcngdyMdM7+ejMTYfuws5wbS2K5HIBSGqMqQm+fR5zbTu3AuN8xpu7ulUkuWoXGC+O1QdxXj89EUlfz18ycnMiW39YXdR8nkRiEYJlJZTy41zNNbDuLaGitnTrlbjYj0W7240w3lRlvIYzctmjljtFDkVP8lItWT8KwwebPAtiOnmZgMt65srVwyCOt9D7CPL4x8fv+iyHXXl1W1Me2wav/ZHvacuEhJCyA0HdV18Aopblw2m3nNSRLw5Fv7lQzAhkHJ/eeGyx2/3L6Pg5f7UJNVGIEguEWUzBBLp03g9o6ZTAqJR0yPznfKhuuDh8Y8eXtfwVmz69QlXjt8lrMDGbRYLYpmYdtlvFyK2qDCqjlzWTl7CpMj+o9CsM8/OK8eBZFXBemQYWEogrI37uZRVJVULo/tkPywehlJiTYkfhNSeR/vk54rlMkVSgg1ABKk6xEOBrDMz3Zjx2ulWhlvgWGF1TPR9knra+LJFa/uP8b+c5fwVBXLClGWOo5UeWbHYQZGM6xdNHvVrAnhBIBiFwsNuvVbBRY69Cfg52s6Wh4Eos/tOUy2KLFiSURFNZmhAV7YdQRT1TBnNt1vhOlqZDy8BxBV5aaZjVU1A3OnJTPbDzM4NowSiBGIJhkY7efFnfuoS9ywbmal2e9/v30+CH65vs81eovcv8gJddHBi6m2F/Yd53LGQQ3G8Dyb/NBlrmubxBeXtdNg8shEwf/xVjEzABtOD9vznt15hF1nLuOFK9FDEUQ5h1EcY1lLHZ9bOJvWuPEvIcc5WKUqv3PIdcM3crDwzKh959M7DvPi/lP0FFWUWDXSsJCejZsZocby+MKy+Vzf1sSUiPbtIN7hKoSfqHktXgTB4TGF23uy5RknL/WSdRWkpqFIF6WU57qZbVRa4rV3K+N+KzlYmJGs3HemK9w5lEENhBFINLdEe3M9zZWR/ohgexAOv99aI3D3qb6xjn3neyhrJq4At5hhZkMVC6bWXQpKDkfE+9+Tz+8SgoOOJFEZN9KV8coZmqZw8fIlyq5EMUwUK4hihrncO0jPwCBSMWqjFdEVQVM7U/KcKWGh/FcZfRAOlz0mBjWOVlYlV5mmQXdPD/mSi24GUfQw6VyRnt5uNF2ntjax0FMJ21AXhMOOIBFRlO2heHytUE3OXeql4HoIw0K1NIYHhyiWikxsbOxQdZQyNF7J8+Pj43uMfD4wA7DBUfXEsa7Mqpf3HObiUA7VCqMISWG4nykVFutWdDAhxGNvHw477PKlw7259ud3H+JYzwhOoAJhWAi7hJceZHZzLXcsnse0mPLtRvgW2u8+ot3wjRG463BXpv35nQc5cGGAkh5CCcVQVINCdgwKaaYlQ9y9agkdk6J9lQqPj799+oWYH/DAGAkaOtFgkL4xG8/zkIpKoeySyuVxY6FrGgsixe/mGV2RQIf1NtSM5YvYrsR9w1ukAbFQEBXSn/VxIB+UOpUfDErWz6yzRhKx2RsqohGe33mQ3qEMWqwKRQ+iVVRzsq+Psc27yRTyrJg1dcOksPZYHzz01mrPKmXckyMttOtnTfmmpuk8tXU/mVGJVVGDqKhiaLSbX2/fi2EqwRvmTv56g8K3++AhTcrhGsGPywaNS9uav947mObVw6dQQkF0w6IcqWDPmYvUJSowFkz75iSDrw1J995KoT7uW9HHF0Y+HykOJM4OFe55df8JTvaMooWqQFMpZoZJ6i7r165hdlLfOAX+9K2fOybZse9SasmLB09y6NIQRSuGEYqgu2VID7JgUiV3LZtHc1R55K0u9De57Dr/aKtaTa/H/a/uP8fWo+e5MFTAtiqxQlFcu4yXG8PIDDB/Sh1fXr2Cpgr1eI3Cj96eFOpzbRjQFTINooEAYqyEBKRQKNgOg2MZnPpQ8sO6luT9O2l7EMg7zEnnipQ9b3ywrQRdqMRCFhqM6IJ+33IfjCrBo1XwqBmkMzi/aUMyGmx+etsezgz0YAeShOOV6MlahnMpntt3gr7RFLcsnHXfjMpA1HFJNKpv+z47DpMs7eve1Anf9RzJ87sPM5YZQg9HUavqSY3287PNu8mXbW6aP+2bdQZPhD2xaxB3va6q/c1hHru5Y/p9gyPDnBwaphCIYoYilPB46dBJgiELa86kB2uE+iPfej5Xi//67HPV9Dp87bWDJ9l56iK2FcUzdNxSHnKjfH7FIjomxY5HYdNbPUyn4Jnj/e6SZ3cd5kBnL14ojhGKIVyX3GAP06oq+Px1Hcyqsr47Wfy2lwnGO2JnVW3J2SL3/2TzEZ7ZfYyzIyWUWBVmJPYbUZQf4QvLO/izW69nTlL90RyVmb4o+lAPjHxI1wgYCooEIQQShaInSeeL2FBzFV6iDzxCxIVo0aU5XSrhIvCkQEiJpgpCuoEGw1eSp+RzZdTD95IqP7murXrnV9asYEFzHWQGKKYGEaqCGY8zYqtsPXGBx1/cys4Lo+vSKqsuevzzENz75jqmKi5okpEpYeWvV89t6rt96VwsJ4MsZTBNHSOWIOWZPPP6AV7ee5JRWGerSk2Vqj5aCz8MwqHp1cbGz1+/gPqwilrOomk6ajjOsKOw6fBp9p3vb07BmkFY71vO52rwc4x8rphBWH8Z/t8vH+yd/Yst+8hbFYhQjIJdYLT/ArfNa+PuG2ZRKfjpW5sw9sDfHeorf/7JrXs50Z+CSCXCtMB2sEcHaUkE+PPP3Uhbpf5kM787uuES/NMY3L6/N7/oP17ZxZZjlygZMfRIHCkElPLYY/1MCqv88Q2LuH1BU7rBED+dLPhL32ofLgWYnXK4s3MwRedQCltoaEYAxS1TGw4we0pNyXWpiCjvndOThesysHLv6cvBC8MZlGAYPA/dLTFnUh3NldGRycr72y8Nq7ryctX2Y2foy9koZhCBJCjL3DS3jYaIsTMOv/It9+ERE7xSkkypqzDPTG9tnpfPF+m8eJ68XUQxTILBMJ4w6B0Y5tzlHjBDkxLV0SUI1DI0FJFtVUJ5NCTYV5S0aCojlVWxDtUIqOcudJIr2RhmGCuSoFD2uHzpEroR1Gtq4x2OoMqWbn2NUH5ckjRXxsy8VM3WcxcuU5AqtqIjdIvBoSFKmSwNtfVTwpZmJwU/8y3n43uMfD50RuCuQ135NY8/v5msGkWLJCjYJbxSinlTJ7B22TwSChvDsHMIeW8fPHRS8uKBvsLd/7l5Owcu9WNbUaRu4JSKOKP9NEV0HvziGqZX8EQcnn77Nc/Cf/R4fO2Vk/0z/vvTL7HrfC8iWo1nhCiXS7j5FEZxhCVT6/iLz93I6vb6zip4ZIry22E8nw8HAXbIpDNs6eiKQAiBBzhSZTSbp+Ax42o9QfKNinrvt//uisL8HgQKZZd82cVFQ1V1hJToisDUVDQY8a324TNB8PeT4c8bTf7lz+5YnL/v9lVUaQ6lkV6ccgEpBFayjkuZEo+/uJn/fO0IZ1Ny3RDc5yASb65TKXjcgjNVGo/esqApfefyDsxyGieXxjAsAhXVpEWIn730Os/tPBbsKXt/XRJq06B01zcIvhOGXTe1Tzq0bOZUnNQIwrYxIzEIxTnRM8rLe4/Rk+XuHvg732o+V4qfY+RzRZyT/PvZtLP2/7fxFcb0IGo0ji1d7Owo9ZbLl25czOS4digC2yrh8YuSfx6R3H1qpNT4s9d2cbhnBBGtRVhBnGIWe6SPeQ1VfHnN9bRGeDIMu94e8jgNvzyfYd3Go2d5df8JRmyNYHU9Qui4hRxOapAKw2HF7BZu6phFW1x/LAYbKxU/dPJRUQWPDiqsD1tms4pESomHgqKbDGfz2ALdhejv634cSKZLJfKOC4oCqoIsegQMnbBloELat9pHxyT4G1WQ/nxH86oJVYkVv3ptO0cvdqHGkrhalGjdBEqZNL/Yup/O7mH++Obl7XNrtLQDSQvOCDy7BuXHA7Ch6NJyy7ymOW6xnHz5wEm6us4Tr51AoLKe1IDk6R3HsMJRbpg+4Zv1uvrdfk8+oAvRHxO8dNeK9vZzPYMc6utDahp6sIKSq/DakU6qKxKE5jd9XTVI+2F1nyvBD6X5vC+XJP90Mcf//m/PvcLBSwOE65spey5OLk2lCXetWMCC5iQ1gocN6E3DDcNSfOnIQKH5iZe3c6hrCDNei1RNvHIRvTDGvIk1fGn1UmZWKxsr4IVa+Nc3r9ft8Y1u+H+dHJG3PrP3BK8cPk1WDRJO1lC2XcqjI8jUIM0Jk9uWtHNLRxtTo9rD4521fVH0UTMK63pSpbZjlwfJexpCt8BzUEopVsyfRkzhaByeea810rAqC9ftPd0VvDA8Xq6P9DDcEu1NdTRXRYc1wdj7lVsPwl+c6s+2HezsIuNpqJqFW85RH7VY3T7ZTqg8FYY9vtU+OqKwuQRNVTGr1FDfMEUgGRkeoVC28YSGFYqiWEEu9QxyvrMLw4xMilWEV6gaaR0xmEfOAw9DUXosOFddl1xSKnv0Dg6TKZZQzCCqFaLoSi539RKwDBLJihUBTZwQAtuCc7rKULx2QsfZzouM5ceH3yqaSdl2SI+NkYxXmImKQNITMhxG7PKt5vNe+KE0n/ekF7464LLhxf3H2HO2i0BVHS4SxS2QEAVumjOFJa31VChsEuDYUDMCdx/qy7Q+8couDl4awUg0IjULpVzAyI1PtP/Tm5cyo1rdVAHPvfUt7hL8U6/H13Z1ZVf9dNt+Xjt2gYIaRbWi5DJZ3PQIFV6aBRPjfOWm67h9/pS+KUHl283wV74o+v1gCLpioRABy0RKifQEQjVI50qMZcGFyLWuLQV4V9Gs2pVE04UC+fL4OBApwHNd4pEwAZ3jCrLgW+yjpxG+FYONs6uCj3zx+kWsXTiLCZbEG+2nmEtjBCOEqydyOe3y5KY9vHL0MheL3NcPDxYRLbbn1dTD90y4kBA8/bll0+3PXTeHYGmE4ugAuq4RjNfRV1T51fajbD3ZS4/D13LQYUONDn0za/Sdd92whDpLQiGNZujo8UouZQq8vP8E50dLS9KIVW9NAvfxeSf8UJrPe4qiYY979pwfjr6y/xhqrAojFKOYzWGVcyybPollbU3UmmwMwPEyNKbhhv0X0q1PbdvHqf4ckdpJuGiU8xmibpZFbY3c0TGLqRU8G4dfvTk+YgA2jElu786zbm9nL6+f6ORo9wgiGEdRFIrpNKZXIuwWuH7WZG5ZNJspCW1TBLa+U2m/z0dLwDQIWQFkOoeHQFd1yp5kNFfAjQWuOpQmr3FyhyNJpPMFcsUSMjQ+iNZ1XSqiETQYeXMchc9Hz5vd7QMhjuuzW79fEQ6z/cRZjnaPUHQ89HAl4ZoGRlKDPLP9IINjKZbPmTpjctKKJhT9yX54QJEUKlSeUyF9w+ym+xzH4fldR0iPDqCE4kSqahkY6uHFPScQnqBjSu09jWGw4IwBXQtbK/M9I1OCGw+douiYSCOAG4xypHuA1w6foWLJrHXRwG8qZn18fGHkc8X0lOTf5UzRcWqg3PHLrTtIoWFEk5SLNvbYCPOm1LNsRhNtldbTAThegqYxl7WHL5aiv9h8iHPDJcx4PSgWXmEUs5xmwdRqbl8wjRmV2hNBj8PVyrgo6nblNzKqWH465a7ZdvIirx+/QG+2jBeoQCgCWcwissPURizWXr+IhVNrmRjTnk3Az/3W/38gr5GpEQyYSJkFKUERSEUhlcnhEQj+vu7D9YgWimVs10MIFc+TeJ5HJBLx84v+gAJJCYtCeFrD/bUV0Y7k0bO8frKT0REXM5ZAicVJFXK8uOck2YLHyvYpja01oQerDR42BZ118AMPAhMN+u/omLpBul70me0HGXNsjKoGgvFa+tIjvLDrEJZlYDYl7okbbAwKDoc89q2e37piKD3Grq5hXE2ghCwcUcFrRzqpq4gTn1l9X62h/9C3lI8vjHyuDlNwYYy7n9u1n968ixpL4EoPr5CjqSLEyjnTmNWY2KfBsA01GY8V+y8Uo8/tPMrJvjRqLAkS3PQQQYqsmNPCrfOn0BrTng3DrlplvBtuL3x1VBHrjvUVOl49do4tx84zUlIwo3HAQ+bS6LkRZtbHWbd0EfOmJPN1Ot+34IwfOvsDPRrQGTIhZGpouNieh43E8SRjmSySyvc9VxQoAAi8/6pG+43XaLwF9vvZt8/loZJLs+MJEDpCKLiug3DLBC0T6Z9vfzBq4Mc1Bj826iK/jMXmrYvHYzy36zBj2UG8QIRAOIJQdXae6GQ0Ncay2VP0ha0ND9ZZPNYPDwhP2kFFHKrUeOz2Ba0PmqbJM3uOkEoPYIaq0MMVdI/18IvXduB687luet0SBQq6Sn9C5fTqhbNa094RDl4cQAlXghkkXSjz0v4TNCatDrUu+up0Xb/Rt5TPu5xPPj6/TRf8w+Ui391y7AwHLvRS1AM4iko5myHklbixvZVFU5LDYdgpwMlJOg5czDQ+vfMgB3tHoLIGNWQhiyMEykOsntnAnQtbmRHTHgtKDr85IuAC/GsvfG1r51jHY5t389Kh84y6FmogNj4eIpciUs6wpn0Kf3n7Cpa3JLdO1PnbRviWL4r+cEjP002ww6YAt4iuqyiqjqKaFEoODiS7Jd94rzVUSCNB13Vc10V6AlUdr/JXVRVFofB+jflclWgqZ5MplNE0C01RUaWHoXgk46H/El8+fzjiGk83R3nkxjmT+fL1c6gjjZIdJTU2gqdpeJEER/pSPL3rCC8d7uTESPm+FKwpIZoreaOUX+eRm9on2X+0pJ2km6eYGkBoAjNRx8W0w5Ov7eG1U/3RvhLrJOhBONySCHZeP62ZafEwAcfFVE3CyRpODaX56Y5jnC/pqy68peDDx8cXRj7vyiCsT8GaPWe62HrsNHk1gFGRwHEcvNwos5tqWTxzCoagy4FEDjqOdufbn9lxgFMDKfRkNVowRC47ilYcZe2SWdyxeCZTw+KJCGwzBF298NVO+B/dZR58fv/F2v/18nYOXR7FDSYJJ2pQFQWZSREqZ1k9p4W7li9gZlX4ySrFe9Qvt/3DU68o3zMUukKWjmloOI6DIz1QNAqlMh4EeJ+cod+EQN8Igb3Zy0gw3lEbnPe7Dw8CtpSUyi4e6huqzcXUIKCrvqE+BlTBoxHYNjHIj26YM7nzLz5/C80xE6OUwS1lUU2DcE0dfUXJi/uO88ttBzjYnVuXVVh8Gf7R87xASLCvTuP7y9smsHbJPEJentGBHqSUBBNVDJYUfv7KdnaeukgKbrahRoHCnOZqlkyfimkXUJ0CKAqhyhoOXOrnZ5v30ufwYDfvLeB9fGHk8xmnRzp/l4ZVx3uyS14/fp7BgoIIJ8iXXXDKTEpEWHPdPGoiHNcURoY97jnYW+j4yWu7OdabQoQr8FAo5cfQnRxrl83lpnktNATZGIJ9HgTK0DgK685k2PDL7Sf49euHuJTyIJQE3cIuZFHyI9SYLvfceB1fvH4uk2PqYy0KX6wSip9P9DHB0OgKB0NYuoZtl5BSomgqqUwGW1KjQP791hDid4e7CnHlWdgOJMuOS75QQqIghAquR0AziAR030gfI3Gku/TXqXx/waTEpr+84yZWTKlHzQ1RTA/guTZmJM5gSWFX5wD/a/Metp4bWzEkua+gKDPKkkYd+mstfrR8+iQ+v2whE8IqTmYERUKoopqRssGvtx9my+mh4KDDChXSIcHp9qkTWNjWhFJKozoFTMPAilSw+9gZXtx1mgGbDb6FfHxh5POuFIQ243S6eN9L+49ztHsYLVaFFBqF1Cj54T5uXbGY5kodDwI56Djen+epbXs5O5JHrahG0Q0UN4cz2sPtS2ZxU0cLEwPi6QhscyRJDwKjsG7PpeyKx1/awfO7j9FfVjArqtCNIHYmhUwPMSmk8aUbF3PzvIlMDPCjtw+j9fnDowrSQUNHUwWe644fJppKKpOlZPN7Sb52JZFCsUw6XwAx7iFyXZtoMEgkgJ98/TGiQeU7NfDjBDw5u1p79r5bl3DHopkYuWHyo/04bplQsoaSEeVo1yhPvLyD5/ZdaLyc576yoBFAg+HaMI+tnt/IrYvbiWsO5cwYUgqiVQ0MlFWefGUHO091k4IlDiSrg/RdP6+F1poYFMZQpUsknsQLVvDK/uO8fqK38TT8stfhq76VfHxh5PNbXIR/7nG476VDZ3n9TDd5I0au7FHKZfEyQ9yxYhHL2qqwYDgLzUcG7ehPN+9jT+cwTiiBrap45TzOcDe3zJ7EXUuamGCyVUWmbagpClo6Pb678ejwjP/18n42He0mY1RgJeoQhoZw8kS8DPNqY2xYewM3Tq/umqjzzbBkp2+dj+XBUbA0gaEoKNJDURRQVNL5Apmcg8eViaM3PURX4yl6E1tSm8oVyBbLSE1BAq7jEA8HCAlsfxzIx48a+HHYlrumBPmXu5bOyv/VHatpDCgURwewy0U8TSdY2UhXTvDEq3v56bYjnEhz3zB8yYVoAI5HBDtXzm1gzcLZxBSHQmoUV4IVraQ3J3l622E2HeknK0mqkK4Owqp5rSRMF7uYpmRLAvE6hsoaz+8+zKGuwrqsxpJBzx826zOOX7XhQzd8Y8Bmwwv7TvLCnqM44TrMUAXlbJbcUA8r57XxRyumY4FdhOSZIYefvriNE30ZglX1CM0inxoiUM6wZkEbX149iwo4rcGIi4hmYPnlNM0v7TvNq/tOkieIWT0JxVRxvTLlzCghr8ANs1v5/LJZNAV5MuhxuAG+g/Dt83FEh/6QaRI0VETGQZEeqmZQzJVJZbLY8YqaK13rWsTRENzruCRS2SJFx0UGVKQAx7FJRKsxoVOHPt9SH0PvkSG+A2AZnNGnT/hadV1t8y8272bfhR6kFUNEkwRiSXAjvLjnBJe6LnPX6qVL2ifGm8KCXUGFwwLsmxZOWqEoCs/uPsbAQDeBRA3RqgZ6Bvp4dvtBPHsGy+ZMaE1odM6YlGhePm8mz+06zGgujRVJYiSquTDSw0v7jxEJzLt7aoVq++0/fHxh5EOP5O8GJBv2do0EXz1ygSHHxBIGSj6LzPSxqLWOL96wgEqws6CfH8jzs1d2c3a4QDBZh4MKpSJR4bF0xiQ+v3wWcTguJLYnCKRgzbF+h2d27OfwhQEKWhAjkCAQDlMujGA4WSbFVJa1zeC2BW3UqPwo6HK4Wh3vceTz8RVGsZBFRSiAGBrDdV0Cuk7ZE4ym89huRQ3q+wmi302wvlJx5EHQdqlJ5YqUpABNx0XiuTaRcAANRnTo9y318fYeSR09XKUvDt7QcU/D4bPsPHmBXH4EPRQnLzX0ygbOptP8zxd2ctt102sXt01al9DF8RDsS8LITfMmrEOMN4Ecyo5gxWuI1jQyMDrIxv0nUHSN5bPrmqPQtax9UuNwKs2Wo5dxS0U0K4AbSbL3fA8V0QjhRa33mEFxYQL8vW8dXxj5fIbJCTqO9uYbn379AJfGSoQSdbgCnFyK5sogd61ZTn0EyqB3j7r88tUdnBrIo4QSCF1D5Auo5RyLp01k3Ypp1Jjjb+mKoDAoWbP3zCi/3nWUs4MpCESJRJPgQnq4l5CXY/qEBDfNbaGjOTlco/CjRvgWfkHRxx4F8hFLELZ0hFvGc20Uy8SWglyphC2p+ajvwZbUFmwbB5CKiiI8PM8haOgoUPBbOnz8ebN1h1plZWJLZ22ojIR4+cAxBkd70MNVeJaFVDQupwd5avN+ckWblXNaZngGAUtwJqqw6eb5zcuFbuhPbz3A6Eg/ZkUNwXgVfaO9vLjzCLoqWTSjvlEHru+YTe9IjmNdwxTsGFYwgqeqbDl2juq4RXDOpPWqIF0P3/Ot4wsjn88gJzxePZN1Vr185AzHuscwEw0IoeEWhmiI6dy+vJ3GhIoHXB52+NkrOzjSnUKtqAVVpZxLEfLyLJ81mVXzp1FtjZdZl6GxK0108+ELbD9+nuGiwKyow1METjmLyKeoNR0Wt0zixrltTE+oz4Y9dunlUj+G6RvmE4AAJ6TTFzGNWksVuKrAkwIXhUy+9L7Zi2/2KNI0DSEEUkoQAs/z8DzvzWvY7/Z5CdpYzmU0V8BTVCSSQrmEoQpqkhV+4vUnjGb4KyVIPr6oeVV1hdW+cd8xjvZ0o4SrUDULM5wg4xR4bscpxsYcrps1uXlKlVkT0dhmQNcNsxuaPSn4xaYd5DMCzAjSijBoF3l+1zE8NJZMr6YiCGuum8vws5voK5eQhJFmmIxdYvPhcwQDRu3SKdUPeqoMNKL5o4Y+uy9+Pp9Fzjj8bBBWvbDvBJsOnsaI16LpAUr5NFHNZfm86Uxrrgage0zy1Cs7ONY1ihWvxzSDqHYZvTjGoqoe8KoAAD2TSURBVJYJLJvZREMUdOgrQ+PR3lL0p6/u4qUDJxlxDYxIBaqq4uWzeKP9tCYM7lw8g88vncmshPpEXPKrBoXvVBumHz77pBwckoIu6A8Z400VcbxxKaNqFOzxJo/v16Dxg+BAsiwledvFU1SEoqAoAkNXCJqmL4w+gQRdeTjm8dKK1rpn77puPoubajHyI4hyFkPVUAMxinqM1w6f5emt+zncNRYckawRYIfg9Io59dyxrIOE6uDlxojFomjhCgaL8PyOA7x+uA8bqK+2WLlkLrKQwnMK2BIIRukcK7Pl8DnOjeQac2gd/rBZ32Pk8xmiG76R0+h47Wg/rxw4jRtIYFoRnHwWCqMsap/JvOmNmApcSjm8tP0IB7tH0CpqsV2BWcoTcwssm9vK8jmtNFRoBOD0sEProfPDvHzwFKd6xvACEcxACGwXL5smJgu0T67jxnmTmdmQTNdo/GgC/L2fYP2J9BjZhqArFjDbDaDsjXevlopBtlimDI0uRN/r87/181VWpTmQKDge6WIZVA1UBc2DoGlQEQ75wugTSJX6m4G/gUmJf6pPLPvapkOneX7/cbKegwiEUQMBHAG7O/voz6RYMW8aS6Y3t9YF6AzD8Kr2pmTA0Hl+xwG6ey8RStTiWRFG7SIv7T+BYxi0T08wY3ody8dm88quY6ixGoQZxgsnOd4/zIt7ThFZ0bFWjyj9fjjWF0Y+nwF64asjcNfuy9nmX27ZTcGIEIzUYJdtVCdPa1M9C+a2YerQlZJs3X2M/ed7IFyJGYhAJkWwnGPR9EmsXjCN6hBokO7N07r9WCfbjp3jzGAWI16Doip45SJKIUOVarO0bTLLZzUzs9p6MgLb3swv8PkE/hITPJqFJYlwEEtTyNruG00eNdL5AgWbqG1efZ7RlQokB5K5skumUEQq1ni3bMcjFghQERa+MPqEMxH+VoswbC1s/Ua0Ihb81et7GMwMosUqkYEgIbOentQQz247QCZXYumsqc31MY2wTn7JzIagUDWe23mU7pE+rIokaijKaDHLizsPIJVZzJpWw5IFU+gbTnH80ggYJlIzKRsxdp/uoTqeJDp/8v2GSVcj+CE1Xxj5fFrpg4eysOTEqGz/xda9XMrYhCqr8TwPt5AmHoBF82ZSEYW+Edi86yCnLg0iQ3EU3cQr5rCcNEtnTOL69lYSIVAhf2GU6JYDx9h1tpsxVydSO5FyuYxXyOLlRpiWCHJzx0wWTZ5EY1j8qAn+m2+NTz469EVDFiHTYDDnIKVAUXXyhRK5gotnqoGP6to21GTLZfLlMooZxHNthF0mWRkhrNHnz0n75FMP3/MMAivaah6sTlyf/NXOfRy+cBnbTBCKJYlVVmPn02w6eJIL3f3cdl0HLY3hYECFBa01CEXjV6/tpj81iohVogUjDKdHeGbrfnLufDpm1HDDsvmUnAOc7x2GQALNimJ7kteOnKexKorWVPk1oeEY0u2qEqpfyv8Zwc8x+owwCOuL0NJV5O5ntx/gVH+aYGUtZRScch6dMu2zWmiZEqVvFF5+fQ/HLwxTEEEUM4Rn2zjZARa2TeLGJW00xMff7I/1O8Fntx9i67GLDJU1CMUQQsUpZNCLY3RMquSPb1jITbObjjdFxbebFF8UfVpQIR22LEKWieJJPM9DUTQKZZtMvoAr3z2Udi1eojcZgntL0JQqFCg6LoqqIl0PUS5TVZHAgG4Nhn0LffJpFHyrXuO78+ujG//khkUsmlJPwM5QGB2gVCqBFcKxKjjZP8pTm3ay7Ug3qSIIoGN6ks+tWkqVqVDOjuK6EjOWIOuZvLR1P0fPjREOw4K5bcQsBUORCFVBBGOM2Cq/en0fp4ezwQwsd4Sa6CuXH/It4gsjn08JQ3L8F0lPzn5wy/5j7Dp9ibIZBT2Iqal45RQzWurpmDuJdA4279rPye5RHDOOasXxyiW87DAd0xpYe0MbFRakHNjfVeLJLfvYc3GIUrASPZKgmC9Qyo4gcoOsaJvIl1cvZfmU6ifnqMz0XdKfusOjYGoqYSsAnhwXJ0JQdmwy+dz4MNmPAAeSRZvWTGE8cVZRVPA8hCeprogjwFalH0r7tKCXy/2V8NjseOiJ+9es4I6O6YRLGYqZFLbjYcYqUGJVnMsUeGbPIV7ce4qMO956fd6UCu64fiGVliA7MoTjghmtIUeAzTsOcPLsAC1NAW5Y1oGbG8MuZHEVIBzh3Eie53cf4WKONSnJGk03fLHtCyOfTwt5Qfug5P7DvSO8uP8EbrACJRilZJcpl3JMqKlm2ZKZlG14dds+TlzoxzOjGGYA4ZUZ677IgmmTuGvNXEwFMi7sOt7Fz1/dzoXRPI4VQ7GCqNLBKGXQM/38yQ1L+MrqhcxJWo+1wBd9K3w6hZEmwNJAlTZCuiAVbE9QsD1c8e4eIw+C4wnY40eQIt9YUyp4Yrwc/90+W4KmvCvJOx6e0FAUDTwXzStTETJQXAqVwk+a/bRQaRiPV8LjUwVfbguIv7p72Yy+L61eQpVmY6eGyI6MoOsmWiRBXg3w+rFz/HrTAS4PuRgazJ+Z4KZlHURUh9zIICiCYCzJQNZm694jnDifZvLkKB3zZiDtNLrqogYtiFWy49RlXj50ipygIyfo8K3hCyOfTwH98EAWFu+7lGr891f20+0GsY0gZsBC8xzCps6KZfNwgGdePszB04N4VhWaGaZcGMNL9bB26WzuvnkWGpAqwX++dJj/tXEPvTkFI16HHghSTI9S6rvA5KDkf79tOfcsnnx6msnXo5JNvhU+nVTBo+EAhxJRE8XLoXgOqqpiezqpvEPBZUYv7zyc04PAmx4lRY6H0xQEAgVFUXmvHCEHktmyw8BYFqmY2K5EF4JoWKUuESCs+vP1Pq1Uw8MNCt+5c97EjX+x9npmJQJomWFyg4OYikUwUk1Zi7LrxCX+8+XtnOp10YD5MxLcsWI+MXIM913AVSBQ1chQWeelXYe5NARz22uZ1TqBYnqQfDaFZwZxK2r5j9f28OzR/uQorHu359nn04WffP0pZsBzN6QUdc2pEXfFKwdO01XwMCobcVApFAroKly3ZBGaBS+/dpxzXUMEotVogSCF3CghiixfPo9VHfUIFy6NSDa+tovTfWmUWA1CN8mkRlFdh6CdonVCJV9ctYQ5ddamKnikEh73S/E/3RgKXdGg3m7qAltIPE+ColK0wYXoFQ+TfeM9TQBIBQn6u33WhWjJdcmXbaRQUYQK0iVgCAIGfkXap5wa+LHtODXXNSfSiegNdz+/6zC7Tl6gODaMXYqgakGCVUHODA6S3riVFYvm0NaSYN6sWspyAc9sO0B6ZIBIsgE9lCRdTrF5536Wts+kvb2VdKFEz3CakiJQg1G0qgm8vO8ETfFY8+IGa5UAx6+o9T1GPp9QpKJqvTnWbTl2nn2dXUgrgqsZlBybUqFIW1sb8aTC5p1nOXmxh2C8GlcVlPPDGF6Gxe1TmN9eT8GDo5cKPPKLFznRn0aG4+ihMJ6dpzTcQ8wZ4Zb2qfzZbctZUG89Nl1wo9//47OBCulYLIauKYCH57lIoZIvFpACXV7hy5eU8oqv6UGgVLTJZvIomoomwHVdwmaAYEB7z47ZPp8OGjXtWzF4aVpSf/ruVR2sWdBGRGbID/fhuQ4lqaLHaugrKvzi5R1s3nORXAkWtk/gtpVLsdw8maEBhFBBizAwVmT/0bNk8pK5s2YSs3Q0x8ZQBLoVoTdd5Ffb9nN6jLV5mONbwBdGPp9AuuEb3Q7f2Ht+iG1HOynoEdRIBWXXoVQqM3nyZCZMSLB1xxnOX+4nEE1SdG0U4aJ6RRbMaWXOrEk4Hmw/0MPPXthETgvgmCEcBPn0GPnBbporDO5e0cHdy9toT2jfjUi2+bv/mTpACqFgAEVR8DwPqQg8JNliCcd7b4+RlOhvF0VXIpBciBZKZXKF/H+NFPHsMtFggIAGKmR8y3z6qYaHE/Dk5AA/unPJTO66YTEz6+M4YwPkUqMUHYkarECG4mzdf5Rfb9xNd7/DvFlVrFl+HbpbppxLI4SKaka5PJxi5/5jeAhmTGvDUhTsfB4UDS2U4PRglpcOnKa3xP2X4R99C3x68UNpn0L6JA9lBMt3d+Zqn99/gn5HQ0vUUFKgVCrRUFvLlCl1HDx8ie7eIaxIHEURePkMniwwd0YzM6c3UbDh9T0n2HP0HFINEgjGUMplypkxAm6B+S0N3NQ+jQVN1fkGle/Uw/f80Nlnj4ChowmB45YxrCAOgmyxRMEBRyPxjqLojbNHSvlmsvUViaJBWO9BIFssUyrbKCEVgYfwbCrCIXSBXQ3+aJnPCJXweCU8HjQ4HJrT+NXGymTri7uPcvBiP/kCSBHBDFUgdIOT3QOkN+9gacd8Zk1Lki20s/3AcWwpsSJRXDPCpaE02rFzzGqbStuUFg6fOIHrShQzALrOrrPdTKiKoLfWfU01/GGzvsfI5xNBPzyQEtx8bMhb88qRU5weyqHFqrBVA9tTiMbi1DbUc/HCMBe6ejGCURwP7FIZQ/GYN6uNWW2TscuwZdcR9p24gBZMoAejFPI5CsOD6LkhFk+u4+7rF7G8tfpQo8E3/QPis4kK6aChEzB0HMfGA1wBuWKRTL6EJ6++ZP9NgaRA/h0ElV72aMzky5SlRFVVpHRRpEcyEkXz/P5Fn1XvUQ38eH594Nm7Vszl1o5pxEUemRshnx7DEwpqMEbPaJ7nXtnC0RNDzJldxbJF88EuYBcLKKqJasW4PJDmwNFzRJMVTG2Zhm27uKjYWpCUMHhh31F2d/bro7DO33lfGPl8zBlw2ZCSrOnMsfbFQ6fZdaEHJVlDWdEplR1AoaFhAplsjlPnz2EEowjdQtpl3GKG1kkNTJ9Sw8Bgjpde28exzmEcLYZuRfBKJdyxAer1Ml++fgH3LJvHohrzsQT8vA5+4O/+ZxMNRkKWSjRsIT0HTzqgqmSLJVLZIlKMh8uuVAzBb0r33wkPAoUyyUy+hPeGw1tID0ORJCJBdOj3rfLZpBZ+OA3umF6hP3Hb7Ca+sGg6DXoJLT+CKBdRjACuESEvAjy/eQd7DvTQ2BDhxusWIotpvLKNUA08LciFwTQnzvcSjiWIJZIUSmVsKfDMMOdSNpuOd3KoK7PkHPz7oOuu93f/U3eu+XxayCosHhPc/vKRS2w9eRE3msAxLDTdgnKZQCBAIV9icGAYKxhFqAbZTI6AJmid1kLThBrOXxjm6LET5G2JoofRVINSaozSSB+T4xa3LW5nZdtEak0emwJ/6u/6Z/4AGQ4aELYshJfGdV0UVSFne2SLZSTvL4zeKYT2bgnUErSiA/myg2S85xHSxVAEEVNHl74w+qwzVeXLwZh+ODa3eUNVRbT5pX0nONk3RKFgEYglKQsNJayy7/AxMvkCkyc3sWD+PPYev4htu2i6hWUEuDwwTMGRVNXVMZTOUvYkitCwqho53tdHzcmLJMLT72urUNNV4I8L8YWRz8eNLsk/jAju3nJ6TH9mzxHywTgyGMNTDQquDULglm2GhoYpOh4egqCioSgKEyc2UlUb50TnJXp6epAigKeNv55TTuMOd9Fen+CeNdczuy7QWSf4fg382N91HwUKhkJXOGA0qtJDReJJQaFcZiybo0DV9Hf7HIArPVAEqMp4ohHjPY2kRH+nJo021Noe9AwMI1UVXdcpFfMEDY14KICpcsG3ik89fE/RKCyfkry5JrFk7cY9h9l58jzlrAAzhh6MUi4bHL/Uw1C2wOQpLUyd0syBo6dxLYEZClMSOj1jaRzVIhqvJDU6hqJalFWJrYbZebqLiGkS7Gh5UAlSmAh/6+/8p+Zc8/mkMwT3pmDN4d5y9MnXdlMwoxSNEK5i4gqBVBSEquCh4EoVzbQwAkEyuSwzZswgEoty7PQ5uvoHKboS25WIchl3dABvuItVs6awYd3NLKgPbGoQfMcXRT5vUgWP6oL+iGEg8Ma9OoqKJzSKjsT1iA7Ahg/reh4EcrYkb7sIRRuvhLPLREyTkK5jQqdvFR94I7QmuGNGQnvkj1fO5wsrFlCtu7iZIexcFisYRhhBLg+OcPD4acq2S2trK9FYHNvxEJqJ0E0G0ylypRKmFcKWHq5iEEjUUbASbDlxie2nexiBu/zmj77HyOdjxDB86UKRJf+5aSfnMyX06lqkFsATKkJoCAFIkFLBkeA4HrqiMqWlBQc4fqaTbG6McMDECuo46TRaKU1czbN6eTtrOqbTGOLZaXCHv9s+b0eHvlg4hColnpQgVKSqkS0UKXvUesrVJWC/V2GjDTWZkk22aINqgevh2mXi0STRgObnGPn8DpPhzy2LM9bspq9XRcLRn2/ZQ08pTXbMgUCUUCTJaLZI9mIvkVgCVB1UG6SHJz0cx0OqAlPVEKpJueygaCoiWMXQmMsrh89TU13dvKBGu0+AU6v6zR99YeTzB+UC/OvFPGuf3n6EEwNjhOuaKGkhhNCQ8o1+woqG8ASSNyegKwSCJtlsls7+HgK6RiwSRThFymMjiMwgk+JhPr9yJYtbqoZjko1RyWa/FN/nXQ6RkcqKCnRVo+h5qIqCUDQyuTyl8ruX7L8XiiT/Ts+bC9F82SZTLCIC4XEh5blUhEIEdPr8XA+fd6Ievid07EhL5aq6mtvWPrHxdbaduYyeECjBCEHTouTCwNAwRiiM0NRxb6T0MAwDIRUcV6LpOk7RxfHAkxqheB1do9387JUdVNy2vD1QKRb7u+0LI58/IJfhHwc8Nrx06BxbTlxAi9cijfAbQog3cjYUhCcQQsXDQwoPQ9fJ5TKky2UCloHu2qjFMkY5C/lhFrY28LllHUyvNDeFYecEwd/7u+3zHofIcCIaIaBrFF0PECiqRi5fJld0cS01+l5B+7enXr+ZY/T2/24IeW9ZisZC2aZge6ghBSFBExALW+85X83Hpw5+oEO/GeXC/3bnsgebDp5j08GTDI3kiVbVU9It0mUX27aRno2mgBAKihxPt0QdT/ZXVRXEuPe9iIoRTnKi7zxPv36A0E3z7zFDXAh4HK9U/O7/vjDy+b3SA383LPnSzjPD+muHz2AHkxCowBYq48EIiZCAdBFCQSIRQkUISbFYxNJUNF1FcUqo5QJaPkVS9bh+6TyWz5xEc1R91nTtCxNU3RdFPu+JCulwSCMUMBkpeEgx7qXMl4rjo0Fk+P0r08Q7KKTfEVBSd6RIZAoFHAmqogACXVOIhEJoMOJbw+e9eLMhpG7S/0eLpzxQGQ3XvrrvOOeHuxChKoJGmJwnkajjakiAJ0Eq4x53AKkplG0HTTVxAdcIoVfWse30OeIVQeIr2x6qU/i+v9ufXPzk608gA56zoQgtBy9lml/ef5KsEsEzorjCwHE9HDleAq3gITyJlB5Sugg5HkZTFA1XeugaBIRN2M4zNaLzJ8vms27B5HxrVH2kAp5rUvX/5u+2z/shwAmaELQCSFyQCkJTKdllCsUyHr+bYyTAeb91hyT3vl0YeS7BdDYPQkWg4rouhqoRDoXQVL+5o8+VYTpOZxU8unJ6TddXblrCdVNqCJZGITOA6RUwFVA8iesKUHQ8VEqeg4PEFQqKbuC4NhIXWwiKioZe1chrx8/w2rGu4BDc1w3f8Hfa9xj5/J7ICG35uYx3347Tlzg9nENJTgA1QK5o4wkFzXqjOkhKQOAiEVKiCg8BqLqCcFzU3BhWOc3Mqii3zmujoymyNeyyyy879blaj5Gp0BXQ1UbFHfdUCqFie4Ki4+JA8t3dQOPvZkIqb3EZeXiCwNubQ7qIiAvRbKGMpyhIRUXaZQwhiRgahkKXbw2fK/IcadrjADr0B2oDt0eum7MmGjzLa0fPkLfBUTw8qSNVC0UVSEB1BJ43noxtavobuUceZdtGNUPYqBRyY/x6+34mT2hoVsPiLgQ0CL7j77jvMfL5COmHB/oK3Pfa8YvsvTxIMVRB2QhSkipC6OiqgWUGcT0Qqo7QdAQauqKjCoHqldDsLIz2ESuMcuO0Rr6yah6LmyJPV8GjE1VfFPlc5duV5w2HBPtqEjGQHq7tIRSdvAdD+TyO+N3k6zcbOJYcFwUVz5VIKRECpCZAGa9Ae+tnyiiNWQf6xlKgmXhSgOcS0xWSluaH0nyumlr4YRLnJ+0V+jc/t2Aqd183k3otj8j0YKolNM2mVE4jvRK4ZVRXElBVpDOei2R7EluCi4piRNCi1fQXVX69dT+X0rQXBS290i/j9z1GPh8pAyU27L84xM4z3WTUIFqkilxZ4klQhIqiKBSLZQzDwHNcpHSxSyVUXSegSxQ7i5sZolYpc8v86aycOYGJJk9GPGdblaL5FT0+V//2rSiPj8I601Dx7DKmqiKlwPY8CraH7VEzqLD+3SvGfvv9TEqJB4G3d812IVpyIVewx0NpYlwYBUwFU5GokrRfOelztVTxxrkX1jFmNn87GAzy0qETHO27jB6vQ6pBXNfDMCzkG/mbjnTHn1sp0DQdT3rkSg66FsCM1bDvXDcx0yS0fNZ9TRZpf5d9YeTzEXHS5cUjg5n2V4+d40KmjIzE8VwV15WoioIUcvyXheuORyg8B7dsEzZNFLcAhSLuaA8tMY27ViylfVLYjkueblH4ov8o+HxQoqEwrlNGUd4QN65LvlDAdqj1tCvvZeR53jv/PQQKRZtMLouqhtEUFcfzCJoWmqYixDuPEfHxuRIM6KoxlYdXtNXdXJ2sbP7/t3fvMXqe5Z3Hv/fpOb2HOc94HCexc4DEOTZHoAlNWAiFFAVKKsFuqAqsqFSqhaqstFRqq1JpW2mLdpHa/BFpFWmJlkql3dICbQgQCuEUcEicYCdxiEPiOJ7YM/a8M/Menue573v/eMZOCFSw3ST2jK+PNPJ4/Np/XKN5/Hvvw3V9/js/4OsP78NOb8W1pxiWgegyfFCUdY0zSbPKicFoS4iKqBXBOsrBKrueOsj0eJfW5We931oWt8EfS5UlGImX0b7A3/y4z033/OBR9i2tYsZmGdqCUQVE1fyAagjeow1EX0HwtBJLqmoYLROWD/GG15zJ2y97DRfP5w9NKf56K/y5VFe8HMbGOijqZpUyeBSK/qik9LHL/8NSTozxZ85Yi+CW1/qsrfUx3TGMitS+pt1qk1qHVnJdX/zbzcCdCqoMHk9n3M2dN15z40ynwz9+50GGgwHtuW2sVn2MztAarNVoralKj/ceZaCMCo+iOzHPkaMHuW/vk5wxO1Wk21q3Gk1PBm5LMBIvkwPwJ4cCt/7TDx7lu88coh7fSpW3qcoEtAYC3tdYraiqIYbmB1bHiKpG+P4S3bDC266/jGt2zHLxRPrZLtwroz3Ey8VAb6xbkCWOuirBWowyDIYVVc0vNEz2pTT0X/z7CuaWV1YYlTVOa1QMGBXodgpS+68PnhXiFzVN03tIBwZJlwNT1134vq1zc3z23vt49uAT2LE5XDdBKUM5GjQ3MJUhoDDagtKMgmbVpGSdWZ5ePcxXHnyUyfaVO1sTXCZbvRuDHL4+xT0Lf3gIPvqtxw9x7w+foG7PUKctRkFRr2+daQ3KKEKoiXhSq8iUJ6fCrB5mzK9w81U7efNFZ66HoiChSLzswahbGNqtlLou179oWR2O6JclNb9492ulFAqqF1/pfx4+VEa2HVsdELVBKQ3R44DxdgtnWDTIWQ7x8pjT3H6u4je3GP7Hmy+c3P+fbn0Hl8220YtPE48eYkwHOonB6YCxEW0ixOOzAh0VlirtUGXj7DmwyDd27+VwxfsOwJ9IdU99smJ0ClsI8XeORHXb9w/2u3//nUcYZVOo9hSjKoAFE2tCqLHaoKwioHHKooMnDo6h+sucN57zrut/havPzBbH4Ysd4n2z6DukuuLlDkZ5BmOtnMXlqgk32tIflKyNagJp8fP+jYgmolBKo6B+8QpQgLyMbFvujzA2OXHw2plIt0ixsHj83b4QL5ezFb+XwIF0Vt08/c6bbvy7e7/F1x75Mb6ssO1JsiRjSNP8UeuA0hYdNHUd6fmK8bRLVQ/57qNPcvbsOO2d8zen8JSMrpFgJP4NjlThtjWnr3x2jdf83Td/wKHS4ianGdYWHyt0jEQ8zlpCqAg+UKQpRtfoYY+0WuXSHTP82rWXs3OSxztwXyf6+2aUkR9I8bJzsJAbaKUWxQilQGvDsBxRVuH/e8Wohskq4vpljTIJADp4nILMGjlfJF4x8/BJBXXWZt8H3/6G286aO6P4yoN7efrocySTs+AKtDEEPGVZgUow2hGUYRQCxuUsDixffegxxtvFldefNXalBCMJRuLfoHJ67hB84K57vs2jz6/SPvsCBpUlRFAqrjdvhKiaztY61OjhEDvsMcmQ6y/dwQ2X7uCcnC904L6t8OcoI4UVr4gILoX+/PRk8dAz+9EdMDZjrb/MsPY/dcboeDdsrTU+BrRqPo8xgg/EiNPqhTNGHrrDAM8+vwjKkCU59epRisTSzVJyxx75LohXyhb4FEDLsOud15x9246ts9f/47d/wIMHD2K602TFOKWHqDRKK5RRGGupywHBpIRigscOH+aL39vD/NjrPsyYYjvIZAEJRuIXdQg+ctDz8bsffIb79x9CT2+nX2sCjqoumx84P3qhj4sJqNEqrbLPOeMJv3r16zh3OufsnM+NwxdnQbbOxCvKQM/BQid1O3SoCCHgtcHXsDasKSPbfvbB04BS8adWjI6HrRNvFGBurYTV4RB03pytU4pWaikSQ6J4Vr4L4pU2C3f4SOeXtuWD5Porbpp4+HF2Pb3A4rEhJu2AK/C+AqWofSRLMtb6PcbyMVyasu/wYe7d/QStq87/sM4YnKWkoe6pSA5fn4Kh6FDNR77x+OGpLzywl3psDpW1qFEMh0PSNEdri0ITfY2ph7j+MmPDY1w5m/G+6y/nhu3Fly5sq09MwmclFIlXwwzcmcG+ybEW+JpQV4BiVMNKf8Cg4sLD8P4T4Qfql/YdiqoZJdKEI6rjq0pH4DYf6faGgWODEejm/Zyqa7pFQStNcXBIvgvi1TCv+OQk/O3lW7JP33L1Tt5+6bmc1zKkq0fJ6iFORwgeCFTek7fHGNSGlZDSd13+Zc9+7n/yCD3FjYfgI1LRU4+sGJ1iVuHaHx4e7Lj7wT08XxqS+TkqlaDRuESjfAWhIldAOSCpVzgjN1xz6Tm8+cLtnDeu79gBvy2VFK+2FJ6a7o5htYIQ0MqC1vT6Q0aeLS8d8fHzHF8xmoa7Dis+sDIoGVUBk7mmCWTwdPKM1Ck0csZIvHpm4Q5N6O8ct/u7l5zzR1OtNl/fs59HDx9F5ZC2xhjUCh88g0FF6hzGZESjOXZswFce3MtE+7Irrz27e0guDkgwEv+Kw/D+Y/D2fb361q89so8fHRviO7P0g0arSFX2yYxDx4gOJUm1il05xAWzXW666iKu2jG+uEXzqTOQgYXi5HBwaKJT0EoT1nzAGIe2GavDEWV44VzRz6OUQsUXVpSOwG0KqmOra82QZOvwdUT5ijxLcLoZ04A0iRGvoml0M4g2Y2Fy5+xNcxNjt3xl9z6+ve8AUSs8Fp22KJWhLEtcbqkw0J5i39JB/nnXHqYmX3ez6dCLRDeDkgPZEozEi1Uwd7jm1m/s+RHf/tHTxO4Wgm2DcdRl3QQiVWHqEbG/TFGt8bpzt/LvLnsNF51R3DsBnzt+QFCIk0FB3c4MY62ClUGFUgajHWuDIWUV+Fk790qpn/g4/rUYsUo1t9IiuBqmjh5bJmiD0pZQ1zgU3SLDGrWoiQMJRuJkmIPb5+B2M5/+r05x8fvG2zl3f/8R0rSLtoo0abPsIytrqxRFQQUk47M8evh57v7eD5l440XvbVm1SyopwUi8yAL8zlLk1gf3P8/9Tx7gWHS4tIXCEn3AGEOWGbRfI6weYYup+JWd23nbJeezvc2f5bBHlmLFKRCMqtRAp9MirPXx3hOIrKytMaxKIPuJ1774Ov6Lg5LWmuOhCJobaVVkbvHoMnE9XIUQSJ2h3crJErVP3m2Lk63rufeCMRY7V5770fHMcPcP9nK0v0gNOGVRacrI1zjrsK7DWtXnm3t/xI6ZCboXb33vvJJxIRKMBACHfPhIT+sb9z63euW/PLKP54cKOzbF6qBEWUeRZahqhBkOqFef48wWvOuqS7n6jFnOzPiLPLBnWksoEidfBKeBVpZBWCaEmjoGVsuKgY/UMPXi1790a03FZsVH6yb8aOg/X/Oh0rBt6Nl2rD+kRhMVxOjJLLQzR6I5INUXJ9uMaXoT6YzBmy7b/pHpqYniH765iycWnyHtzmCcYVRWBO+oQkWnmGBQl3z+Ww8wVeRXds6d+O9nw+9JJU8+uZV2kg2M3vn4Crf80+597HpmiWVSMDkEhfYeXQ1IqjXikQO8tq247foreNt5s184L+fDZyn+s4QicQo9TPqJY3Hr7AQmlkQq0iLnWFmxXHo8dI8QbzseigLkPkBUBqUMKoJRmug9TnGICLOWO4aK8xdL+PGhowSTMahqQqzIjadQNS6yINUXp4oz4Q+2W373uu1jX3j/W17H68+ZRi/9mNB7lpauaCWgVWRt6In5JM+OHJ+7/xEeXhh99Bn4r1LBk09WjE6ipzx/+dSAD929ay/f+dEh4tgsyhXEqMitJreK0dFDDI4u8IadZ/HO6y5h52SyZ4xwzxxaZp2JU4qC2sJit5VNGQ0qBLyCofesVp4RbK9RJ1aNfnqwrG5OCanwE3/moduvYBQV2ARlHMqvktlIYeVGmjj1zMCdkeB2zhZ1+8ZrbukUOV/8/m6sAu89PhjKoCm1Ie3O8MTRw3z+/odoXX/Vx+24XpxHttVO8ps8cTIcgD85arjlgQNH+erDTzLKJyAfx6PRwZOGIWblOWbiMu+69rX81luu5IrJ5HPT8OktaDlkLU45x5s8jrdbOKWIeIwxVCHSW+tTRrbFX+DNWIwRD11Uc1szQL6yNqCsKpxzGKuIMdLKc1p5jlEyPFacembRd7wG3rmj4NPvveGS6j++9UYmyxXC8hG0H9LObdMI1WQMKbj/yef48iOPcTDw8efg96WCEoxOK8/DhxbhPd/f39v2t/d+G9+aIiYd6ipSWEcWKnTvCFvsiPe86Wp+88adi+fnfLoV2bUV/lwqKE7Vd8kJHOjmOYlWeF+hrSGiWV5bY1SzI8DPHiYb9U8EowguQHF8y22pt8Ko9li73twxeIosI08TKbw4pZ0LvzmjuPPGC7b2fuutb+SiuQ5h6SB6uEyRREajEp+0WNU5X3/kSb792HNTz1V8TCp38shW2qvsYD36L4s2ec8Pn199zf/55vc5Uhli0SYEBX5IBsTVJS4+a4a3XbWTS+bzA2PwpXPgg3IbWZzqHCwUzpI7zUpZkbQNyiWs9EcMawiuOXAdIFeRSoE7fs0+rn8E/8K/56Fbw9SRYyuEGNHWELxHhUC3yEkTh4pU8rMhTmU74LezhMeLc8Zv6WaXXz+ZPMTug4sc66+Q5LPYrM0w1jw/PMaXdu2hlbgt3XOn//c4fFFuHL/6ZMXoVaZsWj078Jd9/lvf54nDy9jOBKkzFATy/jHa/SWuP3crt/7ylVwxn++agr/uxupeqZzYIO+0lgqr6BQFtS8JRLCO5bU+ozo0W2Q/RwjheFCyAfISti0uL4M2aK0JviLRilaRkVoOaCVnjMSpbx4+OQt3XLO1+B+3ven13HTJuczbGrV6hLrfw7qUtDvN/sU+//LwPp5YrN7bh8ukciflOSZeLYfh/YdqPvrl7+5mz4GjJJ1pKu/Ro1Va9ZCpZMSbr9jJL190JjMZnylgt63rpWnr5B2D2CgPlMUigbFOTr24ROVrgtb01oaMqkBA50fgtp8XjBRUHroeuiNgeXUA1hJjbM7gGd2MAzHst7AolRcbwTTcNQ13mQ697pUXfnhrtzt1965HeWLpEHZ8FuUcdT7GI88u8Y09T9L+pdd+LGlxYIuS5r0SjDapPlz60JMHt31j16Po7gzWWkxdY9aOcf7cBDddfhWXbZs6sDXjz+aguXVm5VskNo45uH2/4686eUoM9XqTR0W/rBj5cPyafvHSG2lBNUNko6JZZYIT54yqCP2yemF4bIykBorE4jQLstUgNppt8MdpzlPtS8549+zk5M3//P2HefDHC1RpB20tA+W4/7H9zE+OM3n+3Lu3JBKMJBhtQk/Df3vo4PJH77n/IVQ2TuZaDFdXyPBcc8FZXHfhOVw4W3xnxnHnLNwhFRMblVMsToy3p3QMxBgxacbK6irLawMG48nO3LA3aPIYcdY4QqDpY6QiSimMMSe23Eaw/WgPlpZX0bZAKUWoS1odR7fIUb4ZPyXERjMDdyqoLp/PB93rL7/1zLln+NqDe1gcJLgs58hglXu+t5vJ4urr3Y7xvzkffkOqJsFo03gePvTjXv2xrz+0h2eOHCVtz9HvLTFl4fUXn88Nl72WM8f47Dh8cQZktIHY0BLDgVaaTGkViTGCsow89EtPFZnz+qfPGUWaVSPgxMw0D90AeRmgDBGtmsdVoiO5s2TO4ow0dxQb17TiLgzsnEr2FZee+/FukfLlBx7lmaOLtLpjPLvc48sP7Ga8fe2tbib9y+3wu1I1CUabwkLgd767Zy8PPPYjostZOfws587P8qvX/hJX7Jg7tCXjU3INX2yih8rSWCsnMZqq9hiXMvLQ648YRbZ46CqoosLFGAmx6UvU9C+Kx9s8UsNkgGJQBcoqoHKNigGjFUWe0EodCTIORGzwcLS+FaxbDJLXbvvEZLvFvQ/+kL3PHQFn2PPcYf75gR8y++Yr3pca9kvzRwlGG9pheP8KXPfIvqcv++4PdlPHwLB3lKtfcy5vfcM1XDrf+mwX7j1xnkiIzfFQWewUKam1jGqP0RYfNUdXVxkBHjov/TvHzxfBCytGx3sYrQyGzb9jmsPXMdQUzpE7i4UlqbjYDM6APzUZvfFzJ97SbV1xc/Ld3ex9+iBBG3bve5JvbZnpvvmyM28hggycfWXJdf1XyJHAbSPY/vTh5Q/c973vcfjwAqNjR3j9hefxwXfcyJXzrb86H35DQpHYhA+VQStNaGcpoa6br1jHUn+NUWy2yCI4vx6IggK/fuD6JcGoCJD3VlbxQcP6cNlYe9LE4oxFtp7FZrIFPjUG91y6pfjMe264lht2no/p96iHI/7pa/fx5FJ9vfTskmC0YVWBueVhuOnbux7giSeeoJ043nvzr/LBd97w+FkJH9sue8VikzKRXu4cE0WbUHtCCGiXsLi6yqD2J84OxfVAFIhEND6uf65AQQVQw9Sx3ioBvT5oNqIIFFlCZuWavtic4eg8+PevHVOf+PXrLjn0jjdczYSB3vJRPvsPf8/CyH9YqiTBaEMaVX7Hffff/7pdDzzI9rO28b53v4tfu2bnZ2bhDtkjFpuZVSymRjPWbqF8IHgwLuHY6hpr9Yh/dSzIiyioI9gIdmVlDX18tShGUuto5QV5yh6pttissop9Z6b8wbvfcOGn/8Nb38iOLWM8vmc3d3/1SzseL0d/LxV6BZ9hUoKX37Nra3/42BNPfXjvww9z0Xk7eOMb38jZWyY/U3h2zxsJRWLTP1SWEq0osgQVA4SAMpbVUUW/as4YaeiH+MK5IjjewwiCUgTII7gaikFZEbXGoNAhkBtFa72HkVRbbFbTrjmU7evYvW7nmfvHx97yR/fca3h41y5eO7/lls7Fl/7+vDXy/4kEo43hxwee/sR3vvU1LjvvXF7/+l/+UrtofWcb/LH0WxGnAwWVszAzPUGoH0PVFcooVoawUhpqmFJQ18BwNAJqFDXRR7z3DOuKIZyvYbA8hGPDEThDiDUOT9tFZlqp3EgTp4UtTn0KwG2ZXDjv199x3de+8fX3fvdb32Qszf5i/sILJRhJMDr1PXnkyP9cOPgc1151FRdccMFfbe905CyROM1EEqcOtFK7LdHgQ41JUobB0FurqEmnNAxqAKNRETQBrQ3KWJTR+Ga1aHJQwrD2RKXQWmNDTUIkTzQamZEmTh9zxt4+V9jb8xtu3Lt7dssnjh5ZZO/CwlcvnJt7k1RHgtGpra44b/vZD81vO+Mvpl0mowrEaUcR61Sp/e1Wsc1ZTekrrMmJCo6trhBpN1tlEYwxJ26haa2bz6Mm0hy8XhuMGA5LtHVYa6EsSVJLniYnDmgLcTo5I83+VF98Uf/wwvMfMJGeVESC0SnvnC3zH5QqiNPZLPqOHtzQShNaacJqqJtRHlqxvLaGbx487ngYguZQdcSfaPQYafoYrfaHjMoKY1porYk+kKcZ7TyTFSNx2pp3ySfnt22TbbRXiNxKE0K8Eg+WQW403SIjek8INVjH6nBIuf6auN66KBIIIaBCJPqAj1A3wcgtr/WplUKb5oBeCJ6xVkErldUiIYQEIyHEBuFgoWVholtgYsB7D9axuNJnUJ/oao33nrDe3DHGF34Nsdkn660N8VGhlFl/YAU67RbOsmCQbQQhhAQjIcQGYGGxlcBEq0BTNytCxrJ47BgrA6jBlTXUdSDGeOJ8kTKaqBQ1TTBaXhsQosFHIEQSZegWKYnigHSNF0JIMBJCbAjz8MnCUrUz13SpUAGU5tjqgLWypoZmy8z75kGkdfOhLMY44vrJ6rVRSQ3E9YZH1kRyZ5HVIiGEBCMhxIaSWvaPt3IIJTpGjEsZVDXLwybsaMsLh61jpCxLvPeYJvhw5Bgs9VZR2mKcJdQ1qdHMTU1gkXEgQggJRkKIDcQpForEkJpmm0xrjdKOY701RkCIEJRGG9sMiDXNqlEIgQro15EyRKI2aK0xKpJaRWqa7tpSYSGEBCMhxIZhFUvtPCFPLJaI1hZtMw4f7VHT3DyLaJQ1J4KT1po6QAmsDIYMaw+qCUY6VOROk8lWmhBCgpEQYqMxil47TyiyhBgCBoPWlsXlHp5mLlodIkRNQKEwoBVRgQ/QHw4Z1R60QkUIviZNHEUiwUgIIcFICLHxHi6DIrO0sxQqD0FhdEKvP2wOXyvwMRCI1Ou/gl6/oQb9ckQVPEopYoz4uqSVWoqEvjR3FEJIMBJCbCgWFlPn6LQLog8QwBjHYFgzjM0Zo/UpaQCEEPDHexkpKMsaHyJRrT+mfE0rz0gcB2QciBBCgpEQYsMFo8RZOkULFSMGhbMp/eGIwRA8oIzGmOYMUYyREAIhNCNBqro+0ePIoNBK0WkVOFiQFSMhhAQjIcSG4mAhU9BOHAaPVs3Q2EEVWKuaFSOtNcpYtEqIaAJQhkgNlEFRY1DKoHTEqUArMThYUERZMRJCSDASQmwc03BX2/H4RJFh6qrpgE1kuV+ztApYqGKAaIgY0AlV1Ay9Yujh6KDG6wSbOMr+gCRUbOk2K0bTqLukwkIICUZCiA0lVTzVcobEAgSUNQTlWBtCraCOgagAZUBrjE2aPy9hUMZm1Sg0J5EKZxhvZXIjTQghwUgIsTEZQy9PM/IkJYSANgZlNL2VNWoPIR5v/BibWWnWUBFYXoO14Qitm0eUUpFWnjHWLZDzRUIICUZCiA3JwlKeJWSpI/jmWJC2lqMrq9TQ9CgyTYPHEAIhwshHjq6UDMsa61KMUWgV6bRyilRqKoSQYCSE2KAUVHlqKJJm1hmAcgnH+muUAbAOYwwxRqrgqWPAR8PKYMSwDmAtMUYInqmxDomSq/pCCAlGQoiN+4AZ5M7Syh0qeogRZRy9/ohBBWjXdLuOfj1JGbyyrAw9oxgJCuq6JtQV0xPjpLBfttKEEBKMhBAb9QHTzxy0sgxLc47I2IR+WbM6Ao8hhPXXGoNJM/q1Z3VUUUWF0paIh+iZmeiuX9WXFSMhxCvHSgmEEK9gMBqkBor1c0JKRdCGUeUZVFCt3zpTUWGswSaO1dIzqiAoTeIssQ44FWhnCQCG2AMlxRVCvFLPLSGEeMXeeS05Ba08wY8GhKomKs2wjiwtAzbFJilaa7SzDGtPVAlrVc2wDNQBoq9InWWinUkPIyGEBCMhxMaloMos+4vEYI1C6QhaEZRiVIPHEVEEFD4ASjPyTddrVHMoO/pAK3PkrhkzIlUVQkgwEkJsSDNwZ2p5qpVaUq1R62NAIpqVQYlXlqAdPipCgICmX5aMqgDGoEIk1CXj7RZFgvQwEkJIMBJCbGwODmWpbVaMokepZjWotzYkREtUhkhz1ghtGAxrRmWNWe9vVI8GtLMEC4vS9VoIIcFICLGhGVjJnSV1lhACSimiNqz1S8qgUFhiVAQiPioGZcWorFFaowiEqqTIElSgkhUjIYQEIyHEhldkCVni8L7pV6SUoj8qKasatCFEBVHhQ6SsaryPzZZbbK7qdzstDPRm4E6pphBCgpEQYsMy0GvlBXme46uKGJt+RlVZU9aBiCYo3QSkEKjrQEChoiZ4j1Wa6ckpMsM+qaYQQoKREGLjB6PUkica5UvUejAqQ6QOkaibnkRRN7fTqghRAVqBD6Q6MtUqyGGvVFMIIcFICLGhOVgoEvpTrYREeair5pyR0ut9i0CnBr/++5Gv8QpGVUk5GjKVJUxl4KEr1RRCSDASQmz8cKRZ6GQJmQHW56JFmpWhoELTrwhNQBNVcwbJGINT0HaWtpUeRkIICUZCiE0iURzotlskRjfDZNeFl7xOKUWMsQlTxqIidIqcTHoYCSEkGAkhNgMFlYWl8XaLzDkIHhU8qPDTr1Xq+N9Bq0ioSjp5RqpZlOGxQggJRkKIDW8G7rSw2M0yitSgYgDV9DPScGKFSCmFXu+OrUKAqiZWJd0ix0BPmjsKISQYCSE2y4Nm0M4NY1lKDDWE2ASg9RWiGNd/r5sbawqIVYn2nvF2GwM92UoTQkgwEkJsCgZ6LQedIkWHCkWA9Q/dLBg1B65R6AiGCNGTGpjoFDhYkOaOQggJRkKIzfKgGRSWfid1mBjRMaKIL/z5i8KRIqCVwsRAYqCdZzhYkCoKISQYCSE2BQcLieHARDvH6UhqAB8IvumE7b2HEIg+NFtqMaB8RWoU3SKTAgohJBgJITbVg6ZvYSk1YInEUKMIzdYZ6sRZoxdeH9a30jSplav6QggJRkKITWQa7rKwWKSORK8frI6gac4VGaXRx88XKdWsGvmaVuYoEoODQ1JFIYQEIyHEpuFgoZMnpEZDXaNjs22mX3ToGtbPGcUAvqZd5OSuObwtFRRCSDASQmwaBnrtIqeVJsTKr68YBeLxESExNo0diU1voxiYHO+SOA4ZWJEKCiEkGAkhNlcwyjOKPG2moqkmAEUfIMYTjR4Bom/OIE2MdbGKJel6LYSQYCSE2HTBqMg0RZqhjmegEJvbaC8KRi98Hhgb70rhhBASjIQQmzIYraSGxdxoDDUWhQqKGNYHx653w9aADh4Ta9qJRUcG0txRCCHBSAixqczCHS3YNTvZwsaKOCpJrcNai8JgjEVHiFWNoaKbKma6GRk8LtUTQkgwEkJsOgZ6udPoWDe9itadmJVGMy9Nq0jLWXKjsJElqZwQQoKREGJTBqN2K0cr1m+jhZ9o7tjMS4sQPO0iI0sMRstVfSGEBCMhxCY11m6TOEMI9U98vQlIAa01sfa0spTESNdrIYQEIyHEJmWg1ylSijTBh4oYA6jm6r4mNr2NVCRWJe0swzaHsftSOSGEBCMhxGZ84AzaGYy1c+q6IiiPis3MNKUUioCmae44luc4RV9WjIQQEoyEEJs2GOUWukVOXZcnul4bzYmGjyp4LJGxVkFqeEpBLZUTQkgwEkJsxgdO30Evc5oYaogeTTxxAFvFiI4BpwLtzJFq9kvXayGEBCMhxKbkYMHC4ky3A3WJgfXu1zWGiFGRUI7IE8dUp4uK1NLcUQghwUgIsSlNw10WltqpRa3PQ1N6fT7I+iFso6FILInVOMWCVE0IIcFICLFpJXBgvN1CBY8KEc0LI0GsAqcUnTwjcxaD9DASQkgwEkJsYg4WJtstnFHNGSPdnC1SMWKAWJUUWUJiNHK+SAghwUgIsalZWBxrpXTznFBXzTV9pZrhsUBdjsiTBG0ggpOKCSEkGAkhNvNDZ1CkMNHtEn2FPjEWJKBiwNclrSzHGWTFSAghwUgIsekfOv3EUk2MdYi+GSSrlGqGyMaIVZpWkZEl9KS5oxBCgpEQYnOLzXZaN0/QvsLEuN7xOkDwOBXJk6aHkUNupQkhJBgJITaxecUnU3hq6+QY9epRQjUk0ZEQK7QJpC4yO9HBBHqaKHPShBASjIQQm5uDhelOm1RHnApEX+OMRuFppY7CgdMsTKPukmoJISQYCSE2NQuLMxNdWs5BCMQYMVqj6sBYO6NIEmQbTQghwUgIcboEo6WJlmGileNHJRqFjk0Po26WklslzR2FEBKMhBCnzYOn33Ew0cqJVY2JoIMnVEPGs4RCKbmqL4SQYCSEOD0oqAtHNdttoXxNqCs0ERsC48dXjKKsGAkhJBgJIU4DFhZTzf4tUxPEUKIJ6ODJnWa8ldBy7JpXfFIqJYSQYCSE2PTm4PYk8uxUNydWIzQRHWtyZ2iljjxhj1RJCCHBSAhx2jDQ6xYZRWLAlxg8KgzppA4Li1IhIYQEIyHEacMqFluJIbcaE0aoMCIxisQgN9KEEBKMhBCnWTCCpW6RMZZbdDlAVSNaTpNaI8FICCHBSAhx2gWjxW7hmGwVaD/CVEO6WUqROGR4rBBCgpEQ4nQLRkstx56pboHzI0woGStSCueqObhdKiSEkGAkhDhtzMIdiebAVLuNDZ4ET7fIyNJkn1RHCCHBSAhx+gkwXmQ4PFYp2llK7pRc1RdCSDASQpx+lKfKE0OiIkn0pNbgtAyPFUJIMBJCnIZyx97xbkorgZTAZF5QaHZLZYQQEoyEEKcdA71MRRIqUg2FM8zCHVIZIcTJYqUEQoiT+ABaTK2inTgSZWhnqRRFCCHBSAhxetIw6KSO8VaGjYZWaiupihDiJD+XhBDi5JiBO8fz9N7poqDtNIWR80VCCAlGQojTWDdx9063M6bbGYXVD0lFhBAnk2ylCSFO7kMo1ItbJroYFK1E7ZKKCCEkGAkhTlumKnuz3dZiK2/vmktTGQUihJBgJIQ4fU1nxV2jiYkdxrieVEMIcbL9X5wmkH/BJjZsAAAAAElFTkSuQmCC",
-    logotype: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAhYAAAKtCAYAAAB7SidlAAEAAElEQVR42uzdd5xcdb3/8dep08vuzvZN2fSEkAABCWiQIEUpgoIFSeAGNHgDGriAgv4CAvcCXkDACyhRiEIElK70DkEIQoAEkpC6Sbbvzs7u1DNz2vf3x5pAaKIiUr7Px4PHI5vMnF0+Z+c77/lWRQiBJEnSe9nm5y4dqcbPkpWQJOlvUWUJJEl6L13CPbtYUWe0410kqyFJ0t+iyxJIkvRebE9v6UyXZues3tlMGMsI+JGsiiRJ70b2WEiS9J5cqF63NcPDy1cy4PFNWRFJkmSwkCTpH28kdKy2rgKvdw1R0WiVFZEkSQYLSZL+bi49CwE8iHemLSpmAleWRZIkGSwkSfpHOF5ldL8zNK/kMa17yMINxBmSZZEkSQYLSZL+XulC5yJd1XK1RnKJLWixtSB+MIovSyNJkgwWkiT9vQKG2SGE4vaJ8vz+AmERCuKpBiUB6XJ5jqyQJEkyWEiS9L4JV3FKRae+TgkuLvjgBjTKvoungI3aIiskSZIMFpIkvW/xSGqpogba+mHeQBk8Q2Dj0z0AtqLJYCFJkgwWkiT9fRKRxsvTtj93c28vXggUE158ZTUlmCarI0mSDBaSJP3dLE9M7hjowdFdVF2hvacLSyhTZGUkSXo3cktvSZLenanRPdiHpZigqhSLRSrCr5GfSSRJejeydZAk6R31uiwo+zS093QhFLAF9GZzWPLziCRJMlhIkvT38nVCZQG+o+JWVCxhYClhigJ6YYGskCRJMlhIkvS+pH3mONAwWCrj+SoQQOghXCNM1gEBhqySJEkyWEiS9L6kVJba0Nw7OISDjqsY+FoA9CAdfUVcqJZVkiRJBgtJkt43Bxo6+jJ4agBXNXCUAL4WZOO2dirIU04lSZLBQpKkv4MNzV2ZAp4RpuIbVDwdTzXZ1p2mDONlhSRJksFCkqT3zYGG3qESih6i4uv4voavhxmyPHwIyQpJkiSDhSRJ75sN8cGSA0YE19PAM9CMMBVfxQa5rbckSTJYSJL0/nlAwRUoqonwVUBD1cO4ikEFamSFJEmSwUKSpPdtwANHDaKbIfAVKFUwjRBaIErGkvWRJEkGC0mS3qdeWNBfAGGGcF2XUMAARcX3wdcMiq6skSRJMlhIkvQ+ZTyOaU9XsFWdSqWCoaqgKLiuiyNgICdrJEmSDBaSJL1PfUVr9tbBIUqewPUdhFMGFVzXxvIE23oH6fI5W1ZKkiQZLCRJehurkp5TrvTPA+jGPqO/4tBVKFEQLr4icO0iuuYjhIfluWzu6qbkMU1WTpIkGSwkSXp7Q6AA+CEAF72mIBT6CgUsIVB1ge9VUBUfRYUKPtv605R9MUFWTpIkGSwkSXobDWFoijAAbNQWWzfoyWVBVfGFi6YPD4OAj6+o9GYGqQgxWlZOkiQZLCRJehvdrF2iCNUC8CDuqzq5QhFQcT2Brhn4TgUfgadA1rKooMi9LCRJksFCkqR3CReBusUAAnTPE+iqAY4HaghfDYBu4LoVMDQIBciUHdJ4c2TlJEmSwUKSpHflQENPdxrf8UAzMPQQrgf4Poqu4/ngKSol18eVvRaSJMlgIUnSe/F8Ym1btuJ7gKJjGAae54FQ0TUT3wcFDcuq4KHGZcUkSZLBQpKkd+UrhHv6MihaAISKggq+AEVBBXxPoKoGxVIFAbqsmCRJMlhIkvTuFCiUbQwjAAJ830dRFHRVw3MFCAVVC1AoVhBgyIJJkiSDhSRJ78qHkCNUVFUDIYaHQRj+2nM8YHjeRaHsyGAhSZIMFpIkvbcy1Li+gu0IUDR8BEIIFAGKr6CioWomluPhgZxjIUmSDBaSJL2zPphfBspCoeJ4oOioqooQ3vA8CwAUFM2g4g73bsiqSZIkg4UkSe8oW/YPKrlgexAKhcF1qVQq6LqKwEf4Pr4PjlDIlcoo4MiqSZL0ZnJGtyRJO3iaGu9O+3iKgm4YaJqO6gkEPnguoKFqBgKVkutSgumyapIkvZnssZAk6U3Bgvi6TZtwBMMrQXQdTROoKiA8TF1D0TVcFPLlMgWHGbJqkiTJYCFJ0tukYY4NLVu6uhCaOjxhUxEIPFB8fN8FQFFVfCHIlcuUXOgv+/Nk9SRJksFCkqSduFDjCOoH8wWMQPCvu236uK6D59n4ro3j2n99rEKhXKHiQ21QXSKrJ0mSDBaSJO2QhjkuVFc8YQwV8nhCYNs2qgpCeKga6LqGqqr4CvgIinYZ25e1kyRJBgtJkt5CgOFBvOK5lCplfAS+8AgGAijq8BwLXdcBH6GAK3xKdgXb92TxJEmSwUKSpLdzocbyDTwtimqE0QOCQHh4noXnediejWuX0IWDKnwsT1ASGr2wQFZPkiQZLCRJ2okNLZ15SBcjOEoMVy0STbgIXCq2i6KBaUBLMkhA8QjEa1nXl6MbzpTVkyRJBgtJknZwRKV+wGP2q+s68LQ4ZV/Fc0uYpovv24RCIQxdwS4XmDapBkNxKXvw2qZtVKC12y2eIasoSZIMFpIkDVMUUGDT1q34qoLvg6Eo1CWqEI6DoavoKuDaNNaD57u4ikdXfy8qlFRVt2QRJUmSwUKSpL/SMVTI5PL4qoYvBJFAkJa6WnBsPKcCno2u+gR0UBUHTBUbHw/CqmLIYCFJkgwWkiRBf7Fvvo3b4gBDxTJqMIiDT0Co1McAXyBcG98ug1smEYJAUEUNaQxVSlQAx/HqZSUlSZLBQpIkaiN1iwWa4QAVNLRQECEEuucRUsBQQEOg+DaulcMANMXF1wRZqwiA7SstspKSJMlgIUkSAAqaYwFCD+CqYBgaMdMk6IPu+xgK6BrglfF9CAY0POHiaSoW4Cu6PD5dkiQZLCRJGuZCdcEFB5WK4xAIGtSEI4QEKJ6L4nuYOhi6gg7UJqPYnosWCNLV71D2GS+rKEmSDBaSJAFQhgk5CyKJaiLRMKVchrpEFMMDzfMpl4rgexiaIKKCoboEdB3dCNCby1MWjO/PF+VhZJIkyWAhSZ923WLwjJxXnrGpvUiuZGFZRfDK1MTChDRQfQ/V99ANjUrFQgcmjx2HNZBhKFfguRUrGSy7DRVFjJbVlCRJBgtJ+pRzhVtT8Xw2bunAVzRwKwi7SGMqSUABbBtF+Oi6juc6uB6MaU6C7WJqAboyQ1Q0DWFohqymJEkyWEjSp5SVS88B8FTirvBp6+hG0QxMQ8Ur5airiSI8cO0SpmHgeDaqqaH6EFDA1IMEzRChRBLHVKiossdCkiQZLCTpU0tRhQHg+X687Hp09PTi+gJDuFDKEw+D8HxUIQgEDErlMoZhEDRAqUBENShli+Qsm7ICRd+ZIasqSZIMFpL0KScUdA+BZdtomoZTLmGayvAW3r5DwNDQFZWKY4Oq4A9vuknUCONaDj3pDEoQfF0Ny2pKkiSDhSR9SinKcI+FoiiuUFQU3QBVQ3gOo0Y0oQGKCpqi4jgOiqbiI3BtCGiQDMcJ6CbFio0lQNWMkqyqJEkyWEjSp/XFr6olgDLa+KKrUvF0bNslpKiMa27CBBTVQ6BSqXgYegAhBIYJugrRYADF06gIhW19Fg6iodcfWCArK0kyWEgfA5lS74KBv062k6QPghFKLQXwqQk9+1obwWQ9bllA3uILe+1Oxc4S0BVUw6DiKlglF101QBGEdahNJIiGY2iBBA8//iweZrxerblWVlaSZLCQPuK6B7dcXR2uv7YmPvxGIEkfJAum9A6V8IWGIiAgVBIGhDUN33MRvoKqmKjoKAIU4WAAIcNA9RQUDHIlB4RGGkuGX0mSwUL6qGusGn3q9j/39qUXAPTmi7LLWfpA2GD09qdRFAUV0IRHPAxBTUc4Lr7vo6oqigAdBcX1CQJh0xjeOEvTKOQKKOD4HnICp/SB6OjqPL8/PbRjN9e07c3Zkhm8Wlbmo0+XJfgYvdA6u89vaW48L10uzKmPRWWXs/RPS2PN8QgxOJRH1WrxXBe8ChEdQpgIr4jwPBACFVCFguL7BICQoSJ8l0DApFJy0BRyPoo8jEz6QLQ0NZ8H0Je15qPr1EWMxanqKtlrK3sspA/Clp781a+sb9+sJ2IZgFQwKl9c0gdCoBkCKNkemq4gfBtNeBiAiVpShYLwfPB88BQUAZoAEwhqCopnEzRMQMWHkKeocVlV6YNUlwgtrosYi9e0dTwtqyGDhfQBGd0QO/Wl119vXbNt25WbiwPXy4pIHxQfI2QBrlDRNA0Vj0TYQAcUcHVVA8BDIIRAeD6a8NGhFDJUNLzhYRJVx4awpygyWEgfiLUbtz2+/c9P/OUV0dXROWt9W/vd6UJJzuORwUL6Z3WWWDR5j+k89fIrLH9904mrBgdW99j2wn7LkqdJSv8UB6W+4IGr6gghMFVBfU2C4UM/XDRNQ9FUBICq4bouivBRwQqbKpri43keqBp5G2yhNsuqSh+E6taRtwMsffAJ8fyKlxg/fuKVVYnkPaloWPbYymAh/bNMze2oTVXdss/nPs/DT7/AxnRhStY0D/JCIfnpUPqnuFBTtMEXBkJ4aKpHTTKECQhcHVVBKAqoCkJVhkOE4qPDgGmyI1h4aBQdcBS1QVZV+kelYc4r2fLmTXBjQWPmBbfdJZ5Z+TJ77z+LUQ3J02urY0tklWSwkD4AtQF9ybig8a3Whub79jvgCH665A88uqn3sBeGsle+5FndnViLtg12Xbr98T257jNk1aT3o+h5MzZsHiAUTVDIZ7EKg+y1x67YAgIEtgBYTgU9GMIwg3jCx1AVdMjU1sTI59P4ikqitp7f330vZZTxsqrSm9lez8K817lokN4FAN3Z3ndsn/p9e97mbPqGbCLY+lhn39wf/Xbp3CfXvUa4uZbGsaMfTtueHAKRwUL6oBSyffMBagLcOr51JPG6Bq787U0sb+8gr4UaNgzmLhhZ1XQWQG+mb0FQ6BmA/r7ORbJ60nv2WKhqdc9AFqvioikKEVMhYgpMxUfFt4QQeELBQ+AJHyEEoWCACow2dYGmgS8Eg/k8XZkc+bLT0g9yiE56I1ho+oCvmR1V1F8L0Jiovxwg3zV09vbHdFj++UOqeaiTSBkvdXRzwz13snzNa/jBAEcf+w3KtjU+ZWpyCEQGC+mDEk3ULQZIwdKWOIv33n1XItVJbl+2nEW33Eauqp7X4MWt+fwV9dV11yYTtUsAauuaL3zbp4JSTjb60g6KorgdPf0UKy6eY+GWC0RDOkHU9QrCARAK+AwHDCEEugoeVjweVlF8G0VRsF3IWRU8zcADOUT3KVfmjV2Co6SWJqjdMYRR7OtZCBBrSl6S6R1asK3gX1oKqdNfzrvHPNs+wHW/+z1d3b2owI/P/AEJzVxhKH6vrKoMFtK/6obZovS53SaR6+9mw9YO2gZL/PwP9/NiX34GsdjffH5tOL6kX5Tm9SMnfkrgQH17dy++UEB4uJUCYUPBwOlV8SwVBVVVQVGGg4hQccoWQdQNURUc28LzPBRVp1hxERoIuT/Op5pF/zyf4QPu3kmkruGq7X+urk9e60bV6i2CI6+980Eu/uVvqZQqBByP//nBDwl7Ln6lENolktxHVlYGC+lfRPfzmbGJ4O1nHj+HcbWN+LbGK23dXH//0zy2KXPaK0U2bypwI8DrXdmH3vr8PntoviJcp5aQnAT1KZfGmpMrWjX96SE0zcDUFSJBg4DqoeNlVLySioKuaqiKgioUNBTwfILoGxQgGjRACBzHI1coUvHAR+6++ekOq261917BI12YA9Dt2Ge8WK5kNwhOvO3Pa9hW8FEDCdR8mbOOO56ZNVU3jNP0U6YForvs6O2o9MsPRB+H9ylZgo+P/mJ6nhYwcpXCYOtnJrTmTj/2m/GbHnySbXaezT1D/PT2B5naVNd62Gemt2Zbaw8yahK96yxxbyygPNOkcglAnZlcLCspAaQILfWFdZOPCupwj0VNIoapgo434KHENTQUZXgIBF+gohDUNXRERsFh6qRJvJwLMZgvgmJQsQXCVGS78ikWp/Hy9/r3UCq6tB0uGjLMQ5/c3B7/8+ubeWljOyURpLm2npOOPIi9x7asrwzmW3XhZKiuxrL654VCtUs0TdZXBgvpA2Hl++aXPKfeC4ZyjmrWR6KhFTFYtkdN/LTYgQfwqz8+Qpdvkq9u4J6+Dp668SYO3HV8w9yvHNEwOqRYNrT0w7xakL0U0k58BTRDx3U8TE1h8sSxhAwVEzpslBYFwPPxXQ/x17NCVB9UvJKJxozp03h1WTuaohMORujq6sGb0CjnWEjvqNsVZ+R0ZfaKfuewGx99mpc3t1Pxob62Dqe/n9O/ewxTAjiBUmnLpKrYIQClwc5F4ajZkS9tvSIQjqyQVfzok0MhHwOhWN3immTzhQ3B6qs0Rc9pwssp4I4KctrMUdFbTjj8YNRKgd5MH14kitcwgode38L3L/s5qyxmvtwzeMqAI77ZVyjN335NIY9g/9TrdAuL8oUSlutT9hyqYwn23mN3QorZYWJ26ugZxVfw/Aqeb4HvoAhwbBUVw4qiLB9TX0Uhn8b2bFzN5NX12yjD+LRbkb9fEgAFZ3j4Youwrt7q+ZfdtmLLYT+48gY25CCnxjBCUYIILj3zBEYakDK4aVIifMj254ermi/EqF0SC4863fHffe6GJIOF9A9qUoxLRiraWSPhLNV3rRCsHT8qwtcP2oNoei0jjQquFqOUHMVguJFT/vdqXsuX6deUgwuuvjeA25NdqPyNI9idggwen3QeIp61LLygiRIK4dsV6qMmYaGvrENfHMJY4zk+vm7jKgWggIqP7cXQUQeqEbc3GS6aKKDFTPJqmA19FhVoTemBpSW7f17F7psvK/3p1uMpB929+TXRRvCUhzd0cvszq4iP3JXO3gJhM0TId2g2bHYJ0TZa828YAye927Uiaq3sdZXBQvpXqlP1xRrkmlRu2meXMcz74n4Ut2wkrAaxnQA5PcxQMMLlv7uF6+9+hIpptgLoDYmr/ta1jWhKrhn/hFN00xnMZfFUDc0wcWyL2hgY0AtQC0tUBEJzEZoDioOigKIqKOA2ol9eHdA7dNXDRVB0NToGChRhSjfeGQinXvWdelnpT68N5dJtTjDV4DdO5ofX3spvnniZrV6YTUMWgWgS3XGJ2kW+MHUc1cK+Y4yuniSrJoOF9O++gaJs6TAwwtRWfvmze7JrcxNOex8JLUg8VYNZW49WXc8jf3mZO5e9PLsbztiW5VKAPpj/5s2MBtNyQ61PVbBAdyq2SzgUAt/DsUroCug6mR2PUQUaYvjsUobnZDj+8DJVgEAg1KapKrqiY5gBCqXKXx+poetmh6prOVnpT2mosIu35YLh2a9azP7v39zPC50eW/1q/JYJUNsAQR2TMhOTIfabPLIUsjMdFXd4d05JBgvp39lroQQXu1ahJgBb6mH5Nw86kJaITl1QY6g3Q6Uvj1BrCDdMYulTz3Pd42sv64sz/1V4JQsHDdrFI9cXM3cDVKXevqGW9Mll+c4U24dAIAC+i46HBqgqpTce5aEMH0EGDG+WNfy3w5tgqQqWpqggBJFIbLjnwwcBhqmlloJqyUp/uvSJofmvu0MPDZiRY57alK75r5/eSJeTRG2YQqR5ErlSGVdxKA10Ma4mwmEzd2eveCJiuJXRbtmaIiv48SdXhXwCjA1Fj++FBUM2h+42Osk3vrw3v77vCSIijqM1UMmbpPHREiqLX3yBv+Tb4l/5/IzpeyfrjahpLh9jRmT346eQp+jxYsXFcSqEAxEMDaLQo+Hntn/mEHioAvAFvlAQKKg6KOAAaAq5RCRKZ7FMMFCF0HTyFpQjjAdwfZArBD89ujzr7E1l+2InUsfvHnmeO59YSaB+KiWzBlUPUq44YOcRhU7GhB32n9TC5yaNeRggGRl1uqyg7LGQ/o0K/dsuffPX9XBt0LY3hB1/5aypzUxrSZJ0PRqCVSTizQwJExqayVdV8Zfebn7z6BM8sO71KUMYh3aCHAL5FAoo+hbbFSgC4kGDqK7iQVxneCgkjTNHFaCioPkqMNxd4Yk3NsHSITOyqR48C1/YoKhYDvgQAgiYdXLflE+RshYa/3pB45zrf88tT64i0DCZ3qKKTRC3VMZ0SoTKgyRzvRy5+0QOmTaBSdHgIbJyMlhIHwGaZvS89e9GRc3TazT11mqvsuI7hx3I1FSSvi0b6B7qINlaT86vUFFUPC3G+s4iNz+1hrtW9jZk4OgeWNhr2TvGNzNyh7tPPAsm5yoehqZRyecYP6oFHKhFXQLD4UFRNHRUVDQURQNNxRXOjuAgQB/ZnEKjgufboClki1DxaJUV/nTpg/lrBr0Tf//ndfxlXRa1ZiKWWg1GnEq+QNSEULaHWMd6ZlUHOXLqWGYmQoqsnAwW0kdEqPqdd7drMrhkqhbYc9dk8MrLvjt7eUPYo6E5zNC2VZhhHdeBYl5FMRvp8eL8/tk1XPnAhunLe7nSCZk7ZvB7ojK6z83stFTQ7q3IiVWfIB1D9qz+oQK+75Pp72avaVOoMrjnzc2DgoouDHRhoGCAoqEboILV5xSHT92NB1E9C88p4AmbvoEMmZw7U1b44y9tOW9bdi6svvl++Y1lxFsr3hUb4eaVae+6O55YwQsbB0hN35+iH6Ho6dQ2NROKBoiKMoW2tew3uoUFR3yJz9YllXR2QC5rl8FC+rgYBacn4OGTjp5FJbOGWGOQYrqbqBYi6Cbx7DhFtZptjs7tq9Zyw9N/4S+d9rntcNH6TPvdtcGW8+r06p26sc36wLWysp+gF3/YJGc5qKqKX7Zoqa9GAXfHGwiarmkB3IqPoQXQVBNfAUUTuDjV4GPg9dYlAvhWBtP0cYTN2g2bCEX1XI9jLZRV/nhLhYydlp3ns9suxVAcNTg8xLW5VLo+b2iz1g9x7B+eXMGyNR1UvAjp/jKJmgYUXWOo0E910iTXs5XpIxr5wu67M6EuNXxic6JGLmuXwUL6OAnChgOnNnLiQTOgeyMRz0UTBpoaxaoY2K6GCEbIGQH+9OIr/HTpvTz2+uA5evWIgU7fXtRrWbKH4hPMASxXQXguIUMlrAqCsOGNYIHho6IIHdXX/9pcqPjCBVzqjNhiDSUXC6pofhldcRDCY+2GjRQqxFXNtADSti0/lX5CxBIjzxryFQdg5WB2nRMO169JM+OCX/6eO597lbwaIxJrABdc30FQxsn34A52ELQG2HfqePaeNqIjFmKZrKYMFtLH8dMGLN1bRzlm0ggOG9tCpGxjKAH0SBW2p5IwA9jpNDgVEmMmszoPP7vzz9z41KYT16S5wAmF6rsrnLH9el3lvrNlVT85yh4MFi1c1yWkKwRVBR0Gtv/78DwKFc1XUT0V4WsIQFV9VDxruAHxrJihovolhO8gFOjpHcBXQVW1EoDjuXKTrI+pocLw3jaWGB766HIHz3bMVPiOjduEW5WouX+jfdipP/01r+cUzOaJ5AlgVTwikTCCMvGEQlAZIt+xis9PbeHwz00kaLLBFrT02bbclVUGC+njKF/edulICud895D9mFITwxscwLHKpFJ15NIZTDMMRpBssUxs5ATWFQS/fvxFbnxmFZt9zs0GOHhdyb4XwFS1DlnRTw5bQMFyUYFIwCCkC4aXmr7RYwE+qlBQPAUhhpsM3dDQ0QYAPLscNxWfmKGj+t7wSaiahiPAhhYARVFcWe2PYdth9803wmYHQEEoTifFRZ5eFX/N4rrouJGcd/PymguX3ElgxBTcZBNZxcRMpBBCUM5lMIRF0B1CH2xnYkLl1K8fRH2A5eXc4HjHLtYr+vCS5XRxSPZofcLIfSw+wVyvf56uVkbXGEJvMuqUr+45RfTd/wplQ6Ng+wTMKPniAGpVDMPQ6MlkqBoxAj8g+GNbNy/86gEO3KX14K/tOpGJQMqU46GfJJYDZccnHDWorU4QNjRSqEvfCBaeriigIFCEGN52E/BdB1XTLABdaANRXWFUYyNtZRVF0fGERv8gVAK0ooOqyk2yPo5if10qvNXLXOFq1TUdlj2313L489p2lq3cyOaBMna0HkcNoMSC2JUKmgqBoEbIVfCy3Qg7zRenjuLoz+7OpCDnqF7JIqGCZ+PZlTjBavBkrWWwkD4+N1erXeKrpWkmqpWp9C44aPLohzND+sHXPLwCUTea6voaDCtAJt1JxfcxQnGEGaS7XCDaPJqSWmbJg0+z5pnnOeurh4svTaiRS8M+IdIwp7O3gic0fNdj1MhmdLyBnbezckFRUQX4vsD3fRQhqFQqEAgDUB8IX9sF50ybNKWla1UPllDwhUJPbz9qS20JoM4MyL0sPkaGSj0LXQNSRsNVG73czRWtunVDtjjzL+u7uW/ZS2zsLaAlGxCRGlw0PEXDcWyE76Hq4JZyJFSHYl8Hh3x2Gt8+bCbjNE4rF3rGj442nAow4PXPE77qAKTiSfmB5RNGDoV8wpnKqNNhxI+qA/XXTjI55Ki9W9bP3n0M6c5VdGe34pkeIS1EMliFU6gwNDiEkkyghqK0bx2gdeKerMv6nPObW3nWQayyvNVp2NF1mXX75w2Ue+Ts/48ZF2o2bmoDXcOyLMaMHokiPOfNjxG4Bngowoe/ngAC4AsXDXXHkIkJHZMnTEZXNITQ0M0Q6YHBnVaYSB8fyXDDVX2ZzNEb3OxtBS0+87W8P/Omp17lD8+tZVVvmdCIiYhQkrIvMEwNzy0jnBJGQCXX3wGVDMXujRwwrpX5B85kgsbJVPKMjjacmnN6FhbdvvkhRXFSYdkDKnsspE+EWlhy4PTWiwdFgafbOvF1QTQcppC1icSqKeIiikVyxRyxcBUb13fSWD+KfGmQ71z6Wy7/0QlTXJ9LC4o1M6RYa1TFDbkqpMvpOang8ImomfTAnOqUbDQ+6rb19aPoQZzSEC0NDRjC6n3r5w5NUdBw8YSLQAHFRdUMFPQdIUSDXHOyGiEErvAxAib9uTyOQz2GrPPHTVcpfXa0fvzzG4bKZ/YIm0XX3ERGiZB1VKrGTKRYdvF8F0NX8OwSKgq6ruE5NlXREIF8likjazj5qwcRLFk9deHQYgIxKl56TtxouEpWWPZYSJ8wTUEu+fyI6D1nfXkfxmsWymA7jihBLIirBKAioOJANouWL1EViTGQreDE6+lQqznhgqU89Hp3w1ZbO6XXcU5xNNNoNBsv3x4qhvrS82Wo+OhTwLGEQdHVUT2F0bUQNli186eO0IAhDHTfQ/GLKBQQmounaZTRJmx/XMRmRW0AMtkByqagpGp0DWR3WmECUPA7FznI0ys/aoq9+Z3uSUlPTVvbq57ZJ2Jc/Os7aMu72KEY4VQdFaeC5pcJUkF18gg7SzQg8CtFVNtByReoKQ/xzf33ZHINl5kUOwHKlf55AS211K3I3k0ZLKRPpAlBjhof4JpD95hEkhKOlUaoDhWrAAICQkGpeFQKJTIDORpHjqNICD/eyFCwmp/f/Si/fvhZhoy6KXmqP7e2lH282yqdAZD868Y30kc+WLj5sotqBgkoGiEVVN/faZKlAENVFFRFoPoOvnBAcXE8f8ex6QAjTH4UVekxNAUtqOMbKoVyGdej5s3X8xW32scPyep/tETqY9cCtBcyF3XCom7BsTc9sYLT/3cxnWUwU424RgjbUxG+iuKpmJoJroedzeNYZXAdqqNhTOFwxH77stuohpJj+/VTU6k9uwe2XhEM1C4pZjberAdkj4UMFtInVhSWH7j3DPaZPIak4eLke0DkQJQJuWA6CmY4SmrkaNa3dZG3BAXbJdrUjJVq4Y5XtvGD/7uLlf0cJsyEbpjhXlnVjw8fQoVCgZBhEFQ9goAi2GmOhQdxFAVUBVf4CM9HFcOTOTWU3Jsfq0HO9xwUz8MwDHIli2KFGTsFFaG4AiEHRz4K0jtvpb3eKt5djFbPWO9zwb3rBnlsawcDgSCiOoHtOQihsMukadglFbscoFw0MdQaklUjCaphdF+lbBVpHdHEgfvvQiysPTPWVI/vq5TmN9aMOr2U7zg/Uj3uW7LwMlhIn2ApWNoaVm/58n6fYZfmKtRSH5GgR8iEoY5+IsEqjFiYrqF+UH1qGmrRDZVMJocer8cy6lg3FOAn197BK+32rKzGwat7C8/1e8jDyz4GSjDN8Vw04RJUfILgGKrW+9YeC0UBVVURQiCGN7JAURRUFOstDYkVNQNovo9pmliVMkMle8pbmpsSyKWnH40G4I3hyk2Od6MbilT3wcFPrGnnnudexKuqgUQV2aJFdV0De+y6Gyufe5F4KImmx1GMJI4axVOC+L5K2DTwCgPM2nMXkgYDQdjQL5in+l4JIBxrOU8WXQYL6VPRa+E/v1tVZNmsXVqYNjJB0B8koHvUjZhEJmfjh1SIO4Sag/R0rmXfPXejJpRg4LUt4MdwQyOxkuM557pb+dUTq+daqeiUIdU5tAdfjqN+1D+w2sxVdRM8m5qwhu4xoCvqjjkRabcyR4DuK+D/NVAIMXzEuu95CMROE791yIyqryWgKmh/3SCrL1cg7b2xggihuELIYPHvYtE/r0R6x/3oKnP2FoerHUOr77KZ9ac/v8JDy1+goz+D4+u4lkMoXsXMPT7D6y+9glK2USs2vqoiwlHcUIy80LB9j4DqMqEpSnNcoJRxDE/0lnPZ8alQbGlv37ZLZfVlsJA+YbJe74K83fe27XMbUK8KU1r1uUkjOOKz00moBdxCH6FoAAIG8fpqIqkYljMEhsdzTzzJbhMmMvOzn0ND4GseHbkBCpEEdz77Er/408PxV/sHjxlEPbIf2XPxUdVhOedv6S4auq7jlwu0NtRgenRqPjuGN1J6YKmPH/YEw8MgQgAKvu8P92Dg7zSkIWz0sU3NOMUieD4YJt2ZQSrKG8enq0IfUDzFkXfg30NBGC5eHIaPOC8HGW8btKzs4+A/PLGW2598mVc39RI0Q1Sygxz0xS+y794zeeihB9AMleraKIXSAIbuUlUVQSg+VArEwhpYGfZqTbFHS5jGIJcZvt07IpH4EUB93cizCtk+uX23DBbSJ4mugWaopXf6t5A11DFGC1z2uUmjmD1tHDGtyNY1y4g3hdmybQupmgaCZgBdVVAqNsseepBp4+Icfeg+RAL9BCI5vJBCtwf3r9rM/97yEA++1j67Bxb2+bxjY9IvZOj4sJXt9By3NNy4l1Cnr93SiSd8hFthSmsLYY2VKdPc0T3e79vzBOi26+G6Lj4CfIHnuJi68bYeC1VgjRvRglss4jgOimnSPZil5DOtz3PmAyiKlgvqtUvk3fg3NfYemMKakmfL1Ra9k3sq7omPbqkcefNTG/nji920l1IowRaqzSCH7DGdxkCAjatexXNKWAEHvdZAT/hMGlNPx+oX0EqDVMVNuje/xtTR1Rx/wB5MUDi5ES6vC+68KVo0UScndctgIX2SRKi/Nqyk3nEJaFh48SC5DU2qeOIbB+zLlKYEerBArm0l8WCMres6+exnPkdQ17BzaWpqw/zmpltpadY4/Ev7EtJLmEoF3Qww4Bhsygt+ff8ynt1Smt425F/XV945XHRWyotcxauWd+XD5Qu3xvMqowHKaOPbevsp2w64FVobU0Q0Vrz1OR4i7voeru8hfAUhhnff1DQDHz+80++YwYoxTbWYKDiOA7rOgFWmAq2u8KsBolpKLkP+kJTs/reFd1OrW1wWgbZBz60uoM98ZsMGrr7lDp5Zu5khP0Soupn6plG0jhzBjF1H8PiD97F143pSI1pwfJfedDdfOvIgNrWtIhr1sPLbGOxYw57jGzn92C+id3eV6kAGCEkGi0+zytDWK2Kh0BqjVGxOIW4KF4qc8tXDmNkSgoGtBEsqQSfOMw89x66TpqBXq6StLpSEyS9vup2aWIQffPtbTG+qpUr1cBzIalHabI1zb7iFxzZuZfVg/rresrNjnXxzIHhhI9rlsvofLs/3Q4ap5QCKPlN6BnMIIQgaGg01Cerh2jc/vlY1lwiEoRk6mqbh+z6GqqEpCr7jEsHcKYiMUPmR4YNilwkHQxTKFTa2d5FzmeHgy9NNP+z7rShOujw8nyJt23O6yuWze4W7YE2/c9k2UXPs0mdfnXn1bQ/SbcOgZREK6/jWIImwyt77Tebnv/kNZb1CMGGQ3rQer6eX75/8VR575CHKaglCZVSln4mNJmd+7VCm6Fy2V3NTRFZeksHiUy4QiqyoZPOzqsIt59USXNISCV05Kqj2nHrkIexSm8DI5vCGSviWRyQSIxDQ0AOgaRqlQYtbbriDYj8cd/T+jB3RTF19LY7vYUaj+NE4/7v091z/0JO0ueo1b94G/N0UnP55RTctTzr8V9BUS1WH5zc4KgxaDj4+uuoTUMU7PkUgdCEEQlFQFAVQUXwV/Hd+fAAfzXVxnQq+qrGtrx8RAKGpconph8zxheE4Tv2WwZ6rU6a5tLNQWbSpol0zEB/Jol//iV/e+Rxm9SjKrk/QtPGKXRxywB4cfsRUVm9qp+Q7pIf68EWZeDLJD848gaXXPUAxkycYNLCsfpqqfL5zzGwmJPWOkXCWrLokg4UEgdRSxx4eKx8a6lk4SlNPb9a4cL/mmjO/+8UDCed6SBkeqi94fe1Gvv3t46iKxvGHLBoiTWS74bpf3M2fHniVbx27HwtP/jI1Zpns1jVoVGieOo1lHQPcuPw11nrctMX3r36vHydq1C6J6LK7/F9B6KoltOEVGRUFhooWQoFgwCBkGqW/1Uz8dYkp2l9DhoeIv/VRhu8RUMFxHFTNoL1/AEcBRUFO2PyQVQdqlzTGGi8PRWvWvFSwunOxRPip7gLf/8VtrBiIkNVHkc64OIP9NEctTjl+fw7Yp4pyyebBJx/FiMUJRkLUJuP88JSvsu4vHRi2IOjpZPv6iBtw1P6fYdbIZifkZNcApPssOUFTAuRZIZ96wUjsGSvTucjUzA6AepVrOzP5Rd/83Pi5rpm66Zp7niDjGOQyOiue38S3vvIV2l/v497b7qemuoVcbpBVG9vYsqSL2bNn86NT57Jp7VZefuU12jMFBksOj65az4YtbXzlM1NO2W+XUTNrFO8Ww/Z7UUMgNDyfeH1o56546YOT9vJzUlrdYo/+eRpQciBXLqOYUSJBEzNAx9/+BDI8DCIEmLqOhxd/a/OhI2isqWGo7CMUhYqAgSKMjBCXd+HDtXVw8AolWuX2ucb8l3oG4ksfuZvVfUUsEcZ3Q1SF4kxoTrDboTOZvvtISm6Fx556nudfWY0mVMq5EnvvtTt777k7jz++ipdefJXBvjwN9XW0Vtdw+Od3ZfaUBqIUl8dD6hNdxaGzzWSyQ1ZeksFCQo/ULrGc3gWxxBuz9cNquaOK2NKDdq86pXnMV2de9oeXWLmtj5XLN1HpLfG9ubsyreU/+O3v72LILrKxt59IKYZ13xPsNm4kX/nCZA7eYxR/emQdy1asomQJ/jLQzeqerVQ9VJnxs7N+MCMSLFOPdvt4+Jq8Cx8OjdolfXjzezI2JdsB3yEYDKAo73wK6fbdNXdsjuUP/6eq4OHE3tp8hA2VXSdPYs2LbZRtl3CimraOXnadGK+R1f+QPzBUVW24Y+XWa259ZjnL1q+nccwEAmYQBgaJ2oMce/QR7LbXSAJhePjVV7nvqT/T0e+QjNYSU+GEY79JUwPces9TvLRpI5ZvM/kzExlav5Hzjp7PmCDrp6tMXN+/9W69ti7jRYKxrkLxnJQZkT2OkhwKkSCWrN+pt6AqORwyIvbQitYouSP2mUxKB6/k8crK1/nFrx+ndQzMPf5LjJ9QQ3VNglg0STZvc+8DT/L8XzZgAofPnsj8rx+F6RRxyhWKepBMMMUx5/43j23upweOWZFz0m9dOSJ9sHxF3bGCw0Y0b9q6DccTuK5NMBjE8965R0FFtRTljdUgvs+OgKGgvC2MxML68l2n7oLneVRsl2A0xuZt7fh48nyQD9G2Mpe+2FG45jePPcWyzVtJTdkVMxYl17ON3RqrWHzhKRz/+ZHLwkFYubmHR595ib5Bh3AoQVg32WPcBKaOgqeeWM2fH3kUI2Ri6IKuDS9z0uGfZ+8GzpmeZCLAhNpRR9URWlxyCtOTUfP+PoR8LUsyWEhvVyoNT6AcHUmeGiv3LTtoWoipLRrBgIcXNthWzvPE69tobA5yyP5TGJUIkevpo6srjVk/ghsffoKtRahUYPcxBicf+XkmJoO4AyXwkhhVu/CTq2/nij88yWDQqLGCTJZV/9dRlDc2pXIRNVvb21F1DYBoNIpQ3rnncnuwABXP8xCej+IreJ6Hjj7w1scHNNpGNg9nGCEEPgp96X4AhoSclPuvlPaZ02k7i9ZY7tMdCmf+/J4HaLMs1KoYqnDY+vKzHPmZqZx/yrcI+2UGPGa1Z+HG+16gJxdH1eqJCSi1r+dLs/Zg9Zp+nlr1IsHxY8j19TMiFOSYqRP5ytTWnia45K3ff6xRdfxIjLPqUORyU0kGC+ntwuHUUivfs9Ar9iycmKw7PGxbKz+/91gqdh++WqFzcIClt99FPpdlSvNovnfcV6nWVYyQTsmzqGgq51x4Mds6u4mCs+9uYzjm4M8xOhlnYFsPql5F9cjpLFuzhUuW3MGyTV2nbYGreyuVBelcTr4BfcBqlfCSN4KFVt03VEQ1g5i6TjRkEtDY8i6Ng6Wi7BgKEcID4SGEwER/23i6BvmoCQYCTTMouS45y8FFr3Hsnfe9kD7AUOEwpwKtGaEc3eH6s376+3t5qbeHdClHdSRA5rVVnDvvRE7+ypcRto1ZFeTRlRv4xe/vY1t/AUMPE1NNTCvHojNOJRKBG26+GRHU8IWN6VaoLuU55+uH37RHxGyUFZdksJD+IaFYw1Waozi5wZ6FVaHgPdOntBKNVwgnBQgFp2ByzX/fRAqNWuB//mse9XEHU8+gGTbZYpn/vfI3LH89Z6gK7Lf3VC754UnEnCzuUA7h6wyVdZ5f186v/vQIyzZ3nVJQAzNFMGZs6eu/Wt6Bfw0btWVjVxphRMB1qQ5qmDjvOOnOgB7VA1QF3dRQhIemeKi8y6oQvJ4wEPA8vIpNIJGkrT+DIKgrargkq//P6bfFO+5YO5ArfzPrc1CHrUz/0S8X8/C6VQzqDk2N1cQLWW496xwOaxnrjApzpRo2+c2KTVzz5HLWpjPEkxHI9pK0Bzn3e99mYnOU59f3UgzGGCrmGddQTYta5qenfAcjXZInGEsyWEj/5JtQ2amPVzVc5eZzNTGvzPn/dTJaIU1AU9B8HaEkuOE3z2FXIKjD9078FkldUMnnaRk5lrJZzW/vfoQXX+8gCKVqBEsvO4cqq4filtU0V8eIVdWwteDx42t/xw2PvzR3fZEbRtfVnrqxr//mt/48Q3nZnf7PEmBUfA0PBd+20XwbBdd5tx4L5a9bVvjKcGOhCFARw1d6Cx0/Y0JPdSSEqWuUXY+hkoXlMkVgyr0s/tmeJ1NZkra9Ha+Bbf25SwHK4eD4Py1fNev7/30JmwfyuGqAWCBEqJTjukWns++o8JmjqznVgfpX2m2WPvgUAxWfgKkS9YvUeDn+33dPoDYcpOLDY8ueJRSNETN0NvxlORed9n1agoF7RqbCcq8KSQYL6Z9jNrScZw2m54yOJU5tCZiLpwRVTjxofxJehVDIIIPP/a+8xAMrNmMkYFJjkK/tfxB1ehKrqEJdEysHcjz63OtYLuG4cFdODHDD0vPm8vXdYpTWP0e1adCerlCqncwNr7Rzyi9v5lWfV+LVtU92l7wz3vzzJGNyj4t/Rp+w5wOoGmiaAq6Doelo6Pl3erwC7vBcTfG2pkIgjHcKIhrkXKeCwvDx6UYghFAxFE2Xe1l8AFKmthQgDXMKtdG9HxrKizteeWXC9Q89SkaY2K7J6Fgjk4JJrvze90k4TkkBt6gz48lt7rEXLL6RQhGaUvVUlYfQOl7n4v88gTFxlZYIPS+91EdvZxe14SDW5i1858tfZXJDzZpoUFuezhZlsJdksJD+eaGq4TfzVk072exP87WZU9l/l4kojkVJ8VBSVTzywl/4y6sZPBeO2HMsP/j2PGKU0QMunuLx8vou2rogW1ant3duPbFeK9/yPyfOuez8732bYncXjbXNDAyV6HEccskafn7r09Nf3Dx0nRfW4qv7Bp+Td+GDUfHE6DKM1wMmAUNFwyYWCqKiveswhRB/XW4KoCrDgUNR3jFYKAhHBasqFsFUQVOgXC7T1ZenVLGnyzvwwVhXKd3bBeesygzN+sWDD/E/N/wGP54kVl1HVTCC09nDnP0PZFJIu6XeMK7d5jqX3v3ahvn/s+R6SoZOQ12KwQ3rGRM0uOwHpzGlIbYsYbBiyyANS5beSkjTSG/cyOzJu/CdQz7b5mfLIadYrk8lIku7BwbOkHdAksFC+qcNdG25GmDv2pTSaHs3LDhqf1KmQk1tFWUd8orC9bfcjPCHdzb4/Ahz2Ylf3ou438OIkSmKZYPvnftLnm13MJpHoevxjILrzJo+bsX5/7WQEYZGwi8RSXh4YcGSR5/l6nuXcdfy188N11Wtknfgg1H29fE9Q36NJ1x8rwKuTTwSREF1/1aweONrsT1YvG0lSS3mEg1y8XAAu5RHEYJAKEy2UAA9IG/APyEzMHyoWJ9gfjkQHr+iMzvlf5bcwdOvtxNtHkNbZzcDnR2MrY7x/779LfYeXZuzhpiSsTn6+a39xi8eeJgtuX4crYSa7SJl5/n2UYcxpirZkdB5pOIx+spf38JQpURI85hQk+Ccud8iXGBVnRlYHDG1FQCNNTXveM5P2inL3gxJBgvp/atpGn3q9j+PMbWTWnRuOv/73yWiuHjlEnkrSyAS5qKfXk3Ocukq9M766h7Tl514yF74nevRDBWjfgS/uOtxbnp0Pf2eNs9A71UqOFPrtJ7LTj+Mr+w7leKGFXS2rWb09D1YV/C49s4HWbaha/6rucIrXYXC2QC5dOkdG7CCJ+dfvJt0MTenH+aVfW38mo1bsCoVylYBYZeIB4O4nnjH02YF6MP7V/g7Vob4iL+eG/LOdMh8ZsZu6IpPNjNAun+ANes2UfbFeHkn/sFgn0vPKWt6PcDmIa67+panJpx/9c0M+lEqWgLHVaFs8YXdd+WS/zqO/aY23BM3eUKPkrnv+VWtP/3drfQJSI1oxnQsjEwPv7nkx0we1eQYQaV346B7wY8u+2XNuu4edtl9OqlwkFOO/RoTkpyS9Li/KaRckjKNpesHuu9+t58xZQTlMKUkg4X0jxsLx48N45z4xQOYVBNF5Aexink29/Vz68MPUQipdDsds74yuXXNld85jlCoQsYZpLficPefX+LOlzeGX866V0Z1lifL3D/W4LTvHb5nzw+/ejA1pQy26rKt4pALNHHV0sfo86PT3Ui0ZkNP5jabwjsuW4xqqaUlr3+evDtvcMrdZwCkIvGlZcH4ssf4lWs3IISC51gYeCTDQfDf+fkexH2GN8d6a4/Fu1HAGdFQg2flwfMJBsNkCkUwZVPzfg3awyE54/bP2zS49cZiKDRdSVY5f2wviCv+8BCPvNZFRqlmyArh2yYhW7Dgq0dxxre+TLjorIkorAiFWHPzn1+a/dvlf2YwHqGoKFR6+xjh+1xx2veI2ZVSKKCsGVKYcf3j9/FqNkN4RDOvrVnN1FFNfGZkbLGfJ1SXeOMY9EQs8rC8O5IMFtK/TL3ONbPH1TBrTDOjYwGsXIZAIskfly3n4eWvEjOanDo1sHifMc3nzpw2ilgVWNYAOd9l6QOP8czazeRgdiDClmx/8aA64S7+xt57dCw6YS66NYgqXPqzFh1DPuf+/Hae3lA600lW16dSdYsBBvvbrhvsarvuzT9TWHtjW3IJfOE0bP+zK6gpC8JtHT2omoEuFCIaVIWCqIpivds1tg+D7NjWGxDqeweL2qSJ5ttoCui6SSZXxFGo77M8uSvj+1BlppZm/fScCmq1G45VCyOiP9rWd9k5V/+KB1auoRQIgRnCBAKVMmfOm8s3DtqTugD3JSPG/Q7UP7t16JzF999Hl2NTKlm4Q4O0hgKcPfdb7DayZnEsYDyTh+l/btvIXS/+hYyp0N7RQVjx2WfyRKKwvDHGTsMe9WZcnucjyWAh/euM0jm9ruIuXvClWWum11UxoaGenr40bijFXY+tpctVjXSeuZ7tx7/++T2pZYCqagfVrGA5Hjfd/SAPrR2YvtXngmhN5PkWXT/PzBQ6jtxl8sXnzv06ezYlqDZVFMNkXbrAj6/7Lfeu3TxrBV76xf6N2ara1pOrmlpPzvd1LpJ3411e3JqWs0XPQgBFxcnZsLmzF88T6IpKaXCAuqTZpgrxrsFC0zQ8BJ7wEerwyaau677jlt4wPBQSUCFiDG/nKYSgqz+D5TKlLqR96ndltJz0HKvcNx/Asd59+C6hppYKkTCUQLW79LnVp51y0RXkEikqyTADpX50kaFeL/Kr87/NFyYnnTis8SpWPO+4n+t2OeXu51+mGIlhITAti1EqLJpzLHu3Nt9TKbmjy7o6vq1kc+411+MmUtiaQcQQhCt5Zu065mHKvnwBSTJYSB+ujt7O81tj+sl1wl583sknrBSDAwTNIDU1I9CNRs78f78mo0RnbOzNnDkhFVnzo+/MQUtvQ8/1EtUDCD3Mz2+5g6c3pelVWLDeKt69S/PIffyiG9qrwVh++amHctAeY4nqRRyRR0vG+Pktf+T7P72uptdoiG+DS/vx58Xqmi9MD+TmDPSX5DDIW1/cqlryfT/ULwrzHKh3NPAwUFQDxfNJmCaaS87QlR6Agp2eU7R6F+zorQBD+MMTON/aa/GuQQRyQQ0SsQABQ6NccRgsWpQ94j02Cz/t98QVfjgUrFtcrvTPM0LDK67yhZ0DRkcuf35byb+uz9bn/98tjx255M7HGDNtHyx8ohGdhrDNniMinHfikYwL0qGV3JyoeLobDNUUDX3Gio4yj72wimR1LX42T1U+z7VnnslnWusvmxDkqGhMX95Z8lvPvuhqqhonINQIpg/RSpbfXXkhSZ/7a4Oq7P2T/mHaT37yE1kF6e8Wj8afzPRvu7Q2UX0hKurEXaYdVvRVXl/fieHHUdQQDz79NBN3m0YoEqxtTYY7Dpy+R7xWD7F+7RbKnkpJD/Ho88+xtntLtG7UyEl6OPyFgKK2JzUedLLFls/tNbbb1EpNmcFuipUKuUqAwUqU517tZvOgt6+IJI404/pegXBgW23E+NVQX3l+MKKvkHdne7CIPVf2C3tXFMMoKoG9em1G3fno84hAHN1zmFJt8OX99n5+tKYsBLD94gzhOQ0BI/40QB4+318Ws//w6DJEKIavqih2gWMO3JtGw3gqgfrYW79nEfYacvwDV6zZQK8lsMoVdNvi4M9+lgaTp2Iaz3ya70lAi6wYzHcuioUbripa6TmmEV4VMMOr0uXCnCG7cmjBCOydDQS+uDmvfPWnN9xT9fz6TkpamJ50H0HFZv/pY/juoftyzF4T+VJ1UmlUuKIsvIl+QI+u6i/u/r83/VG7+4kXEWYYv5DlyD1ncPF/zGV6MnAyjsOWYvnqZzsy37jq939ic38Zxw+gWhX2GNHEz//rZEabyjUtunKefPVI/wx5bLr0D+nJdy5qqB15FoAzNFg/ob7qvtOOO+iwdM89pAc10iUbUVvPBdffzM9PP5nRtdr9iVhUn/6lWVv2HDPtgv/93Z28lE4Taqzipc40K6/8Bcd//oBZJx3y2bBfLIWmJiJ79lOZ97XZu88dN6Z59k33PsOadg813siWQYu2J1bz2F9Wceg+kw775qzdDquPc22yLigPQHoL4Wt5X1GqXagp2eApOngapmIwZcx4Qpq6Zvtjo0btEt6yO4WiKG9M1hTK++qxMFWf0SObeKWvDVU3KFs+Wzt62H1yg9x9E6iKNV8IEPlrj8Xa/r7HA4mqtnDQWLV2sHLlPc+t4a5HnmOoVCFZU4/nlNln2lS+ccR+TEhpNFK5ZRyBb6Xz7RelYiN+pOqG9ccnXpy5+OFlRJrGY2OjWBYX/NcC9mxUS80eF9q5YnNLPHLeC535i6+84Xa6KgqGEkDkC+yzxzjOOf5L1Frl5eGytYpwXN4k6Z/7UCNLIP29OisDixpizRcOZjvOB2iprjov5olnaiyWnTPnSCbXJQgoPltzBSqRFA89/izCQR8TMU5q1rnwmF0SymUnHccuNSF8q0DB1sgFa/nDytf5v0f+PMOLhOPdXvaMWgJLzGK+Y+aIphsuP2XusuMP3peBja8RNA2qGseR1xu47al1XL70QW5YsUn0iXc+fr0n3f+p7YKPmXWLfUUNCdB7Mnl8RUNVTQwMWluaMfE63qNxKL3bChAF5V23AQ8HtPUTxozE234su6Lz6roNeCDfsd4kXSrP6fFYmKytu69gGjP/3DN05RV33M2tf36eTDCAWhXF9QscOfsz/Ne3ZjM9oeVa4YJxBL4FYNtarqNcOf/5dR2nLLnrYXqLCpu2pin0Zjl8772Z2ah2xHzxjKl5HUY80ntvuyUu/MVtbOxwMPVqKOaYObGR/zxyf+pg2S6h4D514bgM55IMFtKHzzC13j43PV8YgS3b/64ppFwyJcR+k+NcOffgzzAi6hEUgsxgjpfXb6a/wonbH2unnTljouoFF373BOoVF80GRY8wpAS4Y9nz/O6JZ+ZmveDBfYj5YyMNx49RAycxlOXwvSdw8RnziNppulYtJxgMUhYBlr22iQdeep2nNndc1wMLl2/aIgD6S/a8jszg+Q2p2qs+3d0WKj6E29o7cISKroVQfJ26eBWq61jv0ThYqjr8/B0nnKoK4t0XhaAgHEMRvU11teD5qKoOus7mLdtAka+dNyu7xviSYFpbicvWDThTTrv4clb3ZBh0bAJhHV1YHHfkARz/pamMDvBwTcW6VS8UMpu6u27ssd2Fek1T5vbn15175mXXERsxmUC4BlGq8NnJY/na/lMJO6w0PbtjAP+bLw/kr/n5H+4nqyQJmrUMbu1j1rRdOHTv6dQaDinE0vZ090XyrkgyWEj/Fr5jh1RVL/la4G2fWkeFOP3ISQHlhP13YVpEpc4waC9bXHHPQ6yu8Nym7uyNZspYauqlzr1Hhk+56dzTqfc8/PQQMTNIsaJy52OreGlz6eCMpxy9qeTduGrr5tVTkon9WoziuYdMSdxy8yVz2HdyhHzbc6j2AFokyvLNvfzPrY9z9ROrrqxrHX1Dj+Uu9BVCLdVV5wF09nV9alePCKEYPoQ2b9mK63gIX0FXNKoTSWqN4JK//XyBK3x83pi8+W6rQkCgo2TisQi6ruJ5HrphkC0WUVXkCadAf+fgIoCWuHZevsLnVrb1cep5F+FXN7G5L4NWqRApDXHSYbM4bp9x65uxrwln+1bFfGtZQzR6lZ9sCvWb+rwbXs1d9/9+/zjl+sms2pIm159jUm0V3z7is0ys5qahjr7D0AP0Yxy2ZNnLPPr6VooEMFyPkaEwB++xG/vtPr4npntrcpWe/UekGn8k744kg4X0b9Fg1l2VUpNLU4H423bbK/UNL6X78memnPaVvXfD7e9ADwdZvrmNO19YM5PGBGv6M0/X1cQX18O1TYLFF377BFpDGvmONhpTDazaNMQFV/+BJ1f2HWwHtJZpo8bs0pvvX9BsRi5M2kP3N4ny4iU/Pv6eg6c3UqXlUIRL3tUYNKq5/t5lXPCLW05M+8wlZLKpaN0I0FzXdOGn9X55wo97gni6Nw2uj+25KLpKVSK+UzC03J6Fb+2xUP4aLPDA930UX6C8xzSLFOrSKMryREgnGgrh+z6eHqQsNMo+cvdNoLa56sJV7cXVa20ev+qmP0645NpfoceqyRYcooEQDQGNPUfWcOQ+U4hjPTlaMU8dmag7KxWvXgpQDDLjvldz08+7bilOshFbC1IVi9Mc1lh47OHMbI0sjrjuipGj687stTjxyU0D/HH5ShrGT6G3vwe/0M+8Yw5mnylNpaDtbEiawfujgdDzAL3pdtlrIclgIX20hOvqFtvp9BytWLS+dfAul31u2liyvV0MWBa/e245923NzFVqq90Oh/MBWiOcfMCY+MUXn3Q0IwybttUrqWmeRLcT45IbbmRVV3b2Ro+b62O11wIES5V40kr3VJO7fdF3jlzz4+9+naCTp1KyKHrQY7k8vK6N3z6zfMYa27+mx3fn9sOneimqMDTD9TEK6SK6EsTBxtNsqhLqPW9+nKZpuZ3eAGGJcCroQsNQAxiKiiIEuicQOO868Vuh7FTptAUVF8Mw0MPVZD0FR6Ph01j/zmJuUTfeGb2wYG3Ze3yT4MYOlCnn//qu2fe/spKCEWYwVyZkCyJDeQ6dNp7//c85N1V5Qw+b3tBOc2Bed3nowRe2tP7s17/CNxTqquO4g72Eij1cd/53mdGgr2k1OLnB1K+yFVpez/Sz6NKrGDVhOt1tW4ioDl+aPZUD9xnV0ZDgqqjuPY/j00DyKoD61AjZayHJYCF99Jip1NLauuTioM+GhXO+xohIiJgeYt22bn5514NsdJndUXbPTZfKcwb60/NGGPxo3zH15/y/k05gnymT8DwHJ6Djxur47Z8eI6cye1VfYTVAtKr+2ljE6FVKgzNSwrppv3GN91x6+ncZG9Mp9PRQP6KVvB7mmtvv5bXuAUKxWM+2bPbStO9/as8S8VBiFQeciociVAxTBdUnZLJjRUiZ9BzHcerf1kD8tXtCESr4AgVQxPCR6u/2/RoJXu55Xry2KoGGoFh2IBAm6zI7LZxP3X1ojsQv9NHCGTimV9dm/3Hltrk/u+OPPLluI8H6JoTiY7oWsUqW687/Iad+44iHS+muaTVB41Z8wdZ89xWb84XrNwhue+SltoPveuxJsrZFPGLQseYlRkZ0rvzxQiZUc9O0pLlLOts3v6eSXdjni/mX//o36NFq1r22lsnjRjGhKc7XDvscu1cxwnDt3pDCmpFG5CzZakkyWEgfC6Xc0LSREe2GWa3jqKmo1EZHsL5tgMtvfICttk3GcI+pqU0tAWiCS3ZrbFlx5n+cQCSQwVUzdKYLPLdmgNsfa2soRKJThidmviQGfKgJjzq9yay+xN+4IfT10UFl6Y+/3XbUHpPwB9NUpZqJ1I7mvy+5mj88+EyDH4iGCjDz0xssRLxYLlN2HXw8DEMjFg2iQ2b7Y4KklvruOxyFriioioIv3J3ODFHAea/vGdW05WHTIGgYaLqC4zj4GlRcv/VTeQ8E8bX93uw7n3ud659awV/SRUqxFB19fUQ0h89NbOLmS3/IpKR73ySDQ6rDwTt8YYQUvcYJxho3WNHolMde7Tnmdw8/wQvr1pFKVROy8kxIhLj41JPYrYHFouzqffjzU4m6xQMi9M3/W3p3uGAH0IRGXIfCttV895tfYkJL9BYAr2zFa9Wg3AhLksFC+nhYl22/d3QyeeqYACcde9CBFLZ1YA+WaGoax59fWctDK1aR0/XZPQztGNevEtyzWx03nD73KFqSOvGaaipmnNueeIF7ntvAlop/ZePY3a5ET9JnD8zPZzsXTZow8RCA3WKM+dFxn1tz3P57E1ccysUCgWiKX/7uT/zk2qXhLlc9pYdP586PnlDjuVIZoaugCoRXYdSIprc9TtfMjncKFvDGrpuqGO6xEIj33JMiBGvrkgncsoWmqHhCob0zRwVGf9rq32Vx9uud3pkPPvsaN9z1JKu7hhCxaiLJMGNG1PL5qWM59etfYmYsoEwMRw9P5/vnNYerL8xk7WMUJeD0wMIHXmifed3t9/Lq1m1EEgn8coFaw+PCU09kRrN6sZexY+OC+rcUVOd1Rzz0yrbMzHufeplsWaEqGEEM9nDikbOZNaXuPqWYdwGao4kLZUslyWAhfWxUJeJ/3P7nCc2hM4876nDqE0na27YSTTby5PJXee61TfGcZ87uynWdDdAc4UIx4BrH7tJ45o+P+zqam8fyinS4cPVdD/PwC1sY8tRDM5ZzTJ1ZsziWaL6wVNx6xfbvU1vxb/ivQ3e5eN4B00i4Q1ieQmL8XrxaTDL3/N/y0PrilRsr3AxQzPYs7Epvvh5gfbHr7i2lvqsBctlP3vHrtqClP5vFDIXRTI1KOc+4saPetq9EKPD2Q9y2b5C1/fj09zrZ9M0cQf2U8eMY7O/DsiyC4QiPPP0MttBaPk2vgw6P89cVufjiJb/nkRfbMKvGEk42Uy7kcQa28e0jP8eZx32p7YstzUp33/DvcipWu6S/kJ0XjNVs2Fzmsnue65pw7R/up71QJlrbCL5HTPX5z68fyV6jkovJ5BlXbX6rPZu7yIH6nK7MfnDF65jVo8kXfYr9aQ7cfSrHHjDjvolw+Nh47HjZQkkyWEgfO3Ukdmy0o3tkPv+Z6ewxcQR10SBOucJg1mHJHx7hxQ29RxJvBKAvk50/tkY/vhEuP2R8/IL/Oe07NFabuF4ZEYzzqz88wp+e2TzBD0VDvbDg1a5Vq5VwYItd7l3QtW3t440R9XKzUOr4yt5Tb/jR/JNwC4PkKiU6CjnywRiLfnEDv3vylWNX553nIomGq7Sq1Ip2u++iCZGmo0aH604FiCdSSz9J96HfKc+zfVo2tXdBwEA3dZxygRENKXwI/e0r+Dt6LBRf7LwT53sIKLTVJZOISgVDUXFsl7atXbiKXvNJ/Z0v5noX9HRvu3T71ysKlXReY9av7nuM1T0ZBnIFGpIJnHQHU+vi/OyMBew3YSS7GdExeat3QU00vGr7c4USNLI+Bz3xcgf/d9PvccMRfEXFyg2y+4Sx/MdXvsx+08c/3Kpz8ohU7EdtW7dcNyIR/1FPQSzcMoDxwtqtmJEEAcNkQlMdP1pwdM7p626QLZMkg4X0iVAbYsnU1sCZR+w3nTFJHbNcxCq6vLxugKt//zTbLOXiTTY3FpzC3tufU8nTuncjPbNHRWnUK3jlCl0luPbuJ7n56ddmbrLL14QaRq7MlEU8U3ZrmkZOPmAovfWK+mj42jFw0szW1p4TvrwfTmYNBj0Mlbro9DxuWPYS//PH52beurUo8lr8c7395VM+ybUXqmLYvmKsWbeBkl0BxUf1KkQMBQ1yf+v5bw0S279+t503t2uB86K6SiIUwFA1csUSlg9lPrlLTiPx+msbGkeetbmQu36FS3qdY9Scd/cLsx9avYX+ik1ALdH58oMcMamGn847kn1SkdtH+caZALFQ/bVm+I0eo6ISmLElS+tVN95CTnhkhgbQ7TwNBsz/8mF8deaUh1MaN23u77geoHXU6JOXt6dFOKqsuu6mu+jNFijmh4irLgtPmkMV3DO1rnHPYk4uJ5VksJA+xjID/TuWeZYLlQkzxkTv+8+vfYkazYWKQ7JxPGu6i/zkF3fT5zN3TH3zSQBb05krxsY4vsq2/rjgywdib1tHUq9Q1Ziix3b53+tv5uGXNuOryfCQGz60ITl89kIyNer07d+vOciFx+y/F2ef9BXqGMDp20DQVOkp2tzx/Gq+f/n1LO/wjq1uHnk7wNb2bVd8Eu+BoqmOLTQ2d/SSL1m4bhlDuKiOtdPkzb95HX/76hDQFAUN5T1DSZ/vza9NRAgqAqdcAaEzkCtR8T+Z23qnB7rPSGcH5gBY0fiUjTmv5pIlt3LH48sYLJUY0VCNNtjG2XMP55LvHHn7WLNy03j4WmPAuPzN1+ku5c/o8VlohZl8831PUlEVdEPBL2eIVoa47IenstfI2H162R3wvUpY1XULYFPFvlGvT+V+cdcLB69ctxkVBVFMM/eoA9l1hN7WvbVz7nD4GfEjUUzPka2TJIOF9LFUXfPGJ7DWaODkiSqH7zex5pr9d5tESHVQw0GymDy7oZNHV3Xxsk17P8wLparWdpZzi1pDoZPHR4In33L5eSgDGykNtdE4uo7kyCn8/MYHuenxjUcasUTvxvLwvIk3qze5dnzEPOW4Pacv/s2PvseuMdD6t5AMKAQSNejN4znjqhu45cW+E18skg2NGLm2O5s/Y/vzC9mehcVsz8JStv9jvQdGLcYSX1HoG8xjhsK4nkPUgBG10b/53D68+Yo2vJ2353lomobrunieh4//nsModaq2OBEgl4rH8GwH1/Uolr13X6P6cZN/4/dia7rnilRN4+VD0ZpDV0D60Y3ZmWdf9Su2ZXLU1iRpCDqY6U088IuLOo6bOeWy8fC1sWbwbfMcOsql8wvB2MwOnwseWTU066FnniUWi6CW+hmX1Lj2vIWMCjjrJyocHnLKa0v50rTRVQ2nrhjMpHMBc/azGwfii/9wD6FghJBX4Ut7T+Yr+0+m2J9u/dyo5h3dTkrkkzXcJ330yGPTpQ9VxWX0xGnjZoQT9dHVW9pRAgEU1efZPz+LY7vxSZNbx6uKYxme3R/Tg89FdHWFHjYCRxz1pZl9uYy2avVqhB9EN6t4fd0Wnn5uzaSmESN2DVYFp9ao3Pbm71XKZnZXbMuvCUaWnXD4UXdFIvEvBo0Ar2/eSNl1sAW8/NprbGjrCKSz5SMmTBrVW7HFmJiuPFf2yuNjsbpfGcHIKx/nevfDvNUD5SNve/BpjEg1AVWh1nT54j57Uh/UnorBc+/23CJixoAjjrjlwWeoaCEUXUVzi3zzoH2oD+j3R9Gef89P8R5zX1q3rbbf0nB8laCocPCsz5AM0h2Bj/fx9oHIK7lcz8JAIPp8vx769usV9Q+Pru7a9ec3Pxi+5b6HGciXUBUX087x+UmtLDnv1JtEus8YX5X8xsBA56JwePho+h3hpMwVlaAx9pWuoWNu+NOzgRtuv4doPIbhlzj2S/txyjcOY3pD1WnjQtE5/YXsvIZY/KpkMHT/6oL1XHfZn3DXUyvi//e7O9GjCTTHYcb4Fn78n1/tiGEvrw1of0ioxmOy9ZE+LPLYdOlDVa9zbcbimMP3Hd8wcuwofv37O1nXNki0qpo/PPkSGzdsmXLzonkXIypvPEnYxIV44rxvHV5/5OdnT7/46tvY1DeE0TySFZlefvjLJfzHYQccc8y+01c3BLiqTmNxPt+7oC5Zf+2OT99Z5s/Zd5/Lvh6m+Yj9djv2vxffQLev01/xeLZHZfnGTdx09wNzz/qPb8w9aMbYuCI095367HP5/nnxWO3HZu2/D6GBTB6hmYCKrsD0CWOpMsCA3r/57DcZ3hxLoCkqKqr1t7634glnzKiRvNy3jbxdwRUG6XQFEoGP7e+vle+bD37I0/WBeLzhqk1w4/qKdsz5v7iZF9a2U9U0imCsDn+gnTGhACd+5cscvNsuy9Rs3tqlsX6f9q1dV4wY1Xz6m6/5Wi73ohuOV7+wMdN6yS9/y+buNOMmT8bu6eCcU05k1uS6JybDARm3f14e5tVGa5f0V+x5lmpOsURoyvW/v4NlazZgpJpI96apD4f4z2O/DLk0k+KpQ7qcgbPRw7LxkT40cihE+tBNDnFAyCr37NVs5g7adTR1po9XKTPomGxIW5x32fU3CSViAGwtVa7AdQh5lTW7wm67VoXbLvj+fzAiGaSnvQ0tGqE9nefmR5/izmdemtLtiDM67Mz5sVj9tYN9QzuOUa9LsHhklLPGqXzr8+PqL7tg/jeZNbEF3clTsEro1bVkzDgX/Ppmnt/Yda6IVuntnn9Rt2OfAdA12Hc2wMcpVPw1DLhDQxahcBIhFNyyxWemTiEVNm5JwdL3fq7iCOH/9eCxN60OeR+TNwGEUzFaalP4rotv+/iewsbNWz/Wv7uhWN3iUKzhqmgotfSFfL5474q1c49b+CM29OcJNI+j5AgGO7ayx4hGzps/j8NnTL1liq7s15qInQwwYlTTzqEiP/CiFo/nnn59W+v51/yGzf156idMYPOmtRwx+7N8cXLdZQz0A1Ct1y4ZzOc/B1AbMJdkXQ6665Fl8SeWv4wajDI0lKEmbHDS17/Mbg2BMxsixpUATaHGS2SrI8lgIX2i9RUr8/eoCjYmioMPf/Nz09uOmrU7XiFD44iRDHkG6/uL3HLfkzdsdbhiVDhwukYgNyqYPB2gJaycO66Ktv9eOIeJ9UGcTBfBZIJtg0V+ee9DPLJ2y4SsWX3w60NDD1XVJRcDbF3Xce/2771xoPNm1cqXZo5qvvLcbxzFqQftx0jNpXfTOvT6WtyGZq68+S42ZsW5FU0dXVDNmVsq3tVNVXWXrNq8fvXHrdYC9O7eNJoaRPgKmoAxDfUY/t/qrXjTNYRA5Y2NsraHjr/1PEMTvfWpGpyKjRDgOIKVq9Z8rH93t5ZzV2zEv/k1ePGGB58J/9+tfyJY04TjKQSEh8j2cdyBn+Gn3/sPPjuq+rRxCt/qGsifDdCXfyPopoU3Z32pcncgVtN221Ovzv7va5cSrBtNrHEEvRtfZ/8ZU/nCtPFYmfzkyTW1B3QPDi9jNRJ1a5a1bRGb4ManX9k8/bYHnyDZOJJsNkvEKXPg7pP5woxxbV7FjTdqicuLbt982eJIMlhIn3h1kcBigJhfXt4c0y88ava+7DNtIgM9nbhC45WOfu587iWefHH9aauz3nO6aWbSrjunt5hfkIKlocLQmn1Hmpdd8r05pPwsplemecQIykaU/73+Zu5/fs1MI5ns7bVZ0N49dNGoiS2HA2zNdl8Rr4o/2RJKnDfKCJ4+ytRPO+0rX7ry1MO/yK5N9fR0bqEj3cemdJYfXvJzHl3VdWxOYbYe0AZWZXKrG0aPuWr78r6PCx9CW7d24jgC4fmETYPaZJwA/pa/3duhONt323xzyIDhU0z/1vOjodDy+toYulBQ0XA92LBhM+JjOASbruTm9MF8KxifsrHgH3vqZYtn3Pzwn+kuOJRKZcJ4uD1b+e6RB3H2vMMe3qfGVLx0IQ7QVBO7BKAuNhx0+53yPE/R4iIY0O9etvGYX9xyP7ZZTedAgYpl0TqikW8dMpvdWxuumVgdOxzA0ENrtlXyl/pqNJxsGr1yTbs195e33M6gr9CVyVAdizGtuZbvf+OIUtixVrUE9PMAInrdYrssV4FIMlhInxINVY2X28WhltE10csWHP9NJtZWUcxlKCSSrBjIcs0td+CZWnywwpdtXW+pj8Su7S5lz5iYSh4+Es7aNxU4+arTT6RWKREzVJyKTq5ocuk1v+HFzem5fYL5ocbkmh6nshBAT4QzqDpbnPTVW7K9VzeEA1eN0jn9yF2nLb7k5G8zvTZOfTRAwVXoqSj899XX8/TLHTU9HqdFq+PL23vTF42pbTnp41RjR9DQ159G+Ap4Ak0IaqIsa9DUq/6eHou3fp3G+5tvViGdNYnY8PJUVVXRNZNiwXrbjp8fdb0D6QWWa0zJwf5bCxx83Onn8dSaToKNY0mmmvGLJWrcElcsmMuJ+01Zb3fkWwCaU9ELAQat4ePoB+mf15Ztv65Y8WbkK3zumVcyh/18yd0U1SRaMIVnCeqDMRbN/zZ7jWxYY5beONnUM4KhQCDWloPZBGDp3fezLVdASSSwPAe8Mv971qkDdcJZPCEWOurNP78ZlKtAJBkspE+JgpWeE9C0Nq9cjE+qUW9a+M1DGV8bw0zU4KVa2JQp8pd1XVOMEL2D+fyRAI3hxOVeYXipX11AXbz3xFHn/PKn59Ox5lVM1yUajeLpYW594FGKAaa3O/7FlqJM6bSLiwKE2irl8mhT0TtGJ+pPBcj3DC1srebkvUZETvzp6SfTWh1E1RV6C2UqoQT/97u7+O0fn49vy3NiMFG7oV/4H6vlp45Lfcn20E0TX3jYZYuAxpb33Tz46o6GQhECITyEAgLV+FvPTsHSkM4aRAUNBSMQQzXD73PHz4+O+prUtY4Zqr/10ReO/drJZxFsGI8aq6Ovt5+uzevZc8IIbvrZGbnPjm9YXou3ZNqI2C5tm9/o2aoKNVw15HefUak49aFo1RrXjFQ/+PzGY3++9E7StkowmsAp5WgKKfy/k+cyqTZMQ4CrwsLtKP/1d90xAvWvdKWv6XOZvejK26Y/9cpqIqlGbNcjEQ3z/ZOOR83nrVFh43TZskgyWEifWtFQamkqWL00hlg2Fo7fp8V4+KQjZqIIgVVRiI0ez+2PP0XaZm5dLLa43xpuZMvloUPd0vDYsapi1YTouOai84lUBihnOvFNk8defpXbHnsWS1VbXF+r1rxArtJrt44IVv2oSU/umMwWa0heBVCrs2SEUbnvf06fz167T6TiFEmXfdrygj8sW80lv7qbdEHMFP4bb6iDmd4FH6V69vnFt42nF8vM6BnIgqkTDpso2O9rx81hCrpmonigeAJDE/i+iws4UP9+rhCEDcmIgS9cKhiowSSFwsfvpNmHn3vpxP+78S78RDNdbd34rkdtzGTvSS2c9/25eEOZ+C5x9mmKapcAtI7ZuWcrqTZe3hBouqRkB6Y9/PLmY3/94FOs2tqFHQriWGnqtTz/c8rR7D2K9a0RTst0dR+dTKSWBqO1S3qKmYVDjn2YqKnitmUv88ymLQz4Otm8hTOU45jZszhkj9Y1VUHlHtmqSDJYSBKQCkaXAkxKhA/Zb7fxjK5NkqipYWtPH69u3sarG7uNjOMdXRuqXTKQXn93JB5d7uHUA6gCK6Vx08iEyRXn/4AR1UHC4TCx2iZ+c/u9PPjnFfimFqq42ujm+uiF2f7iu/Y4TAyFDo+U8yw49suMbKoiEDIIJJIM2SpPvLyR/3fl9by4eeC6zkJlUUdfz/lV1cPLWfuKg//2CXJppzTH84m9rcfCp94TGoquYZULBHQFReC87wZCAL5AET6+cBF4oCjvezgjoNDWUJtE01RcX1BxFWyfj81BZN0OZzybFuIXv38ANVyL4qqgCEYFNRZ+9VCuPntBbnxUv2BsKj631y4sAHCsNzbP6hjMn9+Zsxf1uixYnXWfe/K19hN/e9/jrOvtp3ZCK7GQT6QyyKL//BYHtEbOrLLLfyxlMtMmNTUesuOHiCTIK/qM3pLL7Q8/RlnVGdE6BqeY5YCZu/Pdr30+5+VK8dHx6KmyNZFksJCktxhVFT5zwTePIO5kGVlfS19miCuv/x15VZu1Ppe7uyY14ahSxWlQVbUE4JQK9bZNS22Ee/YcGV78gwXfRlTKBAIxMn0Ov7zpAf68uu8wL6QMvxGqRWMw8+6T2fZOJJVxAWflT44/gmnVOmE7ixnQsfUwz7QN8r2f/447X+26gLo3znOqi1Qt3qmXoPLeu3X243zgwykpI7xURXnb3hJ96UKNUMB3HITvMqK5EYX3vwGmgOHhDyHAFztOOH0/q0IAdMiMGzkSQx1eVeIhyOTcKf+WXy7rb+yi6nWfgd91dqE0PCdiHdz7yyfWX/bdy26lGB5PMedR6zl8Y8oofnXyN5g7fcxlIyuls1rgvBT60nozei2AEXpjSXJLVew8PW4O5HRmP7alMPOC3z3Aim0DBMNRjGI/8UInv/7Jf7H/2NrLGuHykaHgWWOqq3f0dqzt63q8iDYjT5DL/u96fDeA4vp4pSHGNkX4j2MOxISOunhw8aaejhtlCyLJYCFJb9EIl+/ZrPecfsIx2Nk+mhqa2dI1wP+79LfxrBI5qN2tXBSOjTyrUPHiAM2R6IWqlbUmKBwVELQdOLnh4qsvOpvetq2M23Vv4nVjOO+Kxdz04PMnrsmVnk7U1C2uqn7vyWz1qnftYRPHnnzR90/kK7N2J+AVqW5IUT1mAgN6lKvueJhTr/z9uQ92DIr1ZfvuDqt4/pufHwnULilktlyd3bj2cbq6z97+9z35/oXdFM4oUprRSWHRB107RVF2Cgz9Fea1tXegqioVq4yh+OwxbSqqQunvui7g+y6+P7ydt6q+/2ZDh4HRTU3ongMIFF1j/ZYt9DvD4apY/PCGk1whdpoXksaZ0487b3Ou6/qBcvcZaKrlCGEUAjovFq3s5b9fdtgty15hyKyhM1shYpgcNWtvfnjclzsOmpBSktbQykil+DcDVnueix9Zkzvm3MW30O0FiaTqUfwKAauPaxadzq71kXNHapy1/fHbt5FvLw1dZAXDk3th7k9/8Rvau7Nk0kNENBXy/Vx09vcYUxvoaICrmlEvHNvQIo9Dl2SwkKR3UgO3fn58vOfbX/syTjFLvLqeFeu2cf09T4WH9MChG4ql26oSLedtf3xrInEyQJPCJUHYMCZK2/GHf5HiYB8D+QL5QIobH3uJ+1/pmLUFrgbY0LVmx5bKQ2866hqgTo0sroPFk5PGud/cfwZzv7AHwWIXufQWwsk4PQ48t3WAn9xwN68NKkcOEPlmP+z4NNzeve7eaPXoUxPjJh+QVd5YUdEQq71KF2rG9OnQ8HMfdN3qtNBOPScVwej00BCqpqGrIOwyu0wajwrW+7ne8AZawxM2EcO9Fds3yHrfoUTgNiRjeOUCAgcMjVdeX4st1BYA4Xkf2goRPVy3oz795a6zS4X22b7bVz8m3nSSa5rW1pI/fqsfn9yhpS5YeOWv4r95ZBndFZecUyYchLlfO4Sjv7gvu4+MjcgN9M2Pp1JLIzU7b5jWl+4+A6CzkF003DvFvPV92fgPLrmKxJjJKPEUuYF+Jo+o5cffPYF9WuvmNmtc+OZrhEzF6c/3LPTD0ZAbT9Zcd/uTPP3SRtCipBJVFPs7+MpB+9CaNNpqsW/wvXRIthqSDBaS9B5Mz+5IwCNHf35SW2M0QDGbQQ/HueWhZTz8ysD0PhE+ZvsbeTbXcT5AT8e6ewFqYUnEZsWcL+6FVkxjKg62UNk6aHPFLfez+MGXT/lLybJjTWPuyLrDQyLJxpFnvfVn6MllFzbDhWMTgRvmH7HXE4u+fRT7jEnS8/rzFLMD9A3kWN2d5Zyf3cD9z2+Y0FXm7PaSe1FvPrdgROPEwwF6M30LEo1NO+16WKuElzSpiUsaiF/1Qdct7Vk7DfE4goZMroiq6kTCQexCjqZUEoW/Y44FijMcJPzho02Fj6Jo73s4pU5hcTJk4FeKgI+LYO2mNhxVqwcwFS33Yf1epa03lsj6nlOfikZWhHQ9s77YcXdBjc0cCjYe+tSm4rHHfP+C+Kasj6cZ4JbIdazlkM+M48jZExndoJ7bm8suiNcMh5SBwZ2H1epSjZe3F4sXNUcTFwJk4Oj7n3iGYDzBttWvUunZwq7jGvjmF/fngBmTF6dgaTo9PBHZ78/OA1BCqaWOpoUGfP2bj760ybjvqRW4RCgNZlFLOY48YB+OO/zAUozKMy2EzmvQUlfJVkOSwUKS3ouVZywcz2COYw/5LElDUMoXyPkhfv3Hp9hiw0t9zg1p/DmJeMt5vVtebm9IJe8H6OjrO398iK+FrFLP1ecuxCx0EzM8YlU1dNtBbnjoJe54frORIXh0VotPf9ubT2H4zbkhnrgKYIypnpQsZe87bFL1xUt+ePxNXxgVIFLcRjzgU8iVaRty+fmt93Pr46snZNCPro/Fr+20nEUA9dV113Y7lTO6KtbZH0bZUlpopyEeTyO2dmMbaCqaDyEFEkHQEe/7uHQUHxjupVAFIIbzxd8jHlAJ4qIpPmXPYVtfGlsMT+A0Y2+c5/Kv5qHt6B0JGeFVdsWL275ZCkdaVvbY5tzFD2yccOpPf8+A0kJvn0OtGSAytJVDxodZeNSeTIhwoonbIUKmkRbOnLTw5tRUDQ+rre/YcPf2aw9W7CPXCe5d6bHukRc3HbbsLyvIZ/pIGhYtAYvTjv4Ch+w28h4vNxQDSKWGQ4pam9jR++GHq0L9FRquXnI3thclYsaoMnVqDJdvf/1L1Ov+tWPViBz6kD6S5CFk0kdOY7TmcoD6ENccNXvvGRu39R372KtbsYoGW9MFvn/uL/n+17/I5LrR04Gl8arUTQSH36Ba6urOA9ijLtxY43PF767479MW3/EoD7/4OqFQhIGyy6/vfornV6ycdfqxR8yi2UTLl3LNsfCFAKlo6G3zLxrDicvLTt982ylvWXrJ/1v+5Otd19z+xEoefGE9aCq+FuSXv7uDZx5/bMJ/fPWL4kv7Tjinw+V8RcU1jEBvHSz+d9TRNwm/um49Sv1EylaR6nCQaIC2WpT3fd6JoghHURRj579TEAgd3t+QSNxkIKz7NZYmKNse2VJ5R7D4MAkPI+0wJ2WwdNAyp5nhqo6enHfxn555oeXxV7awIeNhqwmwBE2xaiamNE78zpHM2mXElRGsFSmMpaCDsXOz2V0eOmNCy/ijALYW81dEq6uWr+wun/inh57g0af+jBKI0hBWOGjfqZzw1UMZGeNKvVLOmMHAjg2w+rLO/LqEsRigD39+Bb31zgeXU/YMXMujIRHj81Mn8e2vHcDohHpupdA9mmjjznncT88JqXIzLOnfT3nrrnqS9FHQl267ri7VejLAK2U23/Xc+tZf3PU0g65OIhKksO11Lj7lG3xhlxFrptVEd9nWvunGkSPGvuMnuDUuT6/syM/64c9+TXtOoAVSJCJhtGIP3z5qf0740tT7JsLh7+fnGsr3LHQiqVxJ1adtczjt/J/9gRWrXieRrMIq5KgKanznmCP44qxdlkdghYnd0RQ0/y2HQN2/NSdOPvdKhsxawkGDZKmdh68//0rTLnQ0mtHL3881ni844vDvno8VqoKwQjmzlYd//TMmB7QzG+F9XWN9kbt/8qs/Hnn3mm580yA4uJE//t/57FdtKG6+b74eq/vQgtfWwdwVZcLjLV2fsuyV7tYb73qQ17Z0EUzWUrIdFM+hKRbg/NNP5oDJ6rlqySs1hrXLy6XeBYqiWoG/rvjo7N96Bfjh5trh31GANpfrBl2+/MgLaxv+8MATrGnroramDqwcPz37e+wzNnFNxHNW1BrGuwa7dTnrXjsUanl85ebpP/31nRQdDUPozP/GkRy1z0hndJxTVYqlFBEZIKSPLDkUIn0k1aVaTy6Xehf0FQfmNwa5bGprAzMmjKIqqDA0kIFAjCtv+D2v9RSn9MDCN4eKLQPtV7/5WtWudcf+o2NnnrfgOMZWhwkrKmawmv4Bj1//8SnueG7DYSs91nU5pZ2GLLbPzt+unO1dkIw1XFWr6kuMstsbL9jrz5l3NCccMRs72084Fqc7X+G3f3qC3z+yamZPgVPMoNnx76jflkL+aiUUoyJ0CnmLWChMLGAMn0r29wyFbP+0/098AAnprBndUouhg+d5CM3AcodPS/URH1qvaU9+YOGoqvjpWaEffOVvH2297Lf3syVvEK4eTTxRhe7kOXTfXbj2J//JvuPUm0RR6Iad6wUIhuuvDYRql5SHOhfZha6zm2tHnd5c23rywODwHJ9XMuXNnk7s2Y1DDb+56xFWb+mlqmE0Q4US+8/8DHuMTdw3WuXUdwsVbdnsdav6e1aH46FVq7Zmpy+++V4cVxDUfAwrzYF7jKQxyGV1sFiGCumjTvvJT34iqyB95HhW7wIzXH9txAyvGKg43xqRCj8xZdrYWX+85wHKxRKJZBV9A0N09KRpaZ30RUs1vqfqVAYLg0eOqqo/483XiurG8zF4riYVSY4fPW7m+rXr6WjfRqKphfTgIK+uW0soGq6ZMnbEkG2XRsY04zm32LkooPkhnOIMjOjzAHow+sL2a8Z09ZmGkHZ1PKxu2mOXUd3VVVWfeW3tWiyhk3F0nnt1HR09vTQ0tXx1QjKw03LUYl/PQjMyfM1/laQZuP+aPz39k839Fr4RJd3ezv/77nGMrgm3jQiF3/dS1y5H/Ph3f3pCc/QgGAquNcQJR36RWl29Pwrv6/+hrDJxoOwf9tALr2HZLiHV59D99mFyQj9fC7xR038F2+ubX/IGvxzQ4k8O6dqhL/YUnrjit/dqf17dTt4NEohEqZQGEKU+5n/jYE48+rNMruG0oMpmXalkaiOxnfaG0IPxpzVr8MjiUPeZirBboonm/15XcO71EoHkbc/17v+TK39FX7ZIMJKgUCjRUhXn3O99kxFBrorCu/6/2mp5pBLQ/bRj/Mein90Y2NJbIGAIJo+q46Kz/pPJdfqVIw1+IFsGSfZYSNI/wC32z9NCb0zqGxUwTjegtynIPT855QQmNSbRvBKRZC1bMyUu+eWNlIPUFFT2VgKRnVY8pNMdO97UR8Hpn52YvOx73zyISbU6fraTSDTEQMlj8R8e4LZlq4/JED6mJ9+/UI80Xyh8t6a/t/vM9/pZUwpLR6uc+tXP73blwuO/Slx1CSVSBGpH8vTqjfzsptu5d12/6My7O97MI3UN//JZ/NscLi1UPAoVF9eFaCRCUypFWDdW/SPXE0L8w70W6v9n77zD5Crrv32fPn1mZ2d2tmc3lSQkAUIJnVACgjQBRVzQAAYNaMCABiRAQCEKSBFQQolCpKOAgAJSpEgogSSQhNRNsnV2Z3Z6O/X9Y2mR0FR8/enc15Urm83MM8885zznfM63Clapqb4Gs1wAB2wkUrnCv+VcqthmOF0y6gH6y5z9/Yt/xrOvr6TsgOMUKSY6qXfpXHn+bL46Y+dsg5dFjl2URSdbjCquj1gXikNdl5sOeOt3OFTxNy7sN5w5lk8J/PGlrrG/uutBQg2t1EYbyPf1sdv40XzrhCOJ+Xg2Bh8bpPrWptXLDeyYWwutvvSqXwTiQ0W8vhpctslXDt6TcfXaw25LX1O9MlSpCosqVf5BZG90cbG4bRqfU8zIY+GYGVMar+g4fD/Kg93YRomKLbC6q48/Pv8OvSW+XpLUCV253OUAQ6n4bMO0PduMUyjKB0+JXXTd+SfjyW1EKfTT0tBIwdC45rcP8bsnl07LKTX7AGR0KxBpiN1oFYYrMb4vVmw+UrnTq2eWfXv3scLXDp5GORGnUCiRMQU2ZHS+fdlV/O6vb1z6b11DhWQiU6RkgaxoKKJENOijURMWfu5LhAW8W3lT+Ae0heOUlYBfA9PApbnQDYvk0BefZRrP9c/xK40LXYH2pe/AE5cvuj+wNWuj+QMUs32ExQTTJ4S4cu7X2X8H740RhTvb4YwG0XN1RAxs191gatpmOdR6XmcqcXM3LBhQhFkPvNC57y9uW0KqUKa/ZyuDG99h6viRnHbMQXxl7+Yn3RarP26O63p7H5o0csJOgho2Fz34+6teXf4OFcvCKOTZZ6cJHDtt7KVjFY6hlKoG2lepCosqVf4ZPJ5to9sbPMHhQMFingN2nZA94oC9sCs5UkMD+EI1/Pa+P/Cnl5aTMjlaVP0lgHBN7KaG+uEaFf359ByAEV7POU0il8U85sO3XDWfBq9NKr4Fb8BPImtx24N/4a3u1PE9ljM/FG4/Q3A1LizbZngbK4XI+3Mrv9sMLeIOLkkU0h2zTzj4ii/vNpGAUWDs6NH0JDPk3CEW3v0w37zqXmeLyTW9KfsLTz81LGLxZIqKDorswuPyEg7w2D88oCMynAXybk2Lz2OBskphTXb6cUxEwLEl0rk8A/CF9VjpL5fmxPz1160r89AQHHfZDX+Y8eKyDTQ0tlPMpwi7TXZqC3LFD0998qhxdUKbyFltMp/aayPgrVu0oZC9q+yPjNlY5KLHlnZPuOnO+9EdCZ/HQ30oyI4jmrjgO6cwdURgtVjUS23Kx487trHxmK1w5Zubk5f+/slXwRUmlUpR41OZOq6dZrgYoC7470vLrVKlKiyq/E9gFPrmppKbb2jx+C7wSfbSM089jt0njmFUcx2JwX5sUeKhJ//Kut68okvbpjIOpeKz633DXUwTZDsG9dzMsf7QMS1R77KrLjkXv5RncOt62kdPoGC6+O0DT5K0hBMHYNbKro2rvP4Pqnz+Pa53qznmcvHZEW9oSYvEBVefMePMy791HP3LXsQngxSOkgpFeHDjFg6c+7Oz3yibV3TCzX2GObc7nVjwhWxsiVIqU0CUFSwEsB00+bO2S99WUHzYDfJ5qm6+h22bblkWhzTp3dLikkK5VPlchbo+D5vT6RtwuVlZZNWWPEfPuvCeI55/bStuLUzP+nU0eyW+vM9kfnr+mc/uoHHolkT3Ne+9V899fD+RQSMzc7NeusHxBpRBm+nPLe/i9vsfo2Iq1NU2kOruRylkuXTOGUxu9Nw92cNErz607L3357bTQ+atlLX81fWFc793yQ1knBCpooCqCYQ8Fofvv9PDq7f0vV8hNlvpm1u9ElSpCosqVf4F2OVEh+JtuLqmtu0sgB386qFu21l32bxvIZWzRHweBgYGGEzluOOe37N6XXybJ+FwTeymnD5sWUj0dp0ZVf2LAaIe1+2tUd+yS8+bzchGP8neTmpqanj+zdU8+fqmCV0VLq9rGbUoYeTfd31Y9vYbmPk/VOgppnLT9Il1tz9w81VEVItCKonqC1AwJDblbL6/8Doee61zVlaSp4veUOmLWLNsiel6xUBEQqzo+FUVWSD5uXWFYCuWZOGIOjDsChEd8XOKAhGXqq73uVUkq4woCeiG85k7pH5eLNUfyML0F94amnDq3Gv429tbSJUt9EqJHUeP4Pw5p/PjWSde5MVcNmgWZ46INJ/znnhV/dGPTQWNKsHFZcE1Jmlx/Msr+1jy4KN0bu3DKJXp27SOye1N/HjOGYxp8i0b7eGkvmR8blOo/v1y3X5t27ETDh1qSOo+79KryKMxVLKpjUZoCKicf+apuBzW14XD76fiWta2vU6qVKkKiypV/tGT1LWtW2TQMGZO8QvjXBWSPzzjVCIeD2GPH5/mZemLr3L3XffxTtx4oi/H+094suHIQ4mNd+zQOHHPtV3rHx1WLA5BSXhyr7GtT151wfeJefLYZoKy5mHhrffw7LINtd1Z69KIMtzWPVUYnCl9hgJEm9avXDUyLJ62c71w8k2X/IBDdxyDO5PDpQQJBprJGD5+8usl3PyHZ4/oqthX9MC/tCFZ3C7MLjrWZNs08AqglUoERQHHQgHIkuhI8+lPv72Y8xwVRLeFKevYjo6EgFW0+KRgRICyFZ+NHZ9d0QdmaUposwzJ5rowslNCkhwyhSImhLcrZsz4bPj4DrQf+72N1OwerPk5Wdrnxnv+dvSPf/ErUsjItUF8UT+xBi8LfzqHPSa3PlApFtuciiFHZc/7N3vF2/CJdTn6HObmDWHac0u3cPeDj7Fh/WY8qkLYLdIWdnPON4/mgCk1D/tUlgI01Ma2GS9RHHr/O/UVCnMHy5x6/e2PH1GSJTKVCqFoDYJT5kff/jpjarWlbpXVEb/2/vlW42lcWL0aVKkKiypVvgCiirJ4wGJWxMudu4yPdR518L4014YoptM0j2jjhTdX0ZUtzSjKvF+yWxTFkkt1rwYY1zLmywBOuaRotrXZZTrrd6sPXvqj736LsEdAVWWSQxmuvGkxr67ZElhT5hmAGm/0M1WsHDlm8sSugXUPRWDJhKh26UWnfoXTZuxDjDJ6MoGDREUM8NtHnuO7F19NBdo2Gdz2L7PwiLK7fyjhEUVQBAe/KlDjU6hYtPWVh+YamLUOn978SwBDkp1iKjWA4JgokoBbUagNqusSzkcDWOOlgdkAOWdwpoijYJXHiJhhBJm8ybRxY0chYWBjkS0WKcOY7X6uJGXh81eQrCg17Vuy9qVX3fJQ+/XXLMIXayAciyIJOsVsL9897auEPax2WeZ6r2gt84jC58qQyQtMW96ZDtx676OseKuTmnAMTQQhn2D+mSdz+E51p/pMlrZpnNWdKnzExRXxhN//Thlbm/HWltT03z3yJNmyScuIVgqFLLvsOJbJo1uMWo90T1RkcXW3V6kKiypV/k3USSxSJOK1GvccN2P34gFTx+OTBQK1UahvY/FTz2G5Cawc7F8FMFQsTvYEGhemcx88Cdd7PNfVidIity2sFqF02KT2iy793veRCmlaR7Sgemu48Oc38vvn3pr+jsUTmwv6+4W3irnuBYVc7zyAvr6ej1gcWurGHgPQDBfv4UP44Vd2PfPS7xzJjg0iqXgn6UQKw93CgFHHUd+/9tRnV3adutnhhnf6Nj8BYBc/WzvxhPXRG3zJsCeseWcT6VyeXCGNYRdobK3F5WF9gyt8tY4Rsz5L/KVp4BLE9U219dS4/OQHUqiSSOeWTWMjwnAAa2po4H23U8xddxOAUDHDAo6MYHscWTBsAXfJZMKuu+2CIAzHa6TyGSoO7Qmc9+dfKHYvcMzBmUZh20wegH4zt01mTjHfMz+THe5Ku9U0rtwId7ywsXzurB8v4qlXOxm3/6H09XfTt2UVzTUC1y74AQfvUHdnTODGFkm+IOby3xT1ehaXKp9sGSm/exxeSWSdPyzdcvz51y8mKYTwjxiPYYFPdHj4N1d27jOx6SqhlDL85mAcoLnGezFAPDX4kePYbbHgra7kjB8tvB53tBnZ5WUoOcjY9hZ+NOdEGmtcV9TLUrWxWJWqsKhS5d9NIyyUHLKtPs6bsfdUpk/bmXhfD/hreX7lO+jQ7I/Uvfh235bXG2pHnAMQ8keWFHPb3kxiKjc1wkLHQJ48wnXnCTP2R64UKBbL4Krh2tvv56HnNs6wvGpgS16/pi/RO8/jb77Y629cODDYdXlDQ9NlnzbXdNe6w/ceW3vnLy+dw5f33x1Zk9ErDkNZm7XdaS7/1WL++vaGM8MNbQ8CFAyzFiCf7pur5wZn5hK983LpbYP/EtCxvTgFUXSXeuND2DhYtk6+nKSlLfp3MQ3idmM73uvW2T2YWSDL7iG9IjQn4lmsskQ42EC5ZFETjZDA7EgaiY6a8HDwan+i9P6NXxKUuG07iiMo/YKoxCvo7bJMcuLoCJJt4tgmhUIBQyBWxnzfaiGItkcQBEPxfbTEd73s3+ZGm8iXxgcDref148zJCMohD76w+eT5v/gNW1IOFUujt7uHWEDjwN3Hs2DONxkf86JAfBsXjpXocEkftdxUsh+cH3nkbB/M3Zwpc8Od9+AOx0hnsmBV2KGljh98+xRUw+xuVcXzIu6aJT7VdhuFYTfTYDoxM1YT3cZltCGTvWvI5Pjb7n+coTIUDPBoIn7Z5pLzTkKogALxeKk0u7rDq1SFRZUq/0YS5XIHQKPAQrNs145vqb39a4cfjE+yKebz9MbTXLhw8dSSI46X/ZHkoG3OBOhP9s31+LdvZncMS5EMsid9eTqankbFxh8IkzIVrrr9ARY9+ObJhk+NCcHGEsBAqn9OXbTlgk+b62DX6ufHtYz98ii375QmF5fO/+6xxlknHo1WSlMaGqShsQUtXM+lv7qDdQ43ryrbLyeFYAzAMR1F9UcX+yONC/2hbV0xjuUoMemjsQ4FnanxZAZFVdE8Co5YoW1MAxblwAADs1SUuCp+TKlx6V0hJGhH9JeY8/a6RK3PPwJDd5PJO2SyNms2DZBD3rdW+WAd6yPu92/8bi2yRFMaF9qStlkhsqRc0sd4ZZYFVbplvYJsWujlMja4dWjuNoczY2RF7Ub6ZBdIPN91ebyYmN1aP/qkv3UnnI1Z4dob73lxyjWLH2TrUImy7eDRRJx8ggN3HseFs77O7s2BRaM84hmtcN42g9mOIkhSFifRgfGBaNMCw3PoKxTm2p5azxAcf+cjj9PV081A9wYC5HHlerj0+x0cNq31gQlBeT+AYqV/jiOAospDANFQZPF7WT+9hfS8VfH+l4VAwJx/zV0TnnljLbqjImOh6Vl+fsH3qJEwGjUWxeCmmNtdTS+t8n+WaknvKv8n8cjy+/7xgCw8r0NzXVh9VvPWznhjxTuYlsXG9RuolKwRe+456Z2BgcwZsioNxfyh990ZQ4O989xe/4sAgxVzZoNbvjok8bjile2dJu08femrb5DOlkDyIMgar72xEk+gYdKYcbViqugc3Rrwf6b0P28wurhY6Lo8W8nvVa8FFgzlyseNH9MUmDxhkrLunbfZvHUjXr+b7sE4d9zzEAfNOKo5HFb7HJCNsm1SKIxXPZ6PxAN4RWH59j6vs8Ctv3/yOfqyZRzbQqHMyccfRsSl/82FGVcRSwGid2zvvQXbmjqgaN/VPXLrn/+6YcqVNy5hoCBR2zAKy5GRZYl1q1bi9bqn1o5o2DFnlvavILT5RPG1wfjQbK/P/doHTy3e5QBDldJxLtW1saLT9uCDf661BQ1VFjn8wL18fkV4U7B1Myi6n5LEjy9zni/HZ6uy7zWfGny6q6j/bEByfafi9jRfuPAOHn1mKbmKRX1jHcVMPw1um++e9GW+c+KBT7a6hZ+W0wNjWlzeCz8iJM3izoIcvQPBs9I2SjsK8gdr3JU3Li/7XGP7HH743JqBEXc/8jihkJ9iohd/Jc31F53L5Gbf7S7D2hhQxecAFNn3iiD6XkPyvn9cAi7PcwBvdfe/EGtpvv22h5Z+/5YHnyJUP4KGSA35/s2cd/oJ7L/TiMfEUqkiO9ZQWJL/UN3hVarCokqV/8/4RF7zw8tt7XXp5qaRh73+2hsEIk28taGLDZsHxu6yy87aBL981Iff856oAPDK4vJEbnBmIpf6RosncKHb7xEP2HefvfRCUYoPJJFUL2VB4813OlmzMTmqccSoCapfGFU2jXF+SXrx0+anqMGnPVrgeYCYS/51k8rlXq+y1xGH7NkQrfUo69a+g9sbJF+RuPdPL5PWAzsYpvKVSF2N2BDybLeglqH3z5GE4hSrnD1AVPwvAww4zMoIHHbvo09LOd3BNEyiXoVjZ+yH38mt1YSypolyWsG7bHtjbsjl7l0Wz8648d6n6x9/ZgUFpwZP7QgSBQtbVnC5veTTJdau6cTr800YP7pledEoTKnY5bb6YM012xvTsqmRkAuChf3kky9OKZgStmFx6N67EgtoT2uInT5B/sSeIao83FNkc1m/4c0tma/e++c3mudfdS95y00wFMbvEalkOjn9uOlc9J2vFg+e0nKGVsxujanar2Uz36CpH+1JIsgfCIAPi4rekjPP8kqhv20xzlj00PPS7Q8+jm4auCopTjtiPxZdNGfRDiH52ia3+pP3RAXAgFGY5ZXUj6xrAjoqSmiHyxY9dPzvn12GUtNIpVjEb2W54tzT+dLUUTeOlqWOmKL8uioqqlSFRZUq/2GUK86Y+np/WnUHdn5u2SoG8gYD6TyvvvYa48aPuaQt5PlItH4qk+hwuzwrs6m+HzbVtX0nmU901Ls816ua0L3XbmNWjB23y/5PPv0MoitAzrCJD2V5+q9/xaV5puy0Q9PzAXj+0+aVyAzM8ri2vZlHNGFJtpQ8uH1ES/NpJxxy38uvrJ40mCpStDW6Ejn+/JfnyOSdsbYSvsQT0HxBhaf6M+U5Ppf8CoBkpQ9HFktYCII8/LSftTmgO2d+6Y4HHwLJgywI7NAc45iDd18RkszH/ZIQVwSQ/k5Y9OZL8xKWffKGZG7GD6/+JW+u7yFfcoMQwJI0bFlC83ko5ItYZRAEmRVvvYE35J/aPrq5oEliZwD5ue1abGR5mU/kFVMg+tTzrx85UIRyWWfG3rvTFnXfVy/IN3yWY9tbceY9/re3zz//Z7eyujuPJ9JCIpXC0dMcdeCu/GL+t5O7joysb3KZP6mTXLdlBzovNYrpw0Ph1nnZbP8cTfv0xm/9DnPyhjDt6de3nnrDPY/y3LJViF4fKgY3XPJDjt1350XBSmp1rS98SymV6FDcHwiS7YmKgYo5qySKE77zoyuOfvqNTkxXGMsSCLlEfjl/DnuMqr1qhEs6J5PdemXFLo9xKb7X+hI98/2ewPPV3Vzl/yrVGIsq/1VENGHJSJXT9tplDIGghi9SS0J3WB3P8tvHnuf1RCkzYGxbSromOOxTr68ffVJmsPPmWt/wv6Mii5vh4r3HaRct/MHpBIUCol7A7Q3Qk61w45KH+eOrWy7d4nDNJ80pl090RIIfDUgEGB+qPbC1xn2eoGNe9YMz1rXIJopeAEmi4opy+xOvc9V9z/LEiuy56/I8VB90XQeQTa57CLX5YojdJLo+aGomWLYpKgKWAMViEclyqAtFEHVK9XLwOrdQt8gs6k0fnsOmon6b6XPXPr9646wfXv4LeoeKuP0hSoUCkWgQo5JCLw1h6Tkss4w7UEPRlOnNWNz1yLO8tnbLVANX/YZ88a4Pj1sa+rtaGQ60jhiB7PaiOxJmxcIp85l6YAw4zCppwoRrb3uItOGlaCr09nbRXOfhh9/5Gt8/6YAXmoXKRZM8gZ3U4tDUZP+qlxvCwSfD9aNPKqbiswOBT2/8tlnnhqzN9NdW9Rx/y2/vZtnrb+LWXFAqc+gB+9PeEDb8gvxC2Fd/nVNIdLhrPj0ltk6TFz3/2oZzV3XGCda34aAgG0V+MPNrTGpWrm3VOG+gf8NdwUDrecF3G+81RJouG0rFq8GbVarCokqV/yTaY/5rv3bEdIKaA3oFV6ieh//6Bg89vzxQkJm6pj/9zPs3wNy7KZPFgVnBaPsZfz9Wk8Bl++8YufT6C79Pi9ehe91buFSNvCWz4JpbePz5NWf3wPzeVGK7Lgu/75NvQPWI141SOWVKiHGXz53NUfvsRLZnE6ZRIdYykre2Jrjgql/x+AvvHL0p49wGEKgdTmf9MGveeWt5vSpe99cXnqdQruBWNBREwr4AokEJwCglOtye5osLpeHMh/WF4v1lTR2zsid37nmXX8uazYN4/RGyyQyUEuj5HoxcN04xTrFrDX6vSLk8RDabwFMTYfm6buZd+kuefnvLLMvrCWw1uPIDIaFvU1odASZOnUzetLEUja29cRpcXL1pQ+ddANnswDaCb1M2d9vmSvGGdeXyQw/99bWb9z3iuydnTAnF7aFcyrLf7hP42Y9P59h92u/2VvLLYqJ2k1XsXhB0u9a5vf4XBc9wwStPzQdVUeO57HZv2Mu6swlbxf3oc+uPvu62JWzq7sfv9eIyStSpNqcfux91MosiDKfZCt5tj2nvQPJj+788/eKrVByFoaE0TinLyV+ezn47xpIjZM4BqKsffdLfvydcU+0NUqUqLKpU+Y9CLRe6v7b/1HWH7TQKj2xRqVQYsjQeWbqGR1/YMCtSH7qzN5ObB+D21y0qFAZnlkWx+HHjNatcfNgIQbh67ilMbvIQknVMBwq2ylW33csfnnn7UiUUib/3+kQ50bGld/MNn3feX96pSTjnpMOZf9oxtHgtEt3vUCinUUMhbnvwj1xy429PXTFYXguwOVe5AWB5V98mgPE7TNppUz57m4lIfTQGlo1RKtPe3IrXxTIAxT18QyyXoVc35mlez+aX3tq077fOOR/b34g3Ngo9Y9Lk9bHLxBZO/eoBtIZNFL2H+iYflcxWzvzOCUSbvFTMMtHm0fiiE5h78a949MXOI4oSkwepzARwBL0537NylZ7ceAcM1x5paGujLIvYbjevv72KQZuZI0e3nwSgSh9YUjbnuMGU/bU5PPv89Ka7jv7BT39BTXs7ZaFETRBOPnZffnTa4YwOsEItVHpGuH3nAEi2PCSoDVd7/K3nbfeCZ/J+mm0y1f2+WyxQH3j2wSfWnXrng0/SnbVwBaMY6QRjgxLzv3kM41xcpTp0J2x7u3UvGutqt1sV868bks7yNRtxEBH1HPtMauPkw6dmYwo3VndplaqwqFLl/xANXu/VU/zCuBMPmsZBu+1IoXcrgXA9a7sG+fVd9/N2T/l2wet/v9+F1xtd7HJ9smUhk050HDEhJtx42Q8JSwaqXcHnC1CyJBbf9yh3PPzC7Z0l4+aEmeqQJdszorHtrH9k7ns3uoX9JzTynROms8fYCAG5SC43yMa+Af62egtzL//12FufX+uIfq20MmWtamhpuGpdNv9Qdym3QPEF4q+8upzUUI5SrogqCrS0NpAtOtP7Upn3XRO1NZElqAqre4vnzv/ZdQiBGMmSiNsfwzEVFEdg/712Yfo+Y7FLSUQjSzq+FauSZqcda5g///sgOmTzFfpSNp7a0fzi5rt5cXnPjLwlTwPwhMec4GuaPFGtHXUKwFZdv7K91d1tCQKi20uwro6iw2SAbGLDXS7vB83eJDfZwZxz9NnnXzXl8RfexFffTs9gHI9H4BvHTeeMr+3DmDCLJrnYqdWrnZcb6p9jZ/rn4Ptkl0e0JrAYIJHsn1Nb03xxXzk7dytc+fTLq4+/5c57WL5qPZLLT1mvMKqxlrNnfpUDJ7Yv8uj6ikaBhRFRXAKQqDifWnJ8RV9h7fW3/ZbuvgHcLpldxjYz97Sv0uDmqmYPF/fF+6tNxapUhUWVKv/XmNQSObPjyweyw6gmyrkkoiyxdTDNJdfeSEFmarftLFiXSz/0qQMVEx3B0LDwaPKx6OcXfp8xMT9CJYsgCGzsHeTXdz/GhnhplmmJtaL1j895a3/vlRMbfCefd8hk4SffO56JMRGhFAdZouKqYVlXhitvf4QH/rLxXNErlbIG08uOOMZ0+2r7cpVzk0NFVDyooozf62HEqIDhrxFeUPyu9y0q/Tpz0mUOv/+Rv2KrtSQGy2jeKIlkiUi0kZmnns6xX9kfRYFiqcCIllYioRoEy6BcsqkNw3777YPmDeAIfobyIhUpxLyfXsfbm9Oz1hUrH1lTTRI7BQdDciCXzbF281Z0iea+Un5uIDL6pE2JztsANhvcsDVhn3/eRT9jfXcKyRXG4wtSzCU47kt7c+JhU1e0uji3XeB9t5U/XH+dGKz/zNUq+9P5kwcde2ZJCUx46JnXzv3lrb+lZFiEwyG6tmwkGvJy3eUXM3VU893tfvWMiKq+LzoHi+WZEU34WBE6UGbWhiJ3XX3bXWOXvbMFUVOoq/Ew++QjGd/A+U0alwHIklPdoFX+K6lmhVT5r2UoPTgz6vXeQsBzmDcUbl628m0cxwYH0qkUIvKknXYcudanuV7L2MaMvGXu5Rfl7aaOGqXCVEkbTk+0BDsUCnu3to8cM+3FF16iUCwRa2hlKK+TTmU4ZO+pf4uq3mu6kkOXBz3upz/vvIM+/1MeWVkJMMLvWrDPYfvu+M76DRPKyPQN5vCE6qhUHF752ysEAnWNsYa6CfUh5Vc5y943rzsjnl+6lmIRSvk8smRy1JcPkrwu1iuiPTiYTZ2eKSuHOaqkvPRW6huLfvcQiZKNK9xIMNSIqnr48hFfYpddI8gSVEy4//d/obuzDzQfqqbx9ZMOoliAptYWHn38BYycgeILopeLaKrG0qXLCIdjO8TaI6GKyaihge6vGlaluc7tv0UXaL77zyv3Kuo2qb6NnHjcIeFSobSjo6E57hotYYvfvO2uP556/qU/w5A8xNM5gpEwlWKOCSMbOfu0b9CmyRfE4KZksme+5x/NnqgJk7aEI/+6fMPXf3nbPfQksgSDtWTSCUa1xbjuJ/NoDUqPjQ3Ix/39W72KvPzjhu3K2JdnROGwe//8ypF3/fEvqMEaHMfmWycew9H7jLvIymZqgprrqUohPjsQqr++ukurVIVFlSr/R0iUhzpqfZE7EtCRMipfaWqJBQr5HBvWryefLxEI1rL89Tdobx41dXRL7V+Esm00auqVH7tRNO/yxFCyo2gxOeJ2LcmZzv6xWt/6KTvuuPP6dZtY+c4GvJEW1m3czK7jJ0z3er2+1hrPvJ6yOT8gi//QzS85tOk2j7vmEQe0HXfZ6SuhcISungG6u+LouoPL5WXZG29S31hHQ1t0VC6fneAPetctuvWR2mLBIRTw0dxcw6Ez9kCUK7hw1juqolUMbdSGreVTF/7yN2yOZ/FGmlBdNQxujdM6chSSV+HOex/hoUee4qE/PkdiqMSIibsiKj6SyQx/fORZHn30KQaHdCJ1jSiBMNl8FtvUEZDp2Zxka6KEIwSmjRtTE2/zB87yuIZFmW7R/Ls/vnZ0ulDGJZp87WvTfYLgwpFlZdOgccq358yftLk/R1lUGEgn8fpdlIsZjjp0Oj/50akrmjT5Oieb1/ya+vI/Kiq6iubleVnc62+rh46++tb72NCTQtH86HqelloXl//odEZF3E/u4JUO/7xjZxzhsBfWZb7x81vvQQhGSBXytMRCXDLnqw+LlUplhNc7N1fon+Px1t9AJdFhm8XJH66hUaVKVVhUqfIfSsEsTfXK7uVDtnGcZRqhkFt9etSoUTu/+cYbOKKLvv4E0doG3lz2BuNHjp0xtSV06CeNFx/omV8Xid2QzhcO97tdLwYl4elMsTCjsbHm+XETp+z14svLUPxRCgWdpS++yKhRY/YKtQQ1RRbjJcfe0SsIyz/P/O1yosPrb/pJ3hicmczED54ciu6k1oQu2XvvPXn9jbfx14QpliqYWCx78zXG7zgp0NwcSWZLtDz48FIGh0p4vRrtbU0cfOCOSZCxkd1lRxn79vrkgTfe/gAr1vdT1zqWoVwFRdIol3QyqRSbOtdhWwZW2SCfLlAXbSEzlMGjuPG63Th6GUkQ2bRhE6Io07O1C9uo4JTzeAIhahtHs3lLH13dXYTDjTsHQv699LLZ7HeJL2ZNDrrzkTdmlC2JslFk4sQ98AcVz5be4tj5P7mejd0J0sUKsstFQ30dimQx98xTmXnUXg8byXLDGI98ol9TXwYopnrm23Z5B1ndfrGv7dGbq8wrqurOL74dP/qyG++gJ1nE5QoQ9KgEZYvrfjKPkTH3kzv4XIcCJNK5Do9L+9Qbf0LXOxIl6eSUzVHfW3BTbVIX0A2bkEflm8ceyohoODTepx0ymOmZ71bUXln2rNTL2emyp+4WPd8/R1I/vcZGlSr/VxAcp+rnq/LfT49uzB+smDMHy2L7d869lLKlkU6VCLo0dmyNcOs1Z131kV4Sn8Dm3u4b2hqbz+qHOVmY/uybfUdfe8v9ZPIVskNJ2htCnH3qCRy556gzBAcjKvxjLbBL5YFZiuTIJdNRspYWkH01yTeS3Hjhz37Dhi19KIqCXUoRDrk58IB9OPKYA/jWt3+JzxdmsG8Th0zfnR+fe6gRT6A8/PBT/O3lN3EEP53dCQKhRiqmjWE5WJaFS1UJ+D0MDXYR8KgYlTx+twvJsSnmC7jdGqVyEU2TMG0LU5SpCCKGqCIqLkRRpFKxMHUVn+bGMTLUBwS8doYJrU18b/bpxVA9j59w1oPHdybT+PwKp532NQa61/G3F59j3fouampqKBfS2HqZA/aaxqkdxzK2xfWsUsn2j3YHTvpnzoHuodICy+8OvNFVPvv8K3/F2i0JAtEYsl4mIlf42XnfYdcdopc2q1z8j4y/xuKZ71342+lvbh4kX6oQkA1aa1RuvfKC7pBYebw9oJ1R3YlVqsKiSpX/Inpte17aEg9f0Zna95zzLwcphGWahF0yU8c385Mff/P2bF//9J2a6kcCDGX654Q/FBBYzCU6/r6BWZ9lzM07yjRRpvTCO7mTz1/wc0TNTz6XJuaC75/6NY49aMpF+UR6j3GR0Jf/fk5DycGZ4drox4qOQq5vrkSlHaBoSdlwqOWCLXDN6kHOfvqVNdxy5z2YhoXq8SCJGjWRJgaSJtlEitqgQtAjYukFKpUKFhr5ioUg+4hEosR7e7ENnfqwH1GwMY0KRiWPoxcIeFVsvYLX7UbGolIu4vO4KZfLWI6D7tg4ooQuyhiIWJKE4UChaCMIXlRVQ3PJuBURvZBBtkE0ZTRfmKLoIl2qULZKROtCKGKFfCoJpoFbtFHsHNP32pWzz/xqd0TjTlsvukeonnM+7fimjcGZIlYgoGwbxJkYGJwVqYsu2jBk3rV0XffXL7z2FlK2hisYIZ0YoK3Gw6KFP2SHCGfGxI82dXMqgzN1wVHKolgMysPHv2docH5TOHoZwIahobt0T7j5jAuu33dDXw5b9mGUCkRUgx+c9jW+c9AOQnX3VakKiypV/kvpg7kDZWY99Oc3xt506z1Eog1s7lxPLOzjwP134YI5J97uKhbWN3q8Cz9trMF8bmbU51/cWbRvFjyiUYG2X9zy8BGPPvUyLm+IXC6DTxU55zszOXK/0TcqJnHNyHVG3P4lAFs631o+on3STp94s0z3zgPbLcvykG7Z7nCwcWFvdmieEgjHBy1m/vGlzn2vvv332N4Iyf4UBOvQJB+q40BuEMnMUyrmCATDuEP1JFIFFE1Dtg0kI02N2yHqF9lv710YNaYNv89NOOjG79YMyzAVv1teJgoUzYpV63FJK3SdZsMiZjrUmlCbKZls6e1n7cbNrFq7jg2buxEUH/3JDBVHIFTXTCJdwesJ4xZdlPIFVE3CdGzyRgVHdJAwMNKDNLhEfHaOH597KgfuPfYK1aYbs4LoFEq57NAhI+tGf6LFolDaeqVhO/Jg2mwe0zTqhG2sFcnigrXx4kVnzr8CMdxIIl9isGcLhx5yAN/48kGMb6zJttVoZ0ZUPrWaZvdA74LmusaLATpz2ZtlfyC55E/Lzr/9gacomTJmsQjlHHNO+wYnHbnTtSMkzqnuvCpVYVGlyn+5uOjPcfYtS/7c/PiTf0W3bQzLJBD08v3TT+Sr0yecKxfTQ1FP6DO5L/oLxhxHU2RBxtyarlx5yqzzlLypIvlq6YsPEItGOPGYGZxx3G53jxY4CSCT2nplsKb1vH/me7zcPeBY4TrufnYrN937J9zhBhDdlLb2I7k9UEghWmW8LheSqpIczBOMRvG5NHJDW2nymvzweyczbafaJ82SWesPyC8IYOpGscmlqOtxbDRB3RyFxYOONTMqSO+vR6/FPMMkZgkETKh1JGQLAnmdaa+t6FIuu/JayqKbTN5EiI7BKQsIqg+PpCAaRSzHRPB6KRoVVFmmkuihRs9w100LaK3jhQle9vu862HovfPShfKYaM3I0wD6k/E59bWx6/qGinMbwp6rZ191j/P4i69TREQQYGRTLWfOPJF9dxrxD938u01zgSHL9Y+9vG7WzXc+yJrOODX+EEI+xYw9p3LFhadc0SJwQXXHVflfoxq8WeV/jkrFGTXKI8yMtI++5O3Vq7Akmf5UDsEdYvPWHg7cZ/cJo3zuUwAGB+OzvV7fJ3be9KnSK36Rl/Ol7LSw3/vgHrtNO/rZ516gbMtooSjpCrzx9loULThp1A71UcNyYmFP6OcAJT0+W5E+efyPCKNM/1y/y/eyGPDaKZ3pKzYM8tbaTVRSGUxbQFI0PB435UwaxV+DISgYSPhCYUw9j6xniWo6C+aezoypoVMl3chr5DarlHqaJPdlYUl5MID4XECQnvPCcgCvIC7/8Bz8Ii+GZJ6okXikVuKeiMhdgoihCMTrgsFoe1tbzRsrXkcNeiiUy3jCNcgOiI5N2O9BUTU0Xw2qL0gum0fyuNhp8jhaW1pobZUTA0Vm5cuVPWo0+ZFPWw9LH5wpSt7lkuR/sWSVx3jU4U6vyaJ+oiG5Gy23Erjn2bUv/O4Pf8YRFbAqRL0iPzt/NruOabi0VRHmfd5zqDOTuRmPR3y9q3zmbff9ma3JPJZjEdAEdh3ZwI++862iV5DfqOh6u1eTllV3XZWqxaJKlf9y4nl9tuFSYxsHKhctuucRnnllBXiilLJJTjtqL37wzcMuamK4kNFnoVSIz3Z7h/s7DNrM7Ctw7i/vfHzCX15dxWDZweX2IpQz7DV5JKcdM53dx8fONjMD4eZg3fuBgik90VGjfrT6Z38+OwfVBZKKIyEnUrmTU/nKlD/99RVeebuTpau3oPhjw429LJFIbSND6QKm5KYmEiWVzWKnE0jo+Clx0K7j+Prh+7P7RP8VerbYPCrsOeW9zxoqbrlGk6WsJAqmKEhZESkrS9HPHXi62eaGNzYlzvzdH5/i9XV99AyWcGlBRFtFFAQMBwSXG0sW0S0TjBJRr4yTSzKmsY5pk0axy/hGdh7X+uz4gHIgwGB6YFY0tP1mbh+xJmRzCySvP9sZN666+5Fnee5vy8gUyrgkh2Nn7Mm3TvjSs0Gp8GSj79NdXts9f2D2fS9tuPGux15k7dZBsoU8dSGRvSe2MeeEY9hnRLAaV1GlKiyqVPlfY7BizuzOlS9VI77uq259ctpjf32TTCZHo1dkzszj+dJeEx8b55O+/ImCIr3ptnKpOEVRtU5f7ZgTEkPx2ZFw7KaN6dIdUtCdXRvnzO9ccBVSoI74UAazlGdU1MV3v34Ex+079ux6uO49y4Vbjd2UKfTNDXqHm2e9LyxMa44jS3J3snLp2u6kZ9Fdf2Dl2k2Ikoqhl6kN+CjmsjQ2xLj+xgtYuRoWXPlrCq5aSqYAikjQZeMv93HmCYfyrUM++NxEvtQR8bmXfN61KxcSHaIEqiuyxDIHZoHtliSxZCIWZWFYHPXB3KTO1x//6/qpty95kFxZwhQUDEUlXynw44vPo30kPPH4Sl577Q3Wr9pE64jRdG/aTNiv4fcYBCWLrx/xJTqO2v38RonPLAI25cq3LduSPfWya3/DpoEigWAYl1Xi5/PPZt9x2plCPm/WBXyL/pHzpjOn3/zYq6tmXXvX0/RkHCRZIxqS2WdKjHnfPW7pRNizq3/w8pb6aNUNUuV/kqorpMr/HIXkwCzV413mlcXlJbO4oyO7tMk7j2pd8VanNDSUQTdh85Yt7LPn1LFuvzLog491VThm6mifS+1R3Z4VhXxh91BN/Q2JTLKjORRYkMqVjw7XyCtGjZq48xN/eYayKRJpaGFzdz9vr15PbSR2WFtr7dZ8IbdXyB2+CcD1rhn/w0/GBUvcfUvSOO/ux55VFv76DjalDEJNozGR0GSRtroQv7lpASd/Zd/HUgnGXjz/MnIlHVQ3wUiIUiGBZiaZN/NIvrRb2zKPnl3pU12vAHhU5R8qziSrnpXSu4WdLD19uGOaUWyzFsf2iNJw4apsvnSwpilbx7XXbg76IlPWv7OWwfQQtuJCUEVefeU5RreO4qC9RzN92k5Yhsmqt96iLhxBkmR6BgdwBcO8+MpbvPzamoN33Wu3/aMav/2keW0cKtxRUdSRq7sGfvTTm5bw5sY4WqgBWVE4eM9dOf7QkQ+PkJjr1dRl6IkOSkPHoQae+zzffYshXX/1rQ/WdGdEbMmLaOgEpRI3XPbtpe5KaXWNrDwS9HmfBsikB2e63i0OVqVK1WJRpcr/CF125XJH1JS3e81zL7zil2zoyRLwqtTKGW762QXsXRcQBsrlWXUu1yKAwXRxZjTkWVzK9c3VZCugG+UxrsD2MxYSptnhyLLy0obS7ede8Ss2DuTw+MMIdoWwUOKsU47lW1/a8Yw62O7T8yqdl+N5pn3nnPlUBDdZE8q4sEwTNxUmtjfws/NPRwW2bu3n0iuuJpkD21NLXtAoVMo0Rtz88IyvcfjODQ+METmhovfPkRyQtc/eW+Oz4Jjx2Y4jmKKyrbtik27d5qiS8tLygZOv/PU9bBqy8NSESfRvIhoSmD/nW+y3S9u6bMEcKwkyv7x+CS8sXYEYDFG0JfI5EY8iskOTi4Xzz6ItzFVCxTJaXNIFCYsOCzOAKFDMmVNUv9b95xfevvTnv/4tKcuDpQYpGxBQ4PE7ftAd1HlypMZpAFQGZ6J94ObpLxfm2LbtbvT4P9YysjxtbZp/zZ3tf12xFdFXj2PZjKqTueSsb3DUGHfV/VGlStViUaUKBAX56QLW1JBf3trQMmrnF994m6F8AUWCeH+ccTvtfFi7R57dV3bm+mXhZa9LWQ6gaP6XTas0QfO2fmzwn0cUV3phuawq4/bec89JTz35NKFwhHSqgIlIT98ASJ4jXf6a7zT4xG1cIMuGrMRzb24ee/o5F5MxFQzZhWU76LkkrREf58w6hVNPPABJgMEhgx9evJC8KSO4aigUKhilLNN2bOeEA6dy5LRxS3dQObRQ7J3nEh3FQTBF+V9b7VEQfa8J0nAVzEw60eFyDVs0CnZpqiapW30B75hgqKFmxaq1pDNZwpEQigRvLnuV8WPG1jaGg8mwJjx+wG6T1++7x247PP3X58iXbTw1TeRNKOgmG7u2sNeeO7YqshhP5J2TC/n87pZg16iq1p2pyDMef+Htk2+5/09IoRj9QxnyuQw7jmnljI5jmdDqWzpG5oM0VHlbS4JPVl+pyGKbR5C2a8VZmSqs+u3Dz4z94wur8NW1kS+U8Mk6s088jOlT6q4NSTxRzg/OlNWqhaJKVVhUV6HK/zx+xBdr4BFPzLvza6s37bCltx+vx0dv1wDpTLF54q7jQrphNWeL2ekhl+uJ9zeQ/NkyOsIqD3okO3/oQfvN+ONDj+AIIqagkas4rF67iR0mTPKZsvYDtOGMi+UZNt3w2/sa//DUS/TnITJiNJVSGY9QZsbkVn5+3mnsN772oqDC0lVbK/ueOf9KrJp2+ooKgiuEbRk0eAVmHXcwJ+wzYdFYr3RMOR+frSHYorvh6o8TFRaJDpF/vneFLRamKtLwDTZnmPsKomKEVJ5oaQ3KAXdo7LJlf6OmoZ6eVJpUEZa9sYbRTWM9Ixu8y8aofE2k0vqNbxzxZm9faudXl62ibexYBtIZuvt6WPP2O4EDp+8q+l3CiyM92mkpRzxWl8XmPz6/5ohf3fUom1IGFVGFSo6RUQ/fPelwjthrxJ1eWB6AT+wv4hGklQmr1OERP3ARJcpDHVlZnf63d7ac/PNF91AWo5QMgYDL4ajpO3P6cTvd3i4xuzyU6KBcGSX7Pp9rpUqVqrCoUuW/mP5cbo7j8jYve3MFxbKFPxjl1dffpKl1zLSRrZGNImYppKiPf54xzeLALFHxLvOrwsstfmnBjrvsccnyt1ZTsgT8oQgb12/g9bdWsf/0vTV3AN9LG/K3zl94Tc36rkHiuTJaoJZ8LkdTrY+vHro3879z7LWT/Oqe6Xz+SENSG3/7x5emrB3U6a+4kQL16LqFW7KZ2Bzgu1899IWxQfm4SqpnvmgZ9Uqw6WMzXRwGZzrYPp3yOPmfFBeK5F1eshMdiuBZGZCV58umsUNUkhZHRO5qGhFpzBcrU5947m+Em0ZiyQGS6TIb1mwi7K2Z0tIczquy2Yegsvvu49lz74NG/OGh3yOKDqJgYVSKvP7a8voJEybsX1C1wyRNzL60ou8bl/ziVvDVUXIUzHKRRr/AhWfPZN9JbQ+4bX1NkyR/piyfD4uK/kJiTp2n9pbV6dwLF161SBoqqwiuINFwkJawxLzZRzNZZReASmpwpqehdV51F1WpCouqsKhS5YMndskMxRrqx7zy+hs1iWSBoVwJTyBCV3cvba2NE8Y21f46kU18M6R5nvisY4rKtk2y/CF1Y9uosV959oUX6R0YpH5EG72JJAVTxHY1NF910+30D+UoVAxcmkoxn6GtPsD3v3kCJ86YcLeSzyZyxfR+LcHwBS+ujf/+xnv+TG9OAClIsKmdUjaJYuQZV+fmhEN3vsYn8IpVTB2r1Y6Y+0nzdCjubDm2xxHEkvwvsFpUzMJUk+LOiuhd7pWk5e/9vkbiUZcvesnKDV10DeZRAzHCDSPY0t3PGyvfZNKU8TMC4RoRB6lG5VFJcA769sn7LVv+2vLmZLybdDpJMpvhtbfeZvfp+ze/sLxv0k+uuZmCreKICqJRQTXTXH3RD5jUFl5a6zLvqZe0zx1P0lvIzmvw1ly9Fa686b7H931lTTcFQyAU8CIaKa6/7EyiqvNsVBZ+C6D6Q09Ud1CVKlVhUaXKNvhF9eWhUua43ffYc8Rjf3keR/NRtKBUKdPf3cnUXXfeZ3zAf9B7rx+o2LO8svCpBZAKQ90LVPewiTxfrEyLNfpeGzlu0vQ169YykMngqqlh5cYtPPPKG2TKJrYoUy4WcAkGB++5E5f/6HR2a/dfpTlsNvVytDVY+8M/rdnqzD7/chKmB9MTRqttQi+XEUtZVH2IUXV+Dj1gp1f13FCzy630SZ/SnlvAu1wSfK/8K0QFgCp5lyvi9uMNbFEdNXrC5Cl/e+UVKqZFoVSkNlxLf18ff3tjGeMnTxnl97iby2Vz3M4hqdVyCB11yO4r31jx9l6JXJmBsoHpC3PPYy/x2lub0W0VRRLJDnQzvinMubO+wS471K+IeqTFmWTPjFpP6P7PM/dEsdQR8/puWmfyUJ/JqYsfeJr1PUkUl4ZoZvjJvNmMqfOsCMvGA35Rerm6c6pU+dDDVHUJqlT5gGR5YNYEf81+TTWehxf+9EIE2aKCjRKs4S8vvMbjT75U222y4L3Xl63SmE998u3ddJs33Hzx1t6eK7sTQwvqvNqiYlafvPfEmqvO/94peKUiHq+Co2oodS1YriCSO4ggCEzfezeunvu1S/fyI1T6t7RZ+XRA8QfjzyVxzrz8FgacEI7ipi4cgmISrTKEZqRxiyYoEnmbaWnRdbjqGq4tkSolOv4T1nlUjXTK5Dbvwz+d8zVGueP4S53kk520TpxAt+HilHN/zpq4VVtx5PatmYEr3ZV4qRXOO/WELyMqCk3jd2VArSetNdKXUyg5LsRKln0nxJh74kEcu2fbmZPc7DSUTh7vDoRWD1rJmQAlZ2DWx82pNNQ318wNr49lmIF+mJO1mH7PYyvZGC/T0DYKr0/mxOOms8sOkc6AXHm2QVKvru6aKlWqFosqVT4WjzzstqgVhXtKsnqJ6Qi8s3ELmVyREa1trFrzDqNHj9vf9nqORRXFJkW9vKcwOD+gej82KNDvr3mkPzE4pylWf1nA435uc6L/hqDf87QjSkos4t7aOGGfne9/9C8oNRFUSaLWDVayh/NnncI5J+19RQvMT5QyHS01sfkZzXXYujQ/PmPeVWzqydE4egcsSyfZ14Pi9qAX86hWBZUSDWGV/fbc1dJksSssi38AKNmFqW75/2/WQvfAwIKCbU71usXloxsjD4dqgke/uux10mUBPLWUDDdKpJmn/vQEk8aN0SaPrPtVoTC0Q8EsTo011K/11tbt/trbaykpATx1I7BkH6Jt4nHynH/mNzlk11En1wncNmw2kUVFUgcFx7E9orbSFkrjP84iY5ULu8uyWBJUz8q8Ye+VUZRDXnknP+mXi+9D84WoZAfZb+dxfP+bRyWDmE+7sdb4BOWV6q6pUqVqsahS5TOxh18QZh60W/HEGfsgmmWGdNhqKCxYfC/rC/aUzYXyjRuKybtqPE7cYPhJeEAvbfeJ2HEc+b2fG2rs7oisLOnqHryiAFNzuorbW49mVBCTGylveIG7F57Fjw4ZLbQw3MQqqYsnvm6S+fOGxLmnzLueLTkJf0Mbvd1bcYlF5v7gNFRZwF8TRpDdKIpK0AU1Lh4ZpUnvl+wOv1u3YcAozPpCFq2Q6KDcP+fvf91jM/+9n5vr6i52OUWioro4Cov32G2XpVdedQ2+YC3ZogP+djy1Eyi5Wrjwxrv408bMnWawNaC73M2aXOqcefBOZ1/4jQOpL/aRf/t1rGKGYKyBlKDhhOrI2ez73mdFRXVxRFCWRKThjrIakY+tMuqqqb9O9A7/v+F2x97YbB1x5aK7MR2JbO8W2l0Ol8z66uqwzYOybiRtQ3RXd0mVKlVhUaXKZ6I/kZwD0BJULzhg6kSaokF0o4gja2wazHDhldeTLIHPU/vKhs1dlysMF4WqU93bLXTVEK27GqBsxWdrklgCqGuOLlq2zplyza9+QzDox8kO4CrGWbTwAqa01Jz63nt7S848MegvLe9OBn58za/pTZeQPCFCoSBWOc8+u4zn0P1iZAf7yWfyOIKIAziYSNjZv5/LoFOcaQmi/wtZOG9kCbKc/PCv+gzmCg5G3LJnA2TLiQ5FlXKDuf45XaXi5T6FpY8/8Vey+RKSpKCIInqpiCnJpFE448dX8uz65KyC5J8qiG5TNnPJ7+y5s3B+x1EEjCQxzSC+eT2ioHDlDbewtjc5q9vSFwAkhpKf2/UTt+zZ/UXmXHvb79gykKRUKNDWEOHnF56LWih0t4ucMUJ1n9OoagurO6VKlaqwqFLlM1Efqb1u2NJgyVPG1b1w7ne/hVAcglIaybEZTGS59KqbWTVkXhtpn3pV3MrP/liRUrDmdCeGFgCohpQtlaRs3LBmx3Vm3fHQH0nnBunteps6r8mFZ5/K5DFtt0cFhi0LRWYZbiH27Fvdxy/4xQ2kywZ4VEwzz2D3OvbbdQJfPmAvAkBdIIhbUkAQsAQRy3GwcAJ/P5+o4Fks4pS+sMWTt7UKNChc3SixMCaJNwEEXJElPlfdoiLBtkTZdfKDT68/+5FHn8Oj+dAEAy/9lLpeIVoDPr+LUsXmgoU38uqa5LSU6T46Itcs6SsU5x47bdy5t194JsLG1wmmu4lpGuvWdfPja35Ll6Fe1G2zIBKu/Vx9UNaZ9kODjnjqtYvv9fQNZRBFkZDfxfj2Vlrq3Xdj6tXNUaVKVVhUqfKP06BpVwclntppdB0XnX06QamCYhtUdIuuRJ6/Lt/EphxXmJKvtt+ofMQFsLnCDfVe6brmSPjieO+Wa0RXZMlATp5cVKQp1//maV549TUCPokGv8Ok1hoOmTblYU1gc9xi9jtD5hNJOPFvGwtnX3b9Irp7E7jdbjTRpsblEFQM9t9lB/aeGL1bKGOIpoEiCjiihC0J2IKIZRP4mI1f+v+5rj0m8wcs96yrbr+vecEvbkRyedArBYx0N0b8LdqjNsmNb1BJx5FVH4hBLrlyEVtTTI/DbEn25KxMOnDcTo3CNT88HX+ln0zvRnyBICs2p/npzX9mU4aL4g6zB7If7/YpD3Zd/t7Pax0eTUvi4df97ompT73+NgXDpFzIQiXHsV+azsDW/q/vEK05tLorqlT5ZKrBm1WqfAoF09rNMXX3xFH1f/N4ApPefmctmXwFXfTy1ppNFEo2bW2t04OK/GpA4jnMgVm2ntunD3W6okrxDMwoGOZu9aHwxQCdZfetF15/3/QnXl9BsLaGcqKTCfU+5p/1Lep87rsESTRyNvt3ZfUjbn/4L+3X3Xk/A/kygVAY0bTRLIdJIxr4xSVnc9AuzYvsfMXn88iv3XrvCzuXBBfIApJYpiUsc+Deu3XWisJHUi294nBZ8n8VccueXRKFHYuwsxc+MnYhveEu1RV+EKATbv79S++ce9mvf6e8tKoTNRRBcqmIdoVD9prMBWccz5f33RmvKJLo7sOt+jB0UNQgL770BpMmTz0i5GejYumDfpf2cjAka0cfc2T72q7ewKpNvfhHTKB7sMCqlZtoaWo/IuIXNoY0ZZsaEyk90eGWPCtlb/DpXKl/TlIUpudEdf9bH3uz/p7HnsFR/aQzWUY0RDj9q0exx7iWYnNIvSKgSM9Vd0SVKlVhUaXK5+K9Spnv/dsvii9HVXlxTyI+f+cpOzx70KEHTXp9+XqKpkCmaNDZ1Y9hCtT5tP1Hhb0L9NzgTElR4gE1eE3c4UxJINskiZdvSBXu6iqpl5/yo5+3rxssIKoKkpFn2pgYC+Z8m70b6oSsLR5UFhm7urfw1bMuuoxl67eQs0CSVOr8XsxUirmzTmPW1/Y15EJW8gr26tE+10kDRWb98W/rxuYcFVsRESnRWity8F5TOyOieNcXLr4EezdbED0OaAXDmOqTpNcAipX+OYrse6UsmbWa5F22ouysffCF1TN+dts95EQvjtuPYxuUsgmu/sn5HLXfRCbFPJcGFSG/727jl+2+056T7r/nQWxLIJXTQdC49w8PM2rM+Gn7jYocCpAtDh00Lhz+cnjMuEvSFXh7UxxRC5BMJFi5/FUO2m/qGEXSB72S+r7gcUsfZIZoiu+VVdnCC6f86Jron/66DG+smVwhT13Ay5UXncOe46LJRh8Lm1TpJ9XdUaXKp1N1hVSp8nfInrqPBGD2DW68Y1IktpOdTnrq3TzZcexhSHoBt6Yh+Wu45Z6HefCZpfQ6zFODbWdZgljqLSbmeYXKMolKtg/mDmne46/7w1NjN1YU+ooGGCW0wgCzjz2UvWK1AoApULu8Vz+547wfk5RcSHVRHEWh1usls3ED80/9Jifs03q3u8DqJq9y7Siv+xQAVaNnS89WcnoJWxaxJQkTBxOn9t+xZjFBuqkerpMcKxtTlJve+73n3Q6qJaVOfmBDv3Pvi6vG/nTxg+iBRiy3n1wujU+1+cOdC5nc4jbaPZwv6cWs2yyuGS1x0oRG5cZ7bljIuDofXtHCcKCghfnZ7x7mxqXrnU1wW0tN0wUAE5u8V5196pcY31RHoXszwWgt6wYS/OSm22uLqnfy3895UC/M7MK+fD3c/4cX3qQ/66AFYuCIiLbB7G9+lYmNrA5Y1rONItVAzSpVqhaLKlX+dfiUykjdKk2KeaPnGRCrqQtPd3uC0uvLV5Kt2ATCYXq2bGbvPacdbFfSoyL+yMV+xfNi0cxPMRy7sSRqE55fn5iy6A9PU1SCyKJAq9vgwtNO4vjdJwoAvUXmLd9inH/2z64hLWu4ayOYloNQKVErwZVzv8+Xp406u1XmhzE3v/6weT8rcNAdTy6fVtECCLKCSJHWGjh4r13joiAWPbDy37FOXkFcDvDO1jXP6LLUkJXl6b229OPVg/r3F956Hw899xqSr5ZCycAo5pi+22QuPOubjAyKy6R0PDva4zupUE7v3uSPXAYQknncF5D66htGHLlyzVoGC0WEmgj96SxrNqwlGqvf2RNyH2mLolsWhaQs4QmGWtpfW76Mvu4teIN+4oNxmhubp+3aHFmwzVwldfmGMvcu7yvsetUt92PJNVgW5JK9HHvofnzryJ2z9QLXjtDEc6o7oEqVqsWiSpV/KYIgmKo4XItCMgq5ZhcX7TYmwgkz9kQ08siqRkb0cN9zy6jU1LYNYMxKVFIddXJokWlQmyg5X//Zr35DomLj8rpwCyZtQTcHTd3xovc+YyDPrPMX3sSgoeGLtWPLLgy9TGutn2995VD2ndB0ab3KdnteWBYBURSxLAvLsbEFQBJxREG22H4A57+SVLZvbrIwXL8ikx2YtUPr+AMbveGFPWlhfmeaGRdecwdre8uUTTelbJmoS+aE/Xbjgm8dwZSw9LDY11ucHIlNBKj3Rq8bpDIToKuoX14ns2jq5MY7f3jOt/C4LBxFAH+YQSfIZb+6jxUbs1MrttjmlFFcJdbvPd5f/Mr0SbQ0eikUcmRNL7f//lk64ebuov6+uNhoc0dnwqz9/vxfkrPDmLaEXSmwz07j+d43DsZfMl9ogGplzSpVqsKiSpUvAEcwHMsKlPT47DrFu8gup9zTxjadf+T+u7DbxDZyqUFUf4jfP/s3+m32TaEcVVHc7X1maa7sCiSfefF1hnIVfIEQklHEYxWYffKJNHl4v+Pmzfc81x6v2JiCi9RQDrtQJOZ2cezB+/LVQ3e9u9nLxR+7kUVKjmEhOuBg4TgOznuiCMwvenlqAg1X13rrr0tk++cUdDsMsMnmtideflu54GeL2ZKsULQlYrEYmlVh1/Z6zjzhAHYIctFYlWMmNDbuV0huvRIgUUp1RNEWD6+7AUDQzZMTx4XXHXn43ujlFDXRWvIFE8HfwPwrf81zy3rOLluMcausjvm46ZsnHEx7nQ+/R8ERvby9aYDXOwuzLI8aABi0mNmTtE7+1e33YQlhEAOYFZ36oIuzTvkKI1SuHeeRv1wpxIfTiAv/GaXQq1SpCosqVf5bUGM3WchDjmW7AVxm0WyEhRMa/XeffPSBtETdpLJpyqLMT351D51ljkiLrsNLsnvCxkHz/N8/9ldUWUOulDAHtjLz2C9x+MSYsGZr/hmAR1cVnQefeQ41VIPkQIPXS0A3mDF1Ekfvvzte+MRGZ5JAVtBNVFtAMG0E20IAJISsAMa/Y4my5URHyRZiUqQ+u6LI2vuefufU+59+mZWdvXhrY+jlIvnBrYxv9HLasfsxJsCZTQwLq1yqe4G3tvU8gIi75v3aEy1e7wUAZb08JqDw3KH77kJjAFKdbzFi3CiShTI5OcC1S/7Ao690n1lWGSNCUXEyfGn/3fFLAl6Xn5r6Nv609E3ScPjbZV7fkuLax556iXXrtmKUHETDwas4zDnjZCa2eJYJxbyZyXYv0GQrYAy88wTeyJLqJqhSpSosqlT5l6JodYs87oarAQJuJZ4s9sz3isaywyY3XXvsIfthZBMAPPfKmzzw5FKyMK3P5NTr7/gD/ckSjm7jsSscsPMEDt1vZ9YXud/f5HvhvmVJZ/YFC1DCAVLpAcz0ACT7mXX04cz52oEvxBRulOxCDqBY3n4TLUkgi2WiCIBjg2Mh2M6/dX3SujRFDMVKG9Lc+PPbHx776/sfoTuVw7YsBuNdBN0O7VE33/3GEew8MnJ7DG7K5vvmlvP9c1RV7flE4QRZDTrHN/uXfu2QvRlZ7yO+aTVul0JFVlmbyHPF7Xfw1IrkmUOGdXxTIHzpPnvtTtDvJhT0MpAcYulba0nC2JzK1AeefiXwp+dexnEc3JKFamY4dsbe7LdzNOmDpYpV6A8Gmi+mnJ+muF3rq2d/lSpVYVGlyhdrwJDqFtV6mi4TzIopgHnUPjtz0pemY2fThMON/GXpKh5eOsjKXnh+5SYqkoaMhaQXOOHIwwiGWCd6KL26qXzRT29bDLVhSkYRjSJjYz5OP2I63zhg3O0TBPbzWcbSOtG7CMDjqttuyXABDEEQwLYQ3/0j4IBjEWW4iucXSRxmZ8TAIRszXPrTWx/gz2+8Q8qWcIdrQDbwiAXawgILfzybGVNHXyWWkyUAB7PWEgRD827/e71Hg+q6uhEWarrZedqXdnts9jEzaFYNAqJOLp9DjkbpNSx+fMOveHPzwIQBmKWL8OP551LI9xMMaKxZ383f1sATywrc98zLJAplypUsst7HnhMjzPrarknNZLNs68kGf+xqgIplu9E8K6tnfJUqVWFRpcq/hXpX+LpycnBMk5dFpx57CO21IYb6c/QnTK657UFuvu9ZSmqARKFCRS8zsr2ZHSaGjILJ2Mfe6D35x9ddx+ZMhoxVobU1hmLmOPWrh3HqV3a70V/mxf6e9PyIqixJZQdnDlXi75cN70tX5n54Hg4oggSmYyI4NqLDsDvEsc0EfGHxAYM6MxPQUYH2V9f2TrniV3fz4qot2J4wgXCUbDLJ2OYoIyNubvjJuYyNuh+QzHzWK1qrk6kt1wR9LRcIgpRNpQdnftLnJIqFjoFyeZbH1FcGDeepjn12OPP8U78OmQSxaC1lwwRfgMF0kXMvvYZl6xL1Lhf4wnD0sYeg62maWkZz512Pc/u9f8byRhjIF6hrCFIf1pn33a/gs1kalbm9mMlOAUjEVz/vKNpm1E8WPVWqVNkWuboEVapsH8tOdEjisG897pizY4J80/ZeN7Y2ekxvWZ9Xp6rLpu8yZWpqaScZIUAJixVvrcNdG6LGp6IWkpxx1kxU6H4nYbRfd/fddOWzxFqasctlEv3d/GjOLA7dY9zSVFfv0W2tjWcRCFGID86uiUVvAujNJeapYrhbEbX4h+dQggmoMo4kIgggODYCw11VHVC+iPVJlCodUbe2eD3c/8zrfcf//qmXefKpl4hN2pOKYZEdSBIUYFzEzw9nn4KvkF0XUlyPR2XfYmQfvNsb1OOJLPF4PvmzIh7vR2IcDhjfNPVHM7956hV3PIAiuFC9PnCpFIaS/OyG33HG905j3BgfE3dqg/tyJPuTSM115E1AsIm0NmMKA/z8ku8wImhe6pQMxTCFWCgYfLy/PDSnPjZhv8GhjXe4qluhSpWqxaJKlX+Wij0wy3CM2Pu/EGQS2Ns8+Q9azOwp2/MBGl3qQlGl+OWjDiDgryGfzKFpNQSaxlAqVEj1x5HdCpoXXuky279/4cUMlgxszU1vvJverrUcuM+ufHmvcY+5cVbv3NrY8t7neN8VFQCN/sjCiFdcEgmwzY22YtLmqBKOImGK4CAiOCKiJZUE54sJ3sw4woy3TV7/w4sbjv/Fb+9h+ZY4o3bbF9G0yPd1UaeInHv6yfzsRzOfHR2Szm7wqFdHRfVf5pYZ6ea0o/ZtuerKeXOodwsUU0kqFYvapjH0FxyuvukW3u7M0NLg5+CDZhAI1hAfSJEuVSjaDkOlPMeceAKRhigSrqwlaIFmv+diUVKKoitUAtBl3/rNueQN1R1RpUpVWFSp8k+hiXWLXNJwoGY/5hwDK6YjNMdtZg9YzAIoGUwwFDG2weGulbAqo7LvoAneSC3+aAS7YlNI5PCpHlSPj4svOYeBDJx70RWYchATDbfLhV3KsOPoZg7YbRKOheKXhBc/90aWKVmCiKWoWIqKLkiItoKCEo8I/EMZDV3J1OXxSnk2QDyb3KZ7a59enptVlemLHn926sW33Eq3LWJ6axlIpBlct4JpLTWce/KxHLlH050RkTvr4bo6l+tf6lLIFhIdrQLn7TZafOB7J32JtpAXr6zSn87gqqkjXahww423s2JtnlM7plOybQK1ARyziKJCw4gWRH+E/oqfdYZ4Vdklj9kAd+VhWgWxrdPm5rwS2sNQfbEemN8Pc3odY15vMTevukOqVPl4qq6QKlW2Qz/MyevmHoYk19uS7C7qTM7ndE+5bNC5fgvJZPrmru5BUoUiA/kC/akUGb1MzpCw5BqQakH043F5yMXjjNtxLJ1dOr/5ze3ogg9J8mAaBqJlMqa5mWMO3JsDdmy7PQDPRvj8QsBxUCxHwHYEHEECR0KwJT6PtcLKD86UfNH3LQottTUXACSMckdZN8Z8+LUFxTX18ReXN9/7p2cpOzKxYIhSOoNQybD3pDa++42jOWBq05kxuOmLOkaClZ8GkSVj4ISjpo24TZC/fuq1i+/Dtm2S8V78Ho1s2uCqn9/C2XPPQdYC6IaJrGiYFZ3+nhS3Lr6Xh/0urHwJRfDMEHWH+togjbEa2tuaaG2pJxatIeTneL/Gak1UOt0eZU03LJBthurF7Rcsq1KlKiyqVPkfIA6zyzBGhFIZxujQXIIJJgR0B2wbsGDj6iRbt3azsWsrA9ks6bJOqpAnk9fRLQdsgUrZwnFEJEnC5XKB4MeRPNTUBCnqFg4Olu1gmiYIMpu7hvjFdb9BllUMU8FBJRhQCSoVjj5gR47Zb5ekki3FIwH3P1UvQXBERFtAsmVEHBAsQPpswkIGjESHpGxbsyGiuJZEIvVLenL5+RndOUSu9Q8t76ocfcNv/4glB1CtPKXuTbQEfYzfqYFZ3ziOtjrfAyKUeir6fFEvFRv8wX9pBUu9ODDLp7lXA/SmM/O8weCyGZPD7cWjDp7+24cfJqVYeD0BuvvSyKqfG258hFzOQVJEgp4aysUhRHykk0OUSiWKxSyiu0IgGGNz0sbqT2It60J0dFR0/C6RWDg4oT7knxCrCR0RDflpbYzRXF93bW3Yi9dDtybRqUBchiEZkjCcrfPu36YGnRFYMmg5M6OSsPi/ZmMZ7xYPU6q1Pqq8dx1ynOoqVPk/RZ/DXAcUUaAkQdaEcMWk3bZxiyKlSom2XIF9M7lCIFPIk8zlGEinSBeLlG2beCZHyTIplE0KFZ1CxaBcMTAMC8dykMom2DY2ICgShgMVy8ZEQJQVKmUdWZZxqRrlYgFNdPB6VGy9jMvnJ1cRyOkSJcuLqPgQZaiUs6iCgV7KU+sLIdoGzXUBvnncIXxpivfhEDxeB/+wq2CNwzP7f/v66Wm1DskWcVUGmDFG5fLzTrvTr9gv1qF8rrHT+d55IV/j+423+nTmDpadU+MlYcJ9T73A0rfW0zUwBLZJWyxERHWYvtNYvn7cQbeLAiXQwdDRsDsblMC/vCx2Kdc31+1v2GbcnjLzbRfuVb3W+fc99hSPPP0ykq8BX90Y+hJFbFvFMkxEq4xXNfGoBuGISsVIY0klikaRbMlCoB7DUBBtA1WyUUUbLB3bKGHrOi5VQxEFEGwqZgXTqiCrAsFggIDfS9DlwaXIuN1ufG4XAY+bmqCP2kCAoMdNJBQi4HYT8mnLPC5WKAJxAQwJsoKAKQskdWg2TGIilBSJeL1QtYxUqVosqlT5TAxizDQtJ2zhBBAFRISSYDuGIqlxAB2aCyZTS4YzwUIIWBKBTJFAoWKTzpbpHUiwaXM3mzq3kkimKJpQkl0UTbCd4UrWpmlSLhexLAtRFJFlGVEUkRAQEQBxOD0TEAUb2yziUSRkHPRUHrNcxudyE62tIehXaJzQQkNDPRMmjiYc9lEXlAmqPFmxaCuLjO04+3r68w7hpmaSAynw+8Ctog920TaqgULXBn40+3T227Wh6GQNxW2yuk7mn48/EGwkx0axLVy2ieDIWIIQqKC09WDNb0K67LMOFfI1LuzNbLnGdERT9sWSCVM9+VcPPDvhnj+9iOmN4AkE0Fw+JH2IrxywKx2H7Xr7SJHTAHpIzc8V0vvs4G0/FGAw1z8n6h/ucpoYSM6K1NX+09/170UFQJNruIpnOSSO+eG3DwvsuutuMy657jd0bl2PGmhAcWkIZRuxbCLaGZqCXi4996tEAiRdIusdHMVwhNhQhubuvhyrV69m7dq1JJNJdMPCFEWKgkrFFikaAmVHwlZ94HNRlAXilTJkdSSXhYQDdgXBscDSEbFQJQdNYLjGiKVj6fpUTGOqW5GJ1NbQ2tRMbV2EuvoYsViUpsYIQS8IOqyxudarYvhVXnTDahFKGCBjJhsV+f9r59XBij6cKiwKRBVlcfWqVqUqLKr820g4VofliIEKtFuiELDBbaEETImwCbUwbDq2wW1WqB3Klmq3bO1h1doNrF7fSVffAOlChYojYUsuHFHDERUMR8C0RSRZQ9A0dFvBlgVEwUG0LSxHx1FBwkQVQQUES0cwDRzDQDBtVFHCralomsCI9hg7jB7BzhMn0d4YJeLnBa/MMtvGY1SIKQpx0yKsaWyWIGthBGSspOPoSsoMHJ3PFqa6vE2UdBtXrI6KqSMLDmpYI7HpDS7/wRlMnxJd5rPyS9tCvrMA+pO98+prGxf29SbmNTRGPveNQnCGC2SJgCwYiO+2B3EQ321C9tncIYPoMzF1orJvcWNwxDmDMHNVPHX7Tb+7n6XvZLADI7BljYph4dILXHPxj9gxKi3ViqXN+IbzR5uouQxvDf3mlmuMvBFrCY0+6b3x/xWiopTrn+N+V6j8PQODvfPGRBtPWJ+v3L/7xNrsT358VuDym+9lS08X1ItUrCI+v0RqIMuWvn5SmQKjQ97H3TirGxEWIsBgiJk7hvzug8fvUVssT51smMQcQVZKOhOyJScwkCmyurOb195ew7ruXjKVLBIKiiJiyCoV3cAWFGRZRpY1JNEDlollG+QMA0G0UVU3kk8C2yJt6SRzOmtWb8BZtR5HFHC5NCTHppjPoheLNEbCTJ08Udlx7JjpE8e2T48EXcR8rPAiL9sId1gQkCHpgvUOKArE/xkL2Gfe0zYdliwHLJyAIAjGgMWsOolq3Y+qsKhS5Yul32JO0bInVxyp3ZQJF0ymlBxIl6FnIM/aTVt4+511rO/czNBgAsHUcWkKLs2DKMuYjoTtiNhiDU5ABUkBQQEkLCQEJCREbBscqwz5BF7JQhLB1ktYlRKyY+CSLDyiTXOslnEjWth1ykQm7zCWxoj3RjesdkCxLAKaNOwL/8gXEXm/9gIyJOx0R0QMLYnrhdkgYpXtQFdvfKoh+NBFPzgismmh2RXKqW7awiZnn3s6h05pvjMipp5V7fy0UrnnUc0VfKq+dtjt8I+ICgBBGPblO4KNI9jYgo0jgCAMK4yP6xeSzyQ6fMEPfOO2I7pF2VfqNMybU5XKUYMlp/7kOQvIOiEsrZGGplYG+7eiF+J867h9mBCTVtTJ1qKo5H7/STXPwCwL2+2T3Wt8oRH/8pbj74mKQb0w05FUpU76wM2jSZV2gDE+7YRemCeP0WbNO+v49oW33k/GMbEUjYJj4m5voqIPcOcTjxI49rCTJ0eDl743xocrlSa0dEfE9e76eIEaARq9DIwfN8s4fFzMgJgFgQq0lWwmlCxqMyVYu6mf15e9ycpVb9PfN4BuO8iqB83twhJkKmUb3QYkGWQFNC+WBVgWsqaQMy1sx0L2RvEEJXICPPvWFp55Yy2qLCELNo5hTinns1NMo0JdbZjxE8YxbsQI9tlpRwJuGb9PuVmV6BZsDGxwyax3q6wWbExFcPoVwYlHEP+puIiIyJJ/JLnQdIbjMmShGpfx30g1xuK/AKOS6BBtRxEc223jKLKn/gv1x/ZjzTEhbCN4bAS3iFByQDah1hm+TMYdUEoGE3oThemr1q7njbdWs27zFgazJXJlE0dz4cheLEnGfFcgOIKIIAjD/S5sB8uyME0T2zBxHAdBEBAEYdidIUpIkjIcPKmoSJJEpVKhkk/TGJAY297E5Ek7Mqa9lfqIh4CXoiayWbQo2XrJ7dOUpV5ZXBZDvClhFToikvczX+AsO9FhOWat7jiyT264eqCUnlXnDi3anHZueOiVdWde9PtXybvrCXjcWMUUerKLthqRM088mAOmtKxu1MpXaEZqmt8F2I6SL1l+2RV8yiVH/2Ez8lqHR/c747ojMkoU2TZxVxJMH+3jpz+c9YBbZrUMQ/Vs66fPpQdnViwrEKn94Hzptq0FJVuakCjZx2+IZ/jhpb9Arm2jL2MAHmTbot4ncOge4zj1yD3ZI4SwvfnknPhsvxC76Ys+9zfrxg1eVVkWhcWFct9cryyWsMUSanRxfzE+p+ypGZNAPfnFNYOBy391L7avjjwiFTOPSy1RpxncOv/7xAxWT1aY+N64Q3r3Atu2PYooZWVZToJY8orbPz4Jo9xhY3lEUSw6kqIUkSfndGvfUlkfb9mCx5FkKo5ArmiQ101Wre+ks7uPVes30N03SNm0kTUXsuYCQaRUMZBlGUlScBwHyxreCzgioiiimwbCu3sFwLZtYHh/KFiI5TweRUBTFGRRwOdRGdHczKTxYxnV1swOoyOoIklFJC5DUoKsAKYEWQXirXDeP3IssiQ6Any8ULAYnAnO3xVrEwyJaNV9UrVYVPlPQ9E+2Myf59khUSx0wParGgIMOMzSHafJRKg1HCdWsYX2su2MsRXJXXFQsiUYHNLZ2jPApq09bO3qJZlKk8sWqRjWcEyDPGyCN2wL29FAckFARjcMKhUH29ZBFBEFGRAxEfD4w1RsE8HWkUQZVTWRbB2XCH4VYiEfDbVBRrbUM6KxjvpwiNqgn2DAvc7n4hWPxAoBTBFKDgxXnnSGH9tFgZKouIsWesAyyoEuy7gcoNcy58myOFQn+j/VjJtLDR0fqh17DNbwU5eghYz1Be6vyEL7yq0lCpIPR4JKNo5PzzAh7OKY/Xbl+3uNfvcmrIEcXAJQNhIdPt8//9QmCpQcxwFBpCJqyIKGI8jIMOSC9duzwPhD0cXZ1ND8bSwYpeI03etv/uPLq7jlrj/h+MaS030g6ShWBr+U44QD9+HEGXskp/qIfNx8/h2iohsWoCgYEEs4RkfE1XC1Xe6fI7qGC4p5MQP1qGf5YGlgfPT4d3YaffRjr7xN2pTwNkSxNS9bh7p5/I2NHL3LqAlvlVjeoHJVRGJJWG2+GKBrYOuVLXVNnxibElFcHz1+qgSq+0MuA7sjEhh+XW/LpHk2k9wIMxDAtBwCuQL7JFP5aal8ka2JNBt7+li1ag0bOrdS1C1UtxdH8WAYIljDzg7DEZFdHiRJxnBAEEWKlomo1GCoEpqiAg6DpsmGDRmeXvsykmMjiQ7YZq0qUevzaPh9HuoiNYxqH8mY5ihTmuvOrVGFbreb1apMNyY4NooiOHFNojMmCh85tjmje4EkCqYtDc4U/04oOJXBmbYAkhpdbJkDsyzHkRGlrCpVrRVVYVHl/zyDDjNNCCOADR7b43XbDu6syXQLAqJISRQpmRAuwQTdprlQtAI98QHWbNzEO+u30JcYIldxiA/lSOUNkNyIqgfdEhFEFUV1ISgRHJeALIgIooVjlKmUS5jlAo6t41FtZNHGp4CCiICD6BjgONgORP0CLk+Qxlgt7U2NtMQi1AY8hL0yIRd4RLJelWUBF8++13b7021zf/c3KigqCbHU4TiOgigSFV2f+uRk5BMdHlXr1Atbr1S9ref1FTNzLU8wkHOxz7K11P/xtTeoaR1LOpsm4jVRS4Mct/8hfP2QyVcMppgZrdm2IZjL9a+7uDqOheM42IhY4oclpvPhL74NTTXhywYNfWZUURf3Ys3L45r2y9seCdz71Gs0te9GMg+W7uAWHMIem6/N2J/Ddh3JJ4mKf5u51cYUBUoilCKCsgRAdNVfZ2Tjs5VA7Ca/Z1gQRGAJts0J++x09JZ16+h7ezN1I5roL1fw+Jr4w5+fJ6x6mDG+YYou0byNyd6QAv+MJfE90R8RP3A5NAos/Mi56QN8PsBHgrqOMmPHFEv7T8kWmZ4rm4GhfJn+ZJb+VJZcxaFrYJBV6zbSn0pTsUGUFVweL5LgIPv96KZFXjdwHAdRFBE1L9gCpmXjOBaCLKBLAnnTpiteZvnmjfDaOhTJok6zCchCs8/raQ74/ERCfprrY4xoaqCuNsjYtuj5joksO8aQV5OXeWVhWb0yLMS2e5y06OL3InwkuW6RVL0UV10hVf4zGciUZlmC4G8IuK5OOHSUDCY4Aookk5UFO2mjuw3LrjcRw6Yg19qi7DYdak2BcKFCuymCYUK+CMmhNH0DgwwOJMnki3QPpRgYSjGUSWMYBrYDNgKirKK5PJRNm3zRxLIk3J4gouyiXDHRKzaOKIEogCwiYuFYZQSrjCpYuAQDFwY+RaQu4KGlPkJLfZTmaIRouIZIKEjA48LvFpfKWElVlXtcMutkGHJAER2K/2gVyX8pZqLDMivtacRiXgs05wXvtIdX9U677nePktYldN1h8rh2ti79Mz885XhO3GePRT7TXhr1i1+YyXcdPLT36VcfnVXrwZFw60kOGe3l8vO+9YBHYqViV+J1kvYRa0y8bM3GJdEZT98YioWePPOSX87YlFPYHC/Q1DyBXDqHYul4xQJzTz2Kg/doeMFrlJeNUFzbjZ0oFhMdHs+/70k04dCxvXNicKB/TrTuoy7B2/70ovPQS2/zaleKsi+G4g+QHexiRI3MmV87jIMnj1m2o8au/5F7HmaVYLwJtTo053T2sWUUExhMQf9Amu6BQTb2DdGdSNHT00cqncVCQJY0ECRMW8SwLGxHwHRsHECSFERFRFYVRBEsq4QiCgiChGPZOIaJY5kogogqSNi6TsDjJhIKUhvyU+MPEK0N01AXpbHGw6RGtdMjslIUKUoSOVGiaNt4FIn+ZomLP/V76vqsOlWtBoBWLRZV/p0kKnTUBd2LBmDWeov7iyaTJY2cA3LOYIpg2dgOmEgYjkCuUKEn3s2mrXH6Exk2bu0lnS+SzpQp6zoICqIgY9gOhulgq25MywLBhaJ4kUQwzQp2xYBCBpeq4nFpyKKCaRSwSjk8kkJtQEOUJURRwu3WCHg0Qn4XDXU1tDVFaY6ECLlVwl4BjwI+mRUukfWyM1xQSBZJNohc/bGnpvCfsmsiS5L53nl1oYaru0xr0xu9qfafXnszZqgJQVERCwn61rzKiUfsw5HTd1nmE/WlUbe6uK93cF5DY/QLSQ0UYFgBYiM4DqJjv2erUCwIiI5c/MjNN1eYicdLAaamLBcnf/uSGTnJSzxXJNzQRv/WDbgckx1aajnl2KPZb0r9Cq9lL3NjrIHtt+b6d4oKgI8TmtsTFQCHH7TPuUKw6apVtzyIjYfEQIVxY6axdvkL3Hzno3g7jp4anDzy8hYXF7z3nr5sYm5DIPK5anGYuUSHZVkBRxBLruA/F0MwmCvMjPq9i+tg0YDJLCSwwa06Vje2iIUTqPGasbGjfZTavRNQx5AzCJRKNsWKRaFYoX8gzeauHvoGhygUTYoVnVQuR7ZQxLQMBEQs3aFkWpiKjC7I4DgIgogkuRAVGcsWKNkCkiqQK1pszRZgcx5ZiCMJIook4HLK+Jx0e8SvtNdFahnR1kJTQwMer0okHGDkiOBFgo2hinRrEps1kU4ZhkSbosBwfrioqsU+h7mSSa5OqWaYVIVFlX8LJY0Ja20erUB73mZCxnLIpyokslniyTQbN/bRGx+iq7ePbK6IiYQjaiCoWKjoBuimB8twI8ku3C4vsqqhAbIp4DgCqiSDoGMZRRy7iOIyUCgjOmVK+SQh1U3Y68bv1ojU+GlrbWH0yJHEIhGaajxJTWAzwnAapCySVATiIpRscCsM/yxDUoQS9rs3A5H/6CCuQb0w03CIJYZyJ0cbGm9fXmLT069vbb//yZdQ7TrMjIrHraAKEkJqgK8eOhufrC+N4l2c1QdnvicqUnp8tojtlmyx5HP9a2IRBIbTTSXBwbIrCOiAjShSlAWSsiQN/b1lIeqPLN5oc8cb6zMnX3TtrRR8rSQLBr5aD04lR52nzC7tMX5y7imdbpPVIZXHHctQ6hT//5mL/UCxOKvO41kE0JVNXS74a4ymke3I3hoqUgA8LjYNgbthZ9b1vcONdz6F56Qvnb//Tq2GprI5KrFYFOXS576w+iNL/lUX16jf+/6+2KbeiSa9f/TTQmZmSIouzimJDj+RJWiAJjIcdaVAu4/+PZrnGBArFJkqu0iKIiUDYgWdqX3xdP3Gzs1s7I3zyoYukkWDdDZHqWhgOTKCoGE5CiYinkAtlipjSyqOICKJMo7jUDFtiiZkhTApW2Jdv8Ffe9bhcW3GsUwqpTyOVcKjykrIq7Y31kXa25pi00c2x2hpHC6dHvRgBCWeVATiqkJ3HGa/VxZ+wGSW5eC3RAKaxGYBjH+k/H2VqrD4n6PbYYEq0FOBNoYvCyUb3AWHqQND9oy+ZJKXXnuDV958g01dvcgeD46ikCkUMBzQvEFs0U+5aIJlg6Igu9wIkowgSO8+9Mt4NBXFIyMjYJs6QqmCIAi4BRFZEJEtsKwimGViET+TJoxjysSRNMYCNEZlBBtcEutcIuvBwtYrHlkg6VFcKzXb7vywT3lbM2d6Vp0a2vbG9KFwgESx1BHxuP/jLhYJsh0VRW4r2eoEf4P3xfVprnpp2RYeevJvrN6SxBdtRHQU9HwaqVKmwRuiqSb4sOZkOxEgoH7w1Go6lXZJAEFQ+v+FFgtTFMXhQFhtOBVXEEGyyMkw9GHRls3HZwd8sZs2wW2vbUycfPlNd5AS/AxVXPhqG1HtDMmNqzlqxp7M/eZRKzyl/MpRId8pW1P9V7bW1J/3f2k/vScqANxu9+p4pnRmOOwu+kI+T64/jRIbiTE4hKFK1Da0sXbrSq6843coodMu2ml83cO92dK8KYHQuC9yjkU9PhvBdoPtsQWx6JMbPnelUi9WwDL75spGcYolZqczLCtLtiNlbaSsIKrd9Wpk2IrzoRb1/bo+JySJj7e0BEtTm3YM5M0d9zjZlo+oCAQsG0oVSKZ0NmzuZtU7G9nS008qm8aRFExBQDccTMtGFGQUVUHwSpQcFRMBwzawBYmCKQIqluJHVH1kLZNs3qAnN8iy9b1IjokkOsgiaKKpKEbmiFjYz7i2kYwfM57RbaNurI8Fih4fK0VhOCB7uDYLDMHxHlihQs+/o25Hlc94ParGWHxBT7fYMx3bVhAFBATDgoBh2THdFpo1RepMVziibDFGUDB0h9pCBTJZm8FckWVvrWfDlm46t24hly8gyBJeXwBHlilXDERRRjetYVO3I2AbJjDct8K0GbaISyKaIiNJAqZuoJfziAK4ZIFCOokqglsSCLgVmusijB87ip0n7cioETEiIZZ6BFbKkHRAEaEoQVaGoSgsTkCHbZueOlH+r93IGatvrmXrzYIoliRJiQeov66Hyvycpe1TsJm6cr1Ve/5Pr8dxhRA8ATLlEpYk4Fdkyr3dHL3PZM7/9iErJvnY6d8x301w2z5nXHdq2luP41ZR8wMc2qhw9Vkzr2jxCu+b9bNDgzMD4ejiTbZx2+v9xVOvufNhtgxUKBMklVMIhzyUEss4//RjmVpfw+Ej6z/igBogN6uO/xCrhTU4EwSDz5hhMGAwa0jhuGsfXjHj5kefgUCMmqZWUus2UKso+BSLeHITmsvgivnnM6rOh5NJMDkaObcBrv7fvqYx04DYsGgZruhiQSBV4ei167vbly5dyptr1rFxIEvOFJBlDc3tx3AkShULGwlHUrEAQRy+NjmigCgKiBLIAgiijUMFHBPZBNERkRwFHAfDsbEEC5fXhShDba2PCWNGsPP4sYxqqCOkgWSBbRSQJdBkxVAVqVuVpG5JICsy3ALgvfRaHAvRsYs4DoJtm4KDIdpOqd7lrpZPr1os/v9vNtMhbDhOvY3jNhBjtoi7gthuIQYEMGQYssBftMWxhQqsfbuHV5Yt582VqxjKFjAREWQNWXXjyG500UvFERClCNTUYTk2uuCABSYKsiBgWhUcw0CyQUbEpchoooLlGNiSgWmVsfM6tmni0SQmjGhk910mMWXCWJoiHlwiaFBUsOIqVrciEncr4mqXbK/HqhCRPt5qEIEliP+dp062MDAr4K1bJGIFDL00AVEwUD0rkUA3pOaCydQNA9Re9stFKNEYg6UKpplH9btQRZtiIUddQ4zxE3Yk6OOpf9e8RSgNW6QkRFXDUYThQllY7g9v84riZU2x/ExnxZ5+3V2/Z3VPimzOwhXyUhMOMbR5FT8995scNLmRNlU4c3uf5ViOzH9KaL/0+eIX6hQWDTkcF/LIeD1QEIvkhrYiux1cqsCWrV34mxpRPCIXXX0T8777LXYbVUcWpgsYZj3K/+xN58OFwz7MCI1zdtqxmf13OGpOulI5vCJ52oq2NNawIJkv09ufpKd/iFXvdLL87XcolA1ExYUoaTiSgiEK6LZF3jYxHHNYYTgCggmyoKAIKrKiIogytuRQsgxsxyA9VKLnzXd45rW3MAs5zFIB0aoQDcjE6sKMHTVaGTt2h/bW5pb2cMiNJg/vBMEBGQxFkOKqIHUr/4+9846XtKrv//uc89Sp9965986tu3t32UpZkCIWNGhELIhGk1hWk1WzJqhBgyaWH4nGBJNoVBIligoWYjcKKoqoKKDUlWVh+y7bbu/T52nn/P6YuzTBWNBY5vN6wezcac8885xzPudbPh+YshRzFszbMDkLm7rhqukw3KLjxJeYhsTUH60tv402sfjliYRms5HYtYRTqzGPTxQ5beHXEtE3v9Bkrtxg9+FJJmfKHDp8hPHxScql+kisBcpKIWy3pdkgLLQYIPFpid8gMUnLvaJVwSRoUfsEYSKEicFEeCYhqlXwlcEH0p5Fdy7PiqEix42soK+/h8FlBTzfIuWDI4mkbtUz+IqdPuxSUJbEdUvH860Wy4euEnU9f3Eo5EVKWvO/T+I1s/WZzd3p3sujcOxiUS+dk7Jlw3NT26UcflsrOmRZ5QaFi/7+XxHd/dRTApNWYGIa5UlWrVvP4tGAxakp+lf20ITVM+jNPchfyzk0gUC6EhMEEAdMlauEvjXU+m5sChOGAj81cl+Ds//mPe/lwESVbFcvfkeMLUvQqPKlK97ICsFcH9GlRexHrP8oqtxlv7W/sWaTJ9nnW+KcLi9F1IgQOmDdmlWM7d2Nl05TWQioVRV56fDh/7iC5W/+KwaW5csmiiycJX0nPbMZwEgRCdp6DAB9lnNpn+W0VFGpbk4QuThrdcX9fYWYwa7k3BNzWj8vlcTkEkG2VGfNYgijlQp379/H1753PfP1OrbtohOB7aSImk2SMEAlHqDwUi71Zh1pQ7NRJ3AkWmvSuRyRl0JqzXRYZ26szr1jO+AHezBaIoTCtVxc2yLnu3RmXHtksGfocSesGdqweoi8T92EsW0h5pKmzk3a9htSnnO3k2K0NV9Sb//CbWLx8084mE0xSUEjfRs5FUExiBmJYooafC3xNaQSQfbIWLhm/5Ex7tqxix179zM2t0CYGIySYLnIVJ6E1gRkyEImhwYiYyGEoNlsYkmNVBolDMIyKBEvqe0JlKMwRmOikLBZR5qY7o4cI0NDDPUWOOPkjWRTFp1pm7QHjmoVR9qKKSVa6nnHFPUkNLQyviCOLMx8D86VM6ayWSRxhNbMmcrmgvsAeaiE01sc5R4UEtTv2YQZIooAtjP4rvlKsMLzvH21SDbmaxNfV/n+8o33TLzk//37R8gsW8u+0SOIvjzdg73U62VeseX1TBwc57o9e9FxlYSAAGtFTNzVcif51aIl2W0htKJRqZO1LBLb4khl4UVJrvM6beFbPvM/3FE//5KrPsX+qRrrjtvA/r278N2E7o4U//jWt9BjoOjwoUHLftfv4m/cLbmqDGcPDw3QKJXIpDuphU3GjxziL/5iMx++/KP4qSJhGFIvTWELw0Vvfwef//D7XpLKpLYfe59SIypikpxUqmys6S05u7ed339IdCNz5ayZ3WQMlkHZtrCnlHDLlrLnmnG82mDZaZ8VvTkKK3uzhVNXPe7UP3jCeqyUTzOMmZ0rUykH1GsRQQNmpxfYsf1eDh8+hK+AWGMLDVISWoo4gVC2ZlytFEKDTiQGiRAu2kgakYWVKGYrdRgvsXXHYb5+wx10pVyyvp3Kph26ctm+rnwXmbR/arGn+9ThZf0MDXSQSVM+FPOhOAhzKcfe6ShGM1Lc6sKhR4vkPGRDGkWbjTG2MdpSQpW7Hft3em79ramxmNbxFozhwb4Aj4YJWrbax3T8E8gZsAVEAqKFEucHEalaI2KhUmauVGKxvEipXqUShUxUKtQjTaPRpNEIaNQjmo2IZiMhjMFoC6lcsB4I5yVGtHrDRUIzaSIsjZQSQYw0BscWpH0HzxX0dOVJe4JcyiaXccn6Tus2k8LzXFL5LL7v0uF5pGklMxXUHRi1YUonJqWkKVtCzFkwr9G+RDYEInJgdAD+15bGaaItMUlXK1cqEMhYoCKBiIROYgtrruUD8DtOKLXedKzQdDxovEVZblkoGSeQLRnOKcecvX98wf7a92/nR/ccInFzzNXq2L6DsmO6unI885xzWLMyyyeuvJmj++4jnBvjQ+96E6cts28qEH6uiPMr3+Efhvc/8ZUffkPJ60N5DnFzlGeeUeB1f/5CghD27h7n2mvv5PYdB0kNDRLEdYLpMTYsL3D+M0/jrMetZcBPf3oVvOJ3/Te/u8GeecmaF194CTUrA45HHDS54kN/zeFJuPLLNzI+MYmlQ6jO06USlnX6vOGVL2VFIXOw25efthI9bxk9121Zv3fRilkam0DQzQOKo7Mkm2ITF5IkyVmWNwcSCY2ludcyYB+rb+iGq2ZhUwK50DAUJmZIWCJqaDZYkrk6emOM7FJQDqAvolXfHUet2KqnqDcDUtUgYKayyEStwuHFGWYadWpBjAglQT2mVm3SqAbUqk0q5Sa1akQUaaJQ4LlplO2ilIulbOI4JowTLGIcEaFEghYtZ+RYR9i2TT6XJZdy8SxFzrXoyabpyabo8jzyKZeOlEfK9/DTHulsinzemUyl2G5J5gTEFq10SwArlFmq+TCUlaYs0HGvJS8HmG1WN3V7md/q6+q3ImIxjd4SCYraCP9IGL/HUdZon3rA92ASLqwaHl8J4rMqUTxUT2wWayHTs7McGZtidGyKyek5yuU6zSAmjlp7PI0kQRALQ6gTIjSBEES+QywllrCwpIMt0whXoG0JiWrtD43VKpw0EiEtLNfD91JkfcngUDeFngzDg530F6ErC7YFrVp9MAlY6oGTHycabeJWFENKTALEUGsERFLQlBa+lKlmkqyRWq9xlKybJLGNMbY2MVqAFgYjQGnB4RrvVjGREdhSirq0rYZQMjICOyHJRQY7NrolkCMAqUBqBAK0QAQCS4CUfFpKWLIkuP+21R5qQMStWzQITUtDAaSRdWFk/AuH9MUvd11qZOoB0QuJNA8NYxpjbIloCCEitOGoSt4tpaxrbafiWHaVYlKVGIQDd++Z4XPXfIvDcxVUrovq3AL5oV5Ko4d42cv/mLOeuIyxI6CbENRDGvWAlGXjea2IlUKUfy1pELCN0GgNQSUm7Xeybc8h7itV+eRn/odbb9vD2uOeROh1sThXpjfrsH5wgD9/7lN4wonFgwO++JdeuHy+MrupK/u7Hakq+Hzu0Gz89zMz02SH0zSDGoVCJ5Oz4HmwZctT+Nq3jrD11luQqQ4W44CJQ1O8+xNf5aUvePbIxpXdf2/FEtfI+hHJeyQ0ksTk4sQUACwrmRNCR0KIWAgVgUAIEbUGG0hJ45FCTkvXvg0aI7CEIf5FbjESLUhJQ/2n3T7SuZFQb7WGJ40Ht2tp0SrWNAK7GYjVQojoqKXfLaSMhCBKEpULw6QviCDRGmVJrKW5w2jQGiQaIQSHHPGhJCFnSea0MX7YaKZs246UkOVYR2cK344ikdjCVqmmhsi05kupWpXkzSapJIF8xsXPFBm0iowkxxGrB5z2EgM6ASlb05UxkCSt2SoIYWER9u3X7LvvCLNzNaq1gKgRESUB1eo0SsYI6aJ8C2yL0BgW6jGmHCJNjE2AI6q4JsJOQlQS4UpwbQW2oRkF1Ov1vrBR71OWoaszx2B/Nz2FPBvWrKK/p8CygSI9HdakJZk3kbSmNBd4FvtcN3PoiGYjiQGT4Em57xjpaEcsHkNMwoWVRD850rIoJHGiyTUC1i9UdOro5DS7Dh/hnr172X34IOOLFbSfR6sUQqqWe6CwEUiEsMFYCCOQ2gIlQSiEkhhLYhQkErSgNRoSff+sLTBIIVoLp5QYYzAmIdbJ0hW79FyRgK4Dyf3vIeMAlSRInSCFptUVKEmkJhEQCo3BgJIIYeE0LBwsLCFbizUaubT+WwKiOGilSkxCQgJCkxiN1glxohHKZ2kyA0xL5lm3jLwMCUraS0Sh9Rz1sBoLIx8w+5JS3j/rqaXXtDwpWiTiAVLROlHCgK1ZeuzXDyMgEQ+dsY8dy7FpUgmJRIBuSWBjklZ0SRjqiaHp+ITGRSZpbCuHcjsIpaJqQgwVCKbxulI0p8dxpaIr18NiKaCZ2PR2FoimD/Ox9/wdq/Lhzj4rubQX/1c+KRyCDz7x1R967bw9iON0EEULdHTMUOj32LH7IB29q1mcDLGFQyol8etzvP1lz+cZJw9+Y22a5y42Ji6ym+FQuvOxdyP9TcMuw/dm4eynvOAv6Vi1jgRBEDTo68pw5OAYuH04XUPkOjqZm5vDBI3WtS1CTHWBtG2wkia2ibBkSzLbaO430VMmQkizdPUpHnz1tUzF9EMp4cOJsXhAhP0XuU3k0n0jMMI84i3CtAbLw26VMTiJQNC6v8SFWnPi0vgSSzv8KG7NO61BJREojBAo28cg7zcSRMcIIbAsibQtqvUKcRzj2g6WFMhYk7ZtOtNZmmFAIqAaNkFYNI3BSBukolavkiQJWc8jCpt4Vus4LOVQrTWRtoMWEjeduf8cJlKjMSSYB5xkscH2IHEgsVF2DttKEUdgkoi0A4kOWvcFaCnRyCX9OQ1Cts6XVFi2RAnQSUKSxEg0SmqkbGnKQIxOQrRuQNxEmhCLCJsYmUQkQRWZRBQLHRy/dg1rR1axZvlxDPfmyKVb9R2u4KCv2OXCwaLgt6K+6Tc6YnF0fvqSfUfH3nrr3fey9d5dHJ6apRYKpJ0hNIpY2MSWR2S5RLaNcXvILl9GKRagHIxQSwNaYLQC0xKMcS0fdGuB1KZ10Rm5RGuPjcxj23PTWiWNTtBLi7k0tAaokAhHgLAxLNFykyCFhdAxymhsAa4Q2EJgYRBAo9FAH/sswBGSWEqMUFhakHFdCCKCMEKTIB2JshXCEgRCo9KtHvE4CdE6bhEV1SICjpAEWmGUtUQKNEYv+QNogxKGOEwQwmChWuTDHGOZEk1CpGIQx4hJi0Q9ePdybLIUD4QvHgJlNPL/iFho0ZpMjn2pBx+HMAJpWnWxUkp0EqEw6KR1PhzHodxs0lzKy3oiQ2LS6MAmFAJjEtAB5DM0Z0bp6slTm5lFJ02CsE6me5BSfRFfClwXhBDRr4NULP0KfrLkAFupNunsKRCqJjvuPYQorsKkOkFPEAXz+GmPv/+bV/OMFe5nj7N4KUBKWPPKtafqC1MXpDqLl/0uEwtXcFDC2R2FDsKwTiMxoEO0dsh15VFeN1q5zI5Nkenpo5HWWLbEdyX1yiw6LBHGNaK4jjBLUUalEMpFKUXSqCHRS/PNQ0lFK6Lh/OSv90C0jaVtzC+4VWzJdOufMgAf7SFhIDaCOH6AbyztNB5CLGzXJUkMsU5I9APEQiEwUhEnx8aeBJOgtcYIQyIlWglUvoCOotY0i4AwoRKGSJWlbhSWbZOoPMq2EIkmNgZhWzipPJZrY5IIGScYIXFigS9cUhmDI2yEkDSSiEQJtBRoJYiEIRKtGjjpuDTjGN/PIYVNEiatvWBUxyQJoCnXG1ieg5NyAUkzjNE6BqmQroteMltCQGy5JLbVOldao4G4XqUlImpAWmBZoJcITVxHqBSKEN9XZLoHsIRhIazz/V2H+cHd92FH1+MkmiQIhgib2MQb8p56zslrjuNJp2/80Jknn3jD+qL/tDax+AXhOe4+z/NIpVKk02lSqSaJMmjLA+ljWx6x42GMpBEZao2IJEgQro1IohaxWHLOVMrFVg6WECRRvWVBDCQYNIYoWWLfWgIppGktzFKIFqnQGpO0KKxRS0uqSFoXmKWQEowlkEaS1JpgDIlOCEVCnRhEgjSt6EMmVcBEMQQJIjY4icTVApOAjGNsFaCTJq4E5Vm4KRdjQcMENKIG2iiM1CiVoGhFTnQSEwYxSQxC+iAdjBAIYVAIhDQs7SlwpQKhsUyLNAizRL9Mi51bUqGVWZoYBYmRGPNAauHY343gJydPAaHUj0g4flb8MqREC9MiFktRlIcSi2O3CUopNBrLViTREjnzfXQcUvBTxNWEtEwQSUS1tohyPDKFHLHnEZt5LL+PxbkxBoudzE3PkcpmqQVVXMdF1zWOA5YS87+2SA3YhgSkobOvm4XyLLbnkOpbT6qzn9npSbyMjZINLv2n13Gcy+RxtEgFgOO1CnhTqd/9GoGlvD+2I6hGDfqHhpmfn2N07246B1YR15t42U5WrVzLgYMHwHHoXD7E3NwYmZRNJARCGVAGQ2vRikjQMkRKB+U4SMP9tubwwCbmoVGK+2NoD01GGAm/KLGAVl1X8lNJ6KOOuxYx/8kEiX5QRFAHQSvCpyTCsoBWWlVoA0mArRW2ACmtpfkHEpOgddRK+ybcb44mlEI5ikYY4VkakbIIDSSJQQiwbYXr2gjboho0iEzQyinbgmaU4BhJEtbxsQibESYG4digJdKyQHhYloMRFjE2aAvXaoU1w7BO1GyiiLHQeLbB8iwiR9CIatSDBRAWbsrBknaLTMVVUrZLlJjWPjKWmFi0IiKitSFNeYo4Xtr4xRohDFKK1rrk5dBJRNw0VBoxtTjBtRXCpMHycCVIKyCIQhIMru+giGkmTcomoakkTcnq8ZC3DDj8S5tY/ALoyeSv7Fmbv3LN2vWbXvgiNjQTVgeCkdmSObURCypBzFSpwr6j4+zct5/9o6PMlcqIwEZaCmU7CCyMsUiCOjoRJBp0IpDSAilRVovlCkFLgAUHEoNOdIulmlaizrIkjutiWZIwiVvjX2iMbNU2JCQYrUm0wXV8lAFEjNYRrWBchBIaKRIqlQkIQ0wQ4WiFLW0cYaOMQpgQV0UoN0EDgY5pLASEOgFb4FgCE0sS3QrwtUK0AkcJUkohbAujA3QSkiQJ5tiAFxphWukLJVppAKEFImmla8RS6kQpQ0iMUWYpMtEKiwojQbYiHEYLtBBLodcHJkGNbGkniNa5+YXJwS8V7XhoHkb/xKSrWykhJUh0hLRsojBASIMVpojmFzEixUCmG1dWqEc1lJem6VvUrKQVStUezdoCvV09RGENbSL6i70cGC8RSYu4XieOIVZJF8r6dRELyxxL4DcaWI5H2ndZnDiK9PoQ2qJZWeSTH3wzaRuMbtqHS833L+/suD/1cbQaXzKcsd72u04sHBit1kKiKKKrt5fJqSkQho7ly5BGIYVgcWGeehihHIl0BaXJI5jGHNVSFRktYuk6lgixlSARrbqowCgSDQaB0g8mFq00ySOlnXWrBggtHkyCH0g//gK5bQTQ2jvLpREgEeaB++ZBfwfdiiwIjT4WmRAPYhEPOiItWg9ZSxE/IUTrdVpjt+TjsYWF0q3zkSQJmuT+tKotl16LIEkS4iTEGENsWQSVCrHVwJEOspFgJQalFI2gQTMMEaoVibRTHo2oieXY6NggHB+RCNx0DkSC1hDGmjjWxImDiW0S6dFM5FIQQbZSIrTmRGwLN+0h0ERhg2ZVk7itNLmw3ZZUeRARJBEShUQQhDWUUviWwrIstImJooA4aqWbg6iV+lHSYN1flxaTJBFGJziWwnUsHFsSNWsE83VSvsfa41azftUIjz9hA8v6W4rtYR3SDmRt7nYEo3nB9YkmNyB/c0nFbzyxOIZuuGpaJ1scoUYjw86OTvENDakEKxcNdhaftq6z2Hza8auDRBfCRFBPBAuVOuPTMxwem+TI2CTTMwssVBo0gwQcmyAKiROJNjahETSSsDWiVAqUC7ZESoVUqhUWNAkREWGUgGyRCG3i1sVpAbbCSbk40mKku4/hYpHh4R56CtDRAflMa1+iNUgNntVqQrRaAbJW3jXReI5FENVabadSIvVS0YfWCCRKtIpGo1hjWRIjoN5M0EgsSxBFrYEuZGtgOkqiJBjTam21pEIkMUoKXKnKtmBSCSpL0cLIGGwsCCK9ohEGfXEct6YiKRFSYqR4YOdyLDz6oGgF0Pp88ZMT47G/PXiCfcTnGX5iEn7IJP0oj7XqXpZSVObBk7f5iYy2kK1HtG5NiEIaoiRB1DV9ouugYxhNLHLf+/G9G6/81ncY0w3qRmNkJ75fIK5X+KPnP5s1gwVcV7HYgA99+hpK81Vq8VHqAfgpd+fhxvT7l/u9b/w1EAtbWOr+WpE4TghqTdJdvVRn5ij2FVioHuXf/u1y/v3/baHRbBaU6z2ksNRLW/tmNJt/0z1bHouIhW05SNshCGO0kORyGS587Wvo6fZoNOGHty7w/R/8AJXEGFNDhjV6OxSbXvB8zjhhBSqs4ZgIW0kMiiCRRCxtVogeVnv0QPrQLC3K9x+LEQ9Z5luLuHnIax9+3f/UujgjEcfIrBGtFK1pVVAaszQPHFtYH1adcWzc6ChGCYlSS5odSWuctDYyrSyxpKWWCa30rzFLUUrhYGSKZOk7HSucbMVlWrLdnhT1sBmmLFsRJSEhMcp3CXQMkSAb+dia8lLwxjJo2whtG6PRQmO7Tj0yOhWYhEgIQgWxgBBDjMbHp4kmijVCWi3H1tbvTqShGcPcHOzdP8OuXQcZn14gDBISkSJshtBc+lqtghIQVisdZAy6xZiIdIBWIZ6tsUWISurYQmPZNqFrI6QFRqPjJlLH5NIeA90FejtznLJhLT35ND35LFnPwlXgKzVpW2rKhUO+xU7LMGcJ5nuyPzkWZ8ulTXTk2zUWjwV6pbr8UeJ+oGBGRZsTo3OJkblY2F1JLpWLB5cXklOW5xJBLjZ0Ld0WFsqwWIXp+QoTs/McHJvgwNFRxmdnqAaLJCSEiQVRK4WgpN3KyetWukQoiZEGqRRGtmRp4ygmDEPCRHPP1DR79wiE1GjTwLYi0mlJLm3hWjE9hRzrV69iZGCAtG2T81J0ZrIoJWlGIY7tkZiAKI5JWS4d0h71YaeAKII+C+YiWxZJWt9dZVV5yVrcCj05lBfy+ghTjJO4y1Ji3kUcFMg4IilqHfie5exr0QHdkNAQptWG261abZfTcbxFKCKRdqNuHlDgnCK+IEHnDMY2CGtpybYFRAZpC0TUmhithkBEBmO3Fj1jG8z915pClY/9/aGL47H7P1/I4tjnGowtkXULNW/AfviO/lgtgsakJKL+wHM0Gu1HdtRnRGKtdHnV0bHqJcODmbfZT1p/XWZZxzlv/c8ryRe6WYzrBA0b3+/iw+//GG97yxtZdZxPWkLK72A+qWC5TmuHBbm05239ddVYSNmSdY+CCFcYdFCnVi7h9w5Sr8xhWRa79x3i7/7x33nNHz+X5evX2qOL8TuHOqx/AOgRXPkb4yD7K0RgzEikBc0gIl1IYWmLcjVkeb/HdAW+ft0u7tq2C6kjkqBMb8amvjjLa17xcp54/Aq6FV9yPDnqJGrUtuRUN+n72ydb15R6EKV94Lo3tKqmNdrnQVVKD41OGDRBSqAjgYpaxdsqFpilZkvNsb/zsMjDEiWxI2SxJcUvG8dayJc+JT52rRi03arl0NbSrX1Mvt91vEMCEyUmyWmtfZTEEmpeKavcg7h/oZsl3mS0sQ3CFkJGPSJ3JcDRKLpES9t/cIanJactyhbME2t6M8ds0X2OEl4SwlBNcaqt3KmUx92tNnr8CIpRpIvGGNuy7DlbiqlmzOrAyBFXWcVEkquDPQ8EJiQWDkdmJiktlpmenWN2ZpHp2QXm58uUSgHNIKZUCVBOGmX5GOmhLB/lpFCexLdcTD1AqZaoltYQJwlGRwhtECRkfRvdDNFhCScKyHvQ05FiWX8PPcVuCn3DpLJZCh0d5DMtrSHfhpRNPSXYrjTltGSrA6PS0BBJFHVb6mfuxHIJ7d/0MfY7I5DVg92aFMWjrj6twSDYZPLYYZ6heCDbFZMt1OPlJy024o31IKQpJaOLVeYrTWam55ibm2dhsc7cQpm5+TKlaoBULoFRaCOJpYWWCkvZGCSRsEBaBImGOATlEMaKWhOmEwHShqkK399+J462yFsp8pZPh5uhN99NoTNL/0COrkKGYm+GrixEiiFXMORbRL5gZzNmdcbiVmVRaZmjJ2VDZAl03AHXWuWgUcj1vBn18OtvqWfr4ZPZw85br/XIHiBFrN+Roj7xEzlkkMzUws1hEAzhZhgezLwNwDPhvsetHNrwmpecP/S+z34DN9uHEWkclcHtXcMl776CC9/4Wgr94LlZwkYTpSzCCAIYkcK59lf9bWaj+qbETuWQAqUUnutQK8+zbDhNqVFncnIPTkcXK5evYl/QYO9MwD9f9hVK55331hc/7fgPTWlzgdKLZVs0i45UFV/8jos9CUGjGbX6iZWHdGxoVCnFcPuPj7Bt135qzZihnjxaxDRnj/KCpzyRF5684kPS0FCVSnkwm33Xg2fPR3bZfLQ6CfW/XJv+r+EkPLy+Q/7kcQjrpx5qN9YjSvsP2/ZPT6dZD/2sYZy3jSXJxc04Wi1cEc3DiyJMUWAiGzmlbKtswK4YntxskgoTqDRgvg5js0127DvEPXv3MLM4T2xJ6qKVjiA2YByQHsh+lO2jHBe/V2BI0CYgjutEcQ3qJVAaRwiEabbSxAYsY3AQZFI+hWyWDt+jr9BBf9cwa1cMsHK4SHeGSRumBCa2BZPKEmUFFSlbHktLTs7zEurdcNWMMZvvJ2iCpU6Vn2fVFlGbWPwGplV+Yn2xAdtiAi6KEYUTC93FBmZDFBeLCBupWn3nMXSFhr7xGTg6WWbnnvvYc/AwY9PzVJuVFtGwHIyfpYnASAfbtxG2IkxigqCBCWKkzCKEQUcwV9aU44BFx2J6eg7JDM1wAUtpLBuUNLi2oCPj0duZsTtz7saNG45jqFgYKeQ8fEuScaxbbelOOTBaFFzW8v1r4+cmp+nUlaQfqF6cLE9duCJXfJ0Do88/46Q39XT3F97yL/+BlRugWi+RlDU9/Sv5789+i1e95lxWLF/J4uwk06UZKo2YBCvHryMEINT9KSEhwcQJjeocInS4+I1/xoc/+QUmZ8qMHtxLV1cvM/PTNDMFrvzqDeTSudc+40nDX8oIeWtaiFgRDi42ZzZ3eL+7Uu4S6pVagJAeUaJIkKQLA1x3/V7u2LqN6lQdN9/F5JGjOLVZVnc6/NHTn4IFc+HcwtCy7s43t0fLY4tIqeJMmTMjAdNxyEKtSXWxZFdL5ZHKQpXJiVmOHJ1mcqaMsHNU6gmNUKAsD+W4KCSSPI6URIS0XBMcpHLRxiVOgKSV1g7DOlo3kKaBI5rYqoHnJOQyNh1pl5G+4+gv9DAyPMRgfx8dGfAUWBpsTZSy2W7DcvCfGgABAABJREFUpA+7HBg1YGlDSgiiAcT/WvvQo8QvNbaymd98nZm2u+nPgRkdbo6N6GpqsSYwrGgasbqpGWkkCfUwodZs0AgF+w7OMDY1z9jYGKVSiSAICKK4VUWMJNSGRpRg2T6WmyHUgig2REmLaadSKRITEy6pviUiafVFK4ElNVGjgSM0SaOBqw3DfX2sGh5m5bJhVvYPsLI3Ry4FHZ1szVjcKpZ0YzSkBEQp2C4g+lmkaH/fMB/MbO5yf3JRvf3oRNg93P/pO8cqr7z4fZdTMVmM1UOl0fJ2CZKQtcevZP/ebdj1Eu+88M8494TCzh6iK/qxf+WumLvge3/w2v86u5lZTtJM8EWddQMJf/P6lzI71+C9778M2+9mtqGJc1mCZky6GjGUgYvf8MecULQ/7eupnZ6OC13Wst/phXNbxH13TwYjm996CR2rjmehXGP5uvVMHzlIo96ko2uAxclxBtIWdmWCf7vorzh9VfZyp6FHB1PyXb/rYyCJJy6SCoSw5vkFvYIm4cIQho6pH0u4P/VYNZwZJ3TVm6RmyyETCyVuv/tuvn/brYxXmiSZIigfWNL+SY4VaVho5aCFQngenu3hAG4SYwcholHHBDW81FKnnLRBWiRYJEahaEX0cr5Db1eO9auGOXH1Cpb3ZkjZYBmNRVK2bDUnJQ1XyYOOZMwSzFkimbMM8z1CXQkwmzQ2JUbkEAqtpN+qIMF2YJRmld925cw2sfgNwCxs0pDS4CeQO5YbFBA7MCqhriFVjzipEbBh577ZDTfddgd379lLKYopNQMqUYLyfSwvRTMwxCxlTS27Faq17JbQi9H3VycrLXCVhSstRLwURLUtoiDEVqBNSL1WBt1keLCbJz7+ZB63cR1KN0k7kPdtMq4cdaU+aKHnW4p7qq4TlZJS1pUQ5Qfbpf9e/abh1AXdzkP1HA7Xg/cHvjuyYyo+/6///j3URQ6V60W6WUJtWJibpdCTozk3yp8//ym86pknjhYIPrcM91e+UO+G655ywWXnVDKDLa2Vxgxnrcnw1694IQMd3mgQMfTpL/2Aa2+5g3HhEBqPnvQAqbiBm4zz7xdvYVWnvsGqL85lpH9rv9f1O2kRPhVzwbRgy7U/Htv43s98jdlKQu/xG5mdm8OVoMMGJgiwwiorOz3e9Gcv4vEj+W/nEnPDgCv+5ffh2m8ydQFo36AqGllPL3kGTTTnL4q1LAynOt42DVsiQzEx5IzAihNTiKKoWNXJmZNBkIuWxKoqjSZjUzPs3neQPXsPMD41i+9lSLSFTgSNSCOVRWIEUaJxc91UEoeQVlUYSYDQre43ZEubIgoDhGu19HKadVJJQLej6HQUKWIsEVMs9rBu3QbWHL+eoeEcacnBY3bpDowCKCj7sPNnsUBo4+dD24TsMcAj51cfAUsaKSed0s3Za551QUM8a0MoGWoI1hsXe7YWj+w/eJQjE/McuO8Iu/bsZX6xjK3T+JksGkU9SpCWS6URoqWD8NM0E00zDNFCYrTETmfR0qCEjcimSOKAuypV7vzmDYivX4dvK3TQRDfq2MYMFbs6hzasWc3jTjyJlcuX0d8jWofakh2fs2BuAt50rNjIF+xs6f6bchHxOymm1O0UL9PR9BZEsEJaqlyqaX95euiNBxt8pNexuOJ9b+Uv3vJPCEcwMT+Kn+0n39FL3IjQWOw/eIjAnDgUY7p+XQWRCYaIiEQ2KBQ9gmaZwbx3MB9xfWm29oy/+ZOn3rzxhOGX/9v/XMOB6QUqUReBSOHIAn/1zo/wd1v+6OzTVxWxTDT/uzpWG0G4IXGc3PjENIulGvnhtUxPz+Nn8jTKC+Q9m6g2SYYKb3/D37IyZ0fdlvl0tyV+b3agU3irQ/RQnJiCUH5kwbMFxLHX1RVB39GItwq71WwS0fIZ37P3EPfs3MF9Y+McLldJLAcplorbhSQxgkQ7JKqfsKkRKFJuGmMMKm51yplIYxYNBauO0SGCBNsReJ5C65h6vUqjXsX3fdLGZbC3k1PWn8CZGzewZji71YO9YTMY8i13FxqEIFIWZSUoLy12873QNotrE4vfXRTTD0izHqqUPpgkItebzl5+3AkjQ9EJI8VmfOrqRhBtSIyxNRZxIqgHMfUw4eZbbuOuHXs5ODpOVFMoy8WxHZTdYvrlxQXqSQImRtk2tmvd30ueGEWIwkl34eV6EYlgPjbctneO7UduI+1uI2o2iJs1mkENR5pCb09XYd1xI5ywdtWGZYM9FHLW+bYAWwgmLN7kKg4dM9ixYG4Yfmrx1nQYbBFCRAIdAXTb3m/cpN2Ym93kd8m6McYGEfmOXQYY8XmNpZirKU694pK3n/MXb/o7OlUGz+5nYqGCn84hsJicmqWuIVD2yK/zuI0xCNeiWV/A9gTN+dpIv5e+e6Q//RoATlxJlHn+yz/yle8xt6BZqNap1AOGist490ev4dwzT+KvX/SUPzgKl/iw82cmzb8lqMXy1NBj6PZt9+J4WZLI4EsbK4zIKQGlObLxPJe+400MZzS9jr68G+uq+fLh93flfj1y53Pl2U1SGbsz/YulIWZNssmIYx0owjdgH4uktoTUsGIotNRaycWaQqR1USf4kTCFiknRbEndEMWGuYUF9h84xD079nHo8ChRDLE2aKMQysZybIRs1ZE144Rm4qK1WOqsEC0dHdMSilIC8q5D2AywgiqEMXZsyDgeUhisICBnIro7UwwO9jOycpjh4UF6ervIpgWuTVka6lLTcAWHXIuDjmZUxkHDsfRot+e3Lex/A9BOhfwWYNZEmwzSRkgMwtbgh5qhMDKDQcJIEpMLo2QoiKNcIzGMzc6x2GhQrlSoNOuEUUItCCjVmlQaIYfHJ2mEhmZgCDUg3Fa3irHQRhLErbZFy5ZYUqBEi6SgQ6SOSeImHdkUvmeBbvXydxc6KRZ76Mhk8S2HtOtiOwpbSXIZj97uTvIZG1uC7zBqSeZsmIKWV4fClC0h5lOou3/eKMhsGG7qdpxf6YRSLk9viQIrMtKKugu5+z/r1vGS+eQ1N/G9naPM+QMklotslJCNUf7hzS/jjJXFqBOuXg1//Ks8vt1w3VNf96FzaukBEhI6qXL2co+LX/Gn316XEc+szdQ3p3tSVwLcbWp7aiK95vPfvZvrbrqHSmwzPr5Ivqsf06wwkk940TPO4EnrR1hfdN/QxwOGf7/NmNFsntRc+MMDtY1//4GPoTP9lKoRg8U+KvOTeNR42mmrefkzT2Moy00dKftah3i0m19vvryZTF2glIhbQc6fr0Nn0nBhRfDkOpwUJfTFCblmCKVak7nFCqVqg1oQ04w1jUgT6VZdV7neYGGhxEKtxnhpgXoUEYYhJtHYx9rtY9NSqTVgKYUtFQINSUvyWgiBEhpHB6RTDp35PNl0mpTn4LsOvufg2opcKoXv2ORSLp3ZLJ3ZDB3pLJm0vTdlsd01rY2KkERS0hCCWArqYOhGtIlDm1i08evGZCO8sM93LoVWAVUERQ1+ACNhwlAjYX0EqchAM4F6AKUKTM+WmJiZZ6FcZ6HcZHaxzMzMDJVaeUlESrbkso3GsizCJdU8oUAKi9jERFFEHMekPA/f97GVJArqhEEDkYQtJToSPFvSmc0w0Fugr7eXYqGb3p4C3Z1ddKU9NnTZ/6ghFYUUpaThW+zsg0tnYZMB+8H1HtOx3mKSyBJCxL2O85iGOefrExcJy57qdH56FfYovPNj1+/7+0/c+GMOz1Xo8D1UWCJtlXjuH5zKpvOeSVFyhas5NCj5lRT/7YGvP+V1H3pOLTWIFOA0Z3j66gxv3/TCnSd1OMc//Pm3lidNiU7GKpKL/+0jxE4PoSjgpn3q5VFEc4bTV/bz9JOO49wzThjtT6n3Kh2We1znt6LWZiYqbe6x8w851rsqHL36jh1DX7xlO3tnaqhUN760WNy3kxPXDPDKPz6Xc07qvimTNG9bprw3A8w2R98pTNTnu97elOz/petOZutzm7pThZ96PU0m8xcecykVSsWSVEOi6hEUQxgKY4aERaSgkkB2scZzpqZrufGpaWbKJY4sLrLr0EGOHB1v+XYoiyBMSIzCcnxqzQCjHJTlolwPy3YxUqBNqw3TS9stOeooJonilhljEiMSjUhicikfR0p8z6Ijk6ZYKDA4WGR4aIBiPsOygkNaMem4jFkwd6zl0oapY5HNdkqiTSza+F2MgmA2xZiCQVoPFs6JoNhI2CAVDQNWPWHj1GxzaO/ho+w9NMr47Dzj8yXGZxaYqdQQjoeTyqOlwiiFsi2aOm7JoC+5pAoDJklIogSTtHyQPdvDsdyW42KcgBbYtotnxzQWD9GZVQz3DbBm5XJWLRumr7uDDs/Bt8CXlLOuuinrqpsHxCMXXk3r2hYTJ5aSlLut3K90l3NfZD4+iXjlj+fgnf/xYbIdRWbHx8kS4uuQV/3xizhjwyqWFfiSbjT8tb7/3Mf6GPbCV5/y+svOr6QHMQKyosLxnU3+5YI/i85I287iTHlzR0/uytLs5IV1ERX7C8Nv21FPbikZdeYd+xa47DNfpeEUODq1AN3dKEeRLE4x3OHx0qc9gXM3LmPE4gPLM/xWup8eCuofvHMhfu3r338Fk04BugagXAXTZFBUeeWznsgfnbH+oB/N7cyZ4GafqJgkUTGJm2tsJaKU5++0pXvIGFmXwp4SPHYtf9OwRYMfGoaasLopWF1L2FBrQqMZUWsmLFTqTEzNMT1fptIMGZua5fDoFKV6HWn7OJ5HYgRBHGEcD5bGnjGGOIxIkgSFxLKsJYfmVuFPkiREQYNkyYjPFQGqNkFnyqZQKNDfW6S/r4/BYi89hW46MhmG+zO4irKtmDyW/jxGHhwYHYJ/aM+wbWLRPgttPPrOj2hzI9YbGkatj6TVFyu6Qhiab2CXAqhGMD5bYu+Bgxw8OkqpWiGKY2rNGs1mSJyYlhugabk/2pZHI4iRuGjRSr0ksUAKG8txcWzQ0SJCNyCJIY4xcR2ZBHgkeErTm/Pp68qxcrCPkaF+lvX30NvVScq3dyIE0vMaKEGrwJSyIbGUpuxKechBjBb52a2Hp5PGll716A6ls8HCpsBOjywY+/xpJU79j89fzzdvuYdcvo/m1DzFbA4rbHD+M5/C885dT5fkhrSJti4T9mPaKbIPvnjW6y97UTkziJXyiMpHeerqDG99+QtYrdy3HjMsCkuzmxIZF/xs36WTtehC0ja7ZvnAQgL//vEvc89kiYrbSXZwGExCZfww6bjCn5x1Cq946uM4ocDLo7m5Yn+h8O8P3Yk3NnWnfvPy2+Xm9Jac13v5Ubjkbz791bf+z9YDpFefTqUeQbNOXoS89SXP5vHDPl2Ud3aJxpdSJmm4aB+MrU1csCxZd5QzKhBxTNxlUGWwp9xHIRfTJFsMWBLVAGgp02Jr8Gn5gvihZqiRsCEwrAg0I5UG9kJFs9hoMlqucnBikt179nFkdIx6M0I6Prbjo4VNM07AcjBSkSCIzJI/iW1h2zZxvYZttXxD4jBAYHCVxDKCJG7iCoEUCRYJjmXRkfUZ6u9j+YplDHdnOX11P2kVlR1lj0pJQ0JdCcqOZMyB0USTsyWTCirtyEMbbWLRxi+NSbiwRnxqjOo6Vu8RQTEy9CWCnAOjIiLybPYBzNc5Z/d9h9i2Yw/3jY5TbsYcGp8ltly08kmURywU0ZKBU6ItbCePTiQSjVIgRYJOQnRcR+gAJRNsGSNFjDARggREDEsutNKyWb16Nadu3Mjq5cN0pD1SErI2ZB2ilGC7A6MOZtQ2ZsoWZqqXByTjZzSbY0GXIbCVSMpFUv8rEZkw5qLJhDd8/c7dQ/95zU3EbjdxOUIEMbaJyPuGs590Ii94+mmszHFDZ5xc7ZQX5jIKnPwvv/vdB1986us/8qLF9ACJJ8m4DdakSvz7ha9iBbzVqTZGuzP+VWFpeouT/8m8/T744n0zvOjz372dq7fuJ8p00Yg0hUInzdostdmDnDyU4/UvOY+zBguXB6X5FevyXc/8Tb9e986Uv5pkcrlbD0+dffFHP0M920tD5IhrEb1G0RVV+c+3v4xVBd4tQxqD3s+Xqpoh2BwGYkhrx3dsRoVFXIEnN2F1BMVAMxJEUGvGLVGnyHDw8DhHJufYd2CUI5OzNEKNUC6W7aFtm2ai0fZS4SNqyVtEEiWtdKNlWSRJQrJk8y2lJMGQhBE6rlFwNCKq4diKQj5HIZ+ntyPHiqEBVgz2cdzyblIWpD0OerDPhqkldcg5G6YUlNsaN238Mmh3hfyOYrYRbQJNt+8+prvIViGf9bDJNdysBb4G3ySJrRJdLtrp1mKcgqE1Q+85Y7jn7CZytXC9SNvCr8akFhowvVDi6MQ0B4+Mct/hMabnSoRGkqiWrHGUxIRhkzAJkZbA9lM0w5CmcElI0CJBWK3dmlIKhCGqNykdXGDrge+iw4CkWcVOIlLSkFLSHuruOHV5sffUE9asZP1xxzFcLJTnfF5sIqwooWgsbGnTkLgNSVwvRdVzLOScazmHpLDqCioa/D64dLqxuCVqREUrlZob8tJ/3+WqK5I4ZiFoopIUvT3DLC5Mk+/w+eqNtzC8oh9//eDZjqdGlZe5wUl5j/kELm2Lar1GqtcnMYZAMzKQ8f8FwMn3Xp6EM5uV89COg9Xwx7keLvCefsaHBgaG+MQ3vsuygSF27N1G58gy/P5+7p4+yj9f+TkuevELtzzruL53756qXLeumH0IuTg4NfmRkWLfa359EbV4cw/WQ77L+Hz0FpW2y8qhrAq58tU37zr/o1d/C5EdoNYAWu0P2PUKpx+/ikxIeVjyNjyYrjS39Ga9B0hmU2/GkhgLO4FsDIUYCiEMRtAncevCJY6hq15nY6UCB2er7D96iO07d3Hf4cOU6w20ZSFtD6Mcqo2YUAviRILl4nhppHIxCcRBhJQaZRSWkMRhnTAIUIBj2WQshYyr2EohRUTUbIBJKHR2MnLCclYOFDl53RBdKZdsxsIGokaCSQI6fHeuK62+nIK7FZR/1zp+2mhHLNr4Pcbh+sL7lW2Vle2WrZZ/EAHJimbQXF2NODN0M0OxjR3EcHQ84p6du9m2aw9HJmaohDGx9DCOi7Z8tLLRlkNkBGGUkIRNLB0g4hCtY2xlkXJsHEtCkmDCGAuDJSSWUsjEoJOEKIrQUUxsNOtO2sDyFX2sXzvAUG+OLkfiorGERErQElIW5U64Ogs3HwsHz8DmHVVzxcvf82lm6EHFHbhWmjipUVk8gpsq0+kGvPK8Z/LUdcdxQk689bES59kHX3zK6z78onKmn9hXpFWVddkyH7hwSzSoedfDi0Zna0fe051uKWzOLcxuKnQ+EDXZm/DV2w9Wzn/Tv/0r9kA/E5FG+VnCWkTR9ehPYv70yWfy4j9Y/6EVLq879rrdE4euW9e/4tcexZgl3NRNqytopqY3g2RyngtlN40bdx0987+++nXuOTpLengjtYbCtzLI0gJFU+N9b30Z64p8I2PMbYOeuP8czRo2lRucXQv1qU3k6kCQqidQS2ByocHOAwe48+4dHDo6QRQbbD+HkhaJkVh2mijRxCZG2hLpWmgbGlGTZtRsFT1bAkmrFdMkGrRGYrBEgtJ1XMugNOgwwFGKob4iG1avZGX/ACcfvwbfgoxNPaXY3vKpIGpZiWokuuEra6eipd/w4NTfVH3hAiUod/udDyUVyewmreOCNqpsOb+cnHsSzmyGuAtAY2xjRKSRDWNEjBCR7/a0oyHtiEUbbTy2WJ7qfOMjXopuBlwYJ3xLgD0SW6Krb5ldWN+74fHPfsLaVCNRJFJRaUIthnItYWKuxNHJGUbHJjkyPsX84iy2bAnrKKWIdUxUqREkCQgLJW20kAipkMoG6YBq2V3jtlxrb9w9idp3GOvbFVRSIUNEzvdIp3LYjke2u4tlfcXc+qHiy9cNFl8+mE2/M5/m+qZgdegK0h19TM5LhPBYKNWxU5Aq9lJvNpgOa3zq2u+gY0Pu1DXvriT6yWtT8pcu5lxyqUVogyUFOmzgAiKJI2lUHfmAStdCPL2lO73szVON6QuKfu9lSiY5gPr07JZUb/flaxTPlyPZz3z+Q+96yUX/+l4m5kv4mQyhtJmtaHLpPF+8/hZ60pnXnv/k4VuTIMhNju2/cOPK49f+X1xPx0jF0bB6yUI1Oj+b67zZ6Wf0Y1ff+pwv3PA9RmOwh1ZSSwT4WRq1iI58B1IoKg7sK5vnrO4R7CL4XmKS3NhE7dSxyRJ7Dx7m4Ogk04sNSs2IUlNTiw2BsYmwSYRC2r3IlEMgBFprtAYCgS0dLNsj0TFJM4IgwrYh7booqTFJk6hZIw7qWBgKHXmWDQ8x0NPByFA3Q71d9PcW8R2FCSOUMeRd52AergdwYNSFgw+JOshj/5OPeq6Kqc5HTuup7quk+mmv/NmhltzYDcZGG9sY7YuWXXxDOb3tmox2xKKN30ZEjdlNktZiYaSILfe3azCPmfrFTR2ultJq2MKdlFiNBJ0TqMiGqYQHbNYM2Frja41vDHYkKNYVJ02UkjWj4xMcGZtidHKaI5PTjE4uMF2u4aQ7iaRHIlt1Hlo6LT8B3VociEIcEWHJGspUseIAKUFYaXDThJZFFEW4SUSXbyMbNdAR6e5OIifHgTmL0OTRkYXjWBinSVCfwspqCh0+U7v3srwrxx89+RT+5KmPY9jRfz/IL+dBsRe++rTXf+z8Ra+ASElcPcvpvYZ/+suXz51qu90Pf/50PLtF4tR/WsfMIfjgjoXSa//nR3dx9U13sRClcN1Ohrv6mD+4m5UZePsFL6HfD+pDXe7fq7hKr9f/fyYFfqhe+WBNuqcuSOfMm7cf5AOf+G9mYknPuo1MNUB19JHEEsKYDAZVnuXkNf2YeI6JiT3EogKJRpk8zUaCNgZhKcLE0IwNiXbQ2Cgrh8BFGtWqdYgDjA5RIkEIkAg8S0EckTSrOELTk02xcqCH5QO9rBzuwxEJvYUcywd7yjmPGwxYAmIXDoqWL6dlMLaEhkTUFZRFQkyiiZqNomfZ+3pSTnvn30Y7YtHGrwe23/1bnTsdFKl3oVIP3wcxU5/f3JPquvKRtusP3mpN63hLLmtOXbGysKK5orA6EicWQ6NSDaNoahibq1NqREwu1piYXWRypsL0/CIL5TrNZoBlSUzSRIkmjmNQtqQRJTSTiCiKqSeAdKhaLuVAIyIPIVyoScJKgIkcvJRHHIY4EixLEsxNozr7mKvVobOL6aDJFV++hr7OHM/YsHzLY2VuJQyIRLfMm4RAStF4pOf1Wt0/lWzeN3no4+nuvq0ndubfm3/GH7xped9KPvo/1zNRmedQ0MTyfUZ1g7dfdiXvfN2fpbIyc05Kye3/V9fMdBhuqSWcSsrhE1dfx1dvug2rp4cOt4v5ugZ8TCyxpCIO6zRFhO8rbtqxA0SAsBVupkh9fBwIyXR0YwiIkwae75BEEUkYks9kiOoBhDE6jLHCiJRMyKYUnTmfVNpm2XA/XR1Z+rq6GOzpYbjbpcNjMgXbfcFOWzMlEiIbprrtn1bnIB4+BEBJcNLtSa6NNrFoo43HAo9IKh5p0ZRWa9FUNgCTpnFhjO7SwqQ0yj8hmyKEoYD8ioiBY0ZKdmKwYwGHxiKOTI1yZHQP09MTzM7MMD1fQ2mP0HPBTVE3Aku4CBROrgutVEtGHQGJDUTElRJJ5EA9pHv5CJEfUarM43bncEKX+twsV332WuxnnT0UH7+ydnp/+hdeMTT4QhukoZWzx4CUGCl+pjE+U5/fHBmKUpmGbDa6VvateNX07MyWZd3em5c5vNnbsKzUlXtR7r/+5xr2zVexuorMViXa6eDvPvR5LnjR8855ygl9p0YJxVUer/h1XxuxcrpSWWf7uz9/zZbv7j7AXKKwYkOSBCg7i6Vt4rEyulrDzXuE4SJxJkFYhlxHD2EsMIlH78g6GqUSlogJ6jPEYUgS18j7kkJ3lsFunzXDq+nJdDLU3cdgwaaQZs5X7LRg/ljkQRP5msi3jJ5PC71Vocs6Cn0Z60afn7n0Mck5tNFGm1i00cb/DfqE/xOS1LMm2AQShAIhSIzOJbHJNY1YPTBo2ycPjpzE45YhoRERFxfq4chiw6YiPfbN1th3eIKpqRlqlSZxZKglgvlIo9Jp5uYWwERYvkTZLr7nMT11kFe88Plc/c0vUitPYHt5rEyewwtNPv+dOxAqlfI6Vm3zRbTzOM9+6c/7HY9ZUgvR6owRRi1tegXTsOV/0xvQUvmx0AUlKfu+M1arTV3Q2128bH6mvDmRHqcVnHzSkzfFV72Md33yvynZgllSTI7PQmx4+399ltf80XmFP3/OcY8fg4sH4VdqLz41M3lhsafvUoDxhLeEiqH//uGuLdfesZMJ7ZArriCslMipmILvcOKJZ/Dt7/2YppMn46epJHXCxVGyGYNaqFBwsoRhmh4rRd/gMFGwwMjjVrNuXT+5lKan06PX95C0jDYcGHU1Bx0YtWLmnTgZVSopFy1nqYah5Tg4q2c2dyv/SpBgW0u/Uhtt/G6jXWPRRhuPtIPX8WZEE5OEtoiJeryuK2c1m2JJIYFcFR4vNQ1PtvQ6KiFPngg5ax645PKvsGNsgWzxJLoHVzN+6BDVI3fzn+99BSuy8Jdvfjt4XSxEXRT7jkOXapi5w/zzlvM564S+D4RBY6jDca7tEepnzqHvgu+d89qPnV1OFRGexDMzPG7Q8I9/9fLyMqw3P5ZCRnvg6xdefs1zbp0oUVMpXCcPtZBMEHN8X4a//tOzObFfXJGC7b+oz8gkyYV9qIe8Npif3eR2dV81c/jI+3uWL3sjwO4K100KzvnBnjE+9vVrafpdWPlBJu/bS29jgqJMuPAv30D/cSle+rffJb/qZCpJTFw7yoZCiVc862ROHsyRl/atAawwCXbasLVe4iTPZ5/nsS8MgqGsb988iHzXNMEWiap3Y7VbNdto41Gg3vGOd7TPQhttPAxpIbelhbMtLf2tVlQ5w7LTW1OC7Rm4LQc3dsNnCoIv5uG7efhuj+LKtMPMQoXnfP5rV2N3dmJ3dLFYrVE5fJC+gW7Gtm3naWeu40mPO4Prv/0dtN/JXDVC+lmaYYjnQLGn50zXEZZniX1ZoW7+mYkQvOpT1/54eeTkEa5C0qA/C087/aQgh7whA3c8Vucmhp7j1q09d+u27fjpNHMzJbx0B0KlmV0o8+O772Ro5epThG2fWzec3q34zMTczEX1WumpmXT25v/9u8Sbm8Rrm0m4LiPt24793fJT2wHSHfnrAO6eae4JO61ltx6uZS75+FVUrRwNXMrzVfpzHrlwnr993as4fnUHV3zyRo4sNAml01KrrC9iFo7Q50Q8be3IFWmqd8lqvdGj3CtZqKn1Pc7Te2yurE/PbsyR/KDPS30QII21NcX/XS1JG238NqCd6Wujjf8Frv/QrprJ8vSFP7HDTpoXHqlV3vP1m76F6uykGjaZ2PUjdPUA3UWHhdFDTB6ZZ24aOnJZ3v+v/8RA1oLaKDZ1ymHA17bu57rdY5QTseaY7fXPP6IFiREkRrb0EgzRMT2Dx2w3AuU+j63/+IoX4t93D8vCRcTUYcqleZqOz7bJKh/4wnVsPdqkrDj77vl4j8j0xMWegZ+u2RHMbAbowboybdTWPpV61GjHvZXmnVGP13fjgVLfh75wNZWKoDO3HLsmWJtXRNN72fLGvyK/sod7a3DN7Tfgp+uEMztheg+psEqtofjubQf53o7JV9ZNZmPWydxctMVlaae284Hv2rS6Ozrb0Yk22mhHLNpo41eHjJu+DWC2MXFRys7eMqHnLxqvNd6+bWIm/8lrvk0pEqRSHk867USedPIGdm+7h0K+i9jAtnv3cMZpG+hMw9lnbCQpNRndf4DOQg9zRrL36DjTY+N4rnd2rpDv6BBc9zNGLDZ/6ps/Xh66ORKZIKkzlJU8/fRTGscJNj2m0RzYpqX2e9LOXU9/wumnZl3bLs3PYtuScq1ErrNIqam58+5d3HzHbru7r79QHEy541OVt/Vl3A8+0ntGwfQWJYyLytwBkBLqEaMCY836xUci3negFp/6vi980/3cd3/EXCjoKA6QlGroxUmedvIIf3PBS8h1uYzV4RNfvoZqklCZHGfT+eeyYaCDI3vuppnEBEax7d59dGSL64rZTI/RDas313lZNZq6wFGZOzKZ3PfbV3wbbbSJRRtt/FIw8czmRDROkCK1fZZk07HQ92ywuCllefcveCk7e8ss0aaysP/ws9//4Wnv/cx3SBVXM3H4EK941jm88bwz6usG8vZCxeW2e3dCIUcpqbB/51088wmn4M/F/PETVr17edfIWVvv2kbJz7AYSKaqDlvvOUCptnhmz6rBPwuMXBFpBupVTkm7bHukY56Fl3/i2q0jgZdB2gabJgMZl6eednzKEixm4LbHlFwhbssLvqvsuLZqZCA5+6yTh3pSiX3f7h0kSYbFwMbvX0GY7eAL132XO+65b2TlypFCpMSrsbXMSnXLQyYiK731GKl4NBxuLr5/Aef8T3/zpo2XfPyLHE3SyJ5BGiQ0S9Os8BL+5aK/4KmnLSPjQBjDJz/7DXaPzVGrB5yybIA3vfTJnLGyc66Yt1L7Z6eYqMck3gDX/+AO0p43cMqJQ9vz8N1SUH1i2s7c1h4NbbTx86OdCmmjjYdBWD1XWqKlBZJomZvQXDStzRajI/thi/mmgw3zket33/eiH+w+Ql1lWZivct7jz+TFT9pIl+HLmSbls8/cwPr1w9SSMnaHx0StwnU33MHqovWGeIbCM0/ofuvbN78UJ67h9/YwW7eo5VfykWtv4Orb7hk50ojeoC184RE96g4Byok0RDpC65acudZgDDxYUOyxRp/yLk3F5e3DdvK2Zz1u1U1/94oXkNUVksYiE7NT7D9yhGZnL3ctNvjnz3yRHfOVoYlG9CaAyaB0f0pppr64+ad9zv7S9GcqTuqs20anNnzjngOI4XXMNmF6fpGM0nToKm/+sxewKgP9Ft92ge9c/2Nu+tFWOnqG6OoqcPzqYWRgIq86te/ZZ6y94Q8ffzJhvYrM5GikClz9o3u4aU/1rQfgUz2pvkvbI6GNNtoRizbaeMyREeKOrOCWtBBbrWT+TyxVO73ZqJ80Heqn1xz31K3z0RlXXHcj+6Yq9BT6EHMzXPqXm+lsNr/dlbW+4tnsq3vmqYmjOTxxhHpQZWp6lonJadYt33DucX3e5X0ul2bzdsf+mYUzx2ZL5IojzFdqpLI2u/buJp/NUezpOes4l0dtQ52CC6789tblse8jLIOlAwazLmefdjydkm9k4ZZf1TkKk3CZNDJY4aQu9Ls7Ttmwcf26Q2P7mK/M4OTTJGmX2LOYqc7zvRt/wImr12WMcl6/Jpt5IcBEEF1U9NOXHalX35O3nesBGtWZzbaTvj86k3jp3JRQf/W+r32XOxcSqtomN9CPqi3izxziHa96KeesKb63y+F/6g1OGV9k6ONf+zY1J8XMYonOlM1zzzie0/s735+15Y9s6cxYfuGpwslwxz27iIVCOS533bODvv6+jW5H+uk9qu3w2UYb7YhFG238Klm4DlYQhUNeqnhZ7PqF+wyvfMfln+NQ2cXNLacxN8vLz30qK/O8cl2f90wTleyF2uj5ax3x2XNOHqFoatj1CgOrjiPMdfKp7/2AXfPxRwCWO7zxFc98ItnKGNXRPTSnR+lesY6jDYfLrrmRa7buy21vmB2PdmwaUsJILMtBSRulWnbbUhIJiH+V56XHy1/ZY7dcWrOSm47vd294w8ufyRnDeZgfw9RLGAGdK47DHTqOiy/9KD/aM1bYF/PFvSXz1QB7ZMJw0bJU5s0A1cboOw3hEMDsQnPTwVL0kSMR77lu1yT3jJYh1we5AuXxUQZ9w3/945t50uqBnZ5hX2mmfk4YMPSZL36NKj7aSZNyPbw45MwNK0iIc30qdWljYXHDGQPuu591+omsG+ygq8OhjOJAKebTX7+FmSZn7W/ymfZV30YbbWLRRhu/MiSRTjVjY09HkxdOC73lP79yM+ORz2Kzm0bJpU9KnnbSKnqc1k7X0PT70+n30pjkeFt86O/Oexb5UomgEnJ0rsoBYfOFe7ezm1aB5roO60sfvuiVDEVH6esw7N1zH6p7NdPOMj7w9du5dvfohh9WKmZ3dfy6mXjqgmo0c3/6wIedjnYwgcCYY/8ZjPn1SjL1C/5dhgv1x/V2fOlfX/cn9T9/ypPJL5RxF2o0F5qUGgZ/2Tr+48vXsr/Bi3Re+MIlmhgdfxNAEM5uSrtxwcnI+q6J0e9VO70zZ7P2pk9+++7Cxz73HcIoT9pkcWshmcY8F/7ps1mdk1s7nfjq0Ynxd+Z6UzfcfPeBoVt2HmSyponx8WPN+Wc9iU74hkqaZYDVhcIfD8PbNvbKvRf88R+StwO0VGQGV7N3vMmXv7OLusfGHZXSLWPB3MXtq7+NNtrEoo02HnvY2Zu81Mhr5oXz7NsPj+a+ectWisvX41sd6MUGJw0WWZG3rzj2dCFE3E3nVTlttq7Aed0frD7uNX961lmkoxg71cG9+w5y+/QCP54rnXNXs3o0q/TNK7z4Gx9+x+vINqZwkgaOm4FUgYpX4FPf/RHf2LqLql84E6u7kbEfsJ+2YUrakkQpwiQmThJiozEGzK9ZYXet0/ncTpKr44lyavOzN8694zWb6dUx9aNHEAk0cCjJFK968/v41tbpc0oJ5/QND1x6cHr0I67TfVWMiCpJklP9A+UxeO0Xbz2c+s6Og4zO1pC4RDPzZKpl/um1r+Lxy7vKM0f3nmoI7f6Bgff++Ej53Z+57gaSdBdBI0EEMet6enjeE1ejg2ZqmWpFRQCmFuYu2Oix9qkrU7c+feMIUXWahYUFRKqTL1z/Q75398SGmp85teH669sXfxtt/Oxo11i00cbPCMvO3jKahO/cXdevfPP7P4rbv57KYoRXbvDUVX28/GnHc/pg1+MAxkpHL+lLDfwbQNrJ3gKQlmztG1xx7vY9h4eOzlbIrjmR+TDmx9u28vjTTs7ldbiQlfpHPb5z7cr1a879zo9uo64Nuf4BwiRi5r4DaKFIOx1u1sufP+TzzmPHNgsv/+iN2zbWMxmMDnGSgIGMw9NOO54Oybd/lTUWD8fiwszmLj/zqeGs+85SwrnFHlU8fv1G+74De5iZnqGrt59monCcHLf88FZ68sWejnzmD3u681eMzh34p0ZgdE3meip26slfuONg5vKvfYuZBPJdfdg6pt9VvPFl53PmCoes4PYVHT2XVBN95qKwz7v4Ax/v3Fc1lJVHOtdFp9Bc8pfn0ZOw94SUdfqxY5yoTFzUl+/9j9Y9rYZXDJ13yx3bqTVj6s0QN53iljtv4tTHn6ZsYU5UttI5xI3tUdBGG21i0UYbjwlmw2TTfXONKyYi9yVv/9Anua+UUC5HuEZzfJfHBX/0JDYOp/7RJHND9aTy5GL6oWJQ45NjF2czuRt7fflxu7DsHffuP0xJOsTKYezQfiqVMo9fuWzVWj/z3Klm6bX9hY6dy0eOO3HHjp2UKyWCWpXu/iL77xtn+47D+H6Bvp78ub0uHweYMrz+49+7YyRKZZECXCKGsi5PP3191CG47rFuN/1pEI3GCZaf2j5Vq1ygpfSNlm5Pp+ApTz45MztTYvveAyTCws0WaESGbXfdxYEjh1l+/MrneB1dAanOoGSnz73sGz/s/O/rf0hFZkiUR08uT/nQft73xpdx+oAYHXL4RyvSpala7bXaT2f+/iNfXHOwppk3DtmuAs2ZSd752pdyWh/fTjeSbZ2e/PqxY8y6LbIX6OkteZG5fGx+9B3nPvcp3HjzXZTqAYmtMJ7itjtv54yTT6Y37R7shGvaI6GNNtrEoo02fiHU4tlNjkzdr1kxmcgL54XznH+76lp2zSfUYpus69EpqvzFs0/lD9Z3vXfYEm+rNBaf3Z3qf//D3y+byd2/21UZ54mpfPeq2+7ZRanewMl0cHDvHk5fvdru7M71KEtWm/X6uuOKHdu6LLVudO8uiJtgu1Qbhnqmn0OzJWbnykOrju97uoCorHn6J752a5/wu0AKfAsKdsLTzzhedQm+koatv7bIjp/aXlkYf0viy8UhJ/POREUdoW4M2wj3CY9bm6rFigNHxpkt17E6e1gME+yOLn64bSdDG07qmVdyzdfuuMf+yJeuJfK76BlcR7PcRC7O8ud/+Hie0GPx+EIqn4Vb8kpcfyRy3veV7WM9H7vhDqq5XjzHpTJ2iL952fM5a02GAcX7hjz5D494rCK9FcBNi4l6WT99/fHr7FvuvhvtOzSEYrFSozFf4vQT1qwaUPxLe2S00UabWLTRxi8ER6a2l2rjb/Gc7M1HEt4zGfHaH9zX4PPfvwO7ux8MFBzNS59+GueePjTapepfaYalJ3en+v/9f3vvSFPsH8wUZxfDvtnFRUIjiCPN7PghznrCKet0g8zxKe8JJoqsFcWOxfVrV5xy7+6dTDSaeEMracQWiZti+uh9dKQ6lucy/nm4Sn75ht2ZSmxhew6WCOnx4GlnHE8HfPfXGbFoLE5emIgkh61mfJXa3qCywRGMpoTYrrDjdWsGRqqhZOeRMXQqzYr1x7Nz/0HKoeGeA0eZrIdc9dVv0Nm3gu7eYcb3H6G3I0u3aPBnz34CzxrOi1Jl7GLPzd24Y6p8y02HK0Pv++y3SHqXkcp2IBZn+cONq3n1c06IuiVfMPVZt8NJPaKC6ZyZuChIamd0y8Jl0hWB73knVaMgM76wQOKmQbkkzQbrRo5zM75clYTljrTtbWuPkDbaeHS0izfbaONRkF9KZ2iFf+vBmP+45gZKHT1MN8oEwTxrhzI876knkVfht8Py1AtTIu6qNcd+soOgOvsQSW27UZvya9HOv3jm41jrafJJRFehlz3lkGu3jeeUrcoA3Y591cqU96r1yzJXP/ucjdhejXo8j9ubIyCCVJrPXf1NDk1XbKOwg9jFcTqINcRGozFEya9WIOuR4Hf0XZrrGPqHLqclMtZLx+WD5N41jP+2bFC9qddwwzknreDxGwYo9rgcmD5CYf16SqHiyJzmK9+4g+7iOrqyBRqz0+Q9Q6es8dynncaqofTkAaY/tZiRXduaC/dtq0dn/vPHvkgp8FiWW0amHLHSsXjxU04jE9ZvVcFYpSOtd5Wj8bc8IskT6TiQPgD9WP9ekPHnXvmsJ5ZXZS1UWMP1PSrK4Wu33UniqlzVzZ557LWjU7PvbI+SNtpoE4s22vi5sH925jNHA177H5/7MmEmR6a3h3RasH5FJ6996fPokVyxUhVeVcx1Xu3bQ/+Q9gbfVW08lEgYYexwceKiY/e78+mrMnF42wqft7711X9MWmgmJ6ehMMh/XfMdvn5X6ewd1QeKLZ2kOvq8M07d+69v+iuiiX0ER/eRVppSo8F0rPnabXexc5ZCPRQo5RJrTZTEaGOIYogwxd+U8+lHzX1eZXHf8V2ZubdufhbJwiS6PEOpXsbrKVIJoLBsPdh5Du7fhylNsCar+ZsXP4tnnbaWFGyv4Zy6qxq+4dr9UyNvvfILRF1D9C07jv3btrLcd/h/F7yYM1dkPqCrMynfiiIbYwlpHrHtto/cpUq695u0qUa9vMzizW959Z9y1toR5g7vox7WuefoUb5zaO78iUhuuacabAMYKnb/Q2Vm6oL2KGmjjYeinQppo41HwZGZ8nuqua4zP3j1LX13jU9RxaB0nQGnzj+//sVY8+Ockck9bqoyfUHOLV5GPLvJBNUzXb/nIYqNwklvU172IV0ZGd+5rdFgg0jR4wxuGFq0PPYfOkzVSO4+OkWuf3hoqMde1gnXHJ08fElvLv/R+vziuX/6nHO56Xu3UK/USOfzTJVLjC0ukC2uZdvuIyjXpynqKNOkmLJ48snH0ymTPV1SfuU34ZymnNT2Ttf7uklwhSVOWrX2pFRVK0YnJwiDEJFK0UwU1clRRvps1ndbvPypJ/OU4/q/3W+r/440xcPV6EmTdi//+NnrmVbdNIxD2KjS5wa89S+fS9aCWrly5vKe/D/3ye53TjemXu+p9NYH18w8GGmsbcf+nXPd7y9Uq8/Lppw9UahPNTriyMQogY7Ztf8+Hv+kU+j0rPlaQ5/aaYtr3HTmjqg2dYFyMne0R0wbbbSJRRttPCoOLfBBU3Dtj3zrx+dd+c3vkOsrknagPraHv/3T89nYnR09K5PLH52duGSgs69V1CdT24Wd/pmLJOcMLw4Vy+5aNEP/8+3v4+Z7UOk85ajJPbu2EdYrpxT6e/5msDBwSanRPGego/AVFwpPOPGUnnu23snR6QmWrVuD8VPc8MPbWbnuNGYqFbQdY4kmQ1mXs05eT5dldnYJ+eXfpPM7U2++OrTtITdDbqbuce+efbiZLJ0dHVg6Jm0F2OXDXPCnz+YPT1h9uZ+Eu5VwypFF33d2T2/4hw//Nwt1m66RtaRTaVRYRzTm2LB6FRuWeeQy7t0Aga6M2Ik80un0fvxnPbac43y/aVg70t8x2p3vOmXH7n00goS5csihI7NsPH5Nj2VMv0jqccZyblNO5o5GNL3FVumt7ZHTRhttYtFGGz+BUXjnrnr05n/+wo/P+NY9R8gO9zI7sZdlqsa7Nr+Ec48buNydqh/szNrX5FPZ7/687z+muXhO8LKtC7XX/9f3bhv6xHU/INM5QLZmQbkGXkgYL7IwO8fuwxPu/oXwvN5ly9blLbZbEfMrcuJzTzn1lD8M4iajM5PUpSJJdzM1n2C8FEaG2KbBUN7jrJPW0in1noKUX/xNOb8Hg/pH6unUxh2TybqPfu773HL7PehEgqVoLk7TEc/yB8cPcuEr/oj1/b1lD3XAtZwjExFvuuyrN59x1Xduoi59Ogs91KYm8YM6SVClbiLuPbifgzNVMh3dfRbmlIKX+VbRznzw5zm+iSi4KEzCIa/ePFBMpUZPWL/xlAMHJzky26AUJExPTlHs78j0dWWPLEbj5yWqttZRqmbzgLdJG220iUUbbbTRWlQIL5pBvfqtH/pU523jITpbgKTMut4M/+/Pns+TV/S/d4Xkr1Vgcm5Kbf953/+wDt4/J6wXf3vX2B9+8OpvcsOO++gaXEmwUOYJg0Nses5Z7D2wFd+RNKohB8fm2X5wmu37xhlctuYM1xYbOl2uLnjicycev2K55aUHduy7j/lqRLZ3DcJKEUd1nCRgMJfiCSeuIi+Z6pHik78p53jSsv/mhh0TT7z8c1/j7vtGcTOdYKA2PUqXqPGvF72KP9y4jB7XKpsES0jiuw/WX/kfV30rc+OO/ZSFRb1Rp+hbvOHP/4QnnLCG+/bvYiasEbkOew4d4Z7deylkcqwcKCTd4gHPjyNN3lOzOLWhkw1pIbcCNKuTF8ZhY4O1ZHrWFHqdTkJ/MJW7pNOzrvHydsdslTN/vPsADW2YmhnjviP7Wb62/9TOTK4uUbMFCv/eHj1ttNEmFm20cT/KpdlNrpfafu9c6Uc37Znu/PZdByilssQiol/GvPKZT+XpK/vfvQzeMluf39SZz1z1i3zOdBD+1fV7Rs/80m07uHc6IdU9QrNcIRsscPGmZ/CEFfKm9atWLK/NzLA4XcdNF6lKjyPlGncfPspcmKiu7p7nGMG6TsXVx/V1yaBcW3706DQzVUkcW3jKR4UJlg540uNW4zWCkSHP+j/rYJgl3pRCbgeYSUqbDzW8N3z1pn38eP8YJtOBzGSYHT/MiTmbf/7Ll7Kx1/12BnYv1oITQyz7q9/eN/SxL93AaBVEuhOtQ1b1Zbnkr1/Chi7oz8H6deu4ded25kNNpv84ZhbrTBw5hIhZ09nR+4KiLz8MkLe4vgxnh1oua4rauoxwbmuI5uq03/OpY8ebFmpbznK/DzAe1N4SWs7yfH/Pxpvv2IrruwjXpRI0mZyZp2942fKiXzgU6aA/I6x2nUUbbbSJRRtttOB6qe27arXvJfl84bJrbnYrToaGCem0Y548WGDL00+6IpycXF7IZD6Xsv2fOVJRmi5t8dLe1vmx6Yv9XPrG6/dOfva/rv0+d44uoL0OOtNZ1Mwo//DqF7PcrSIai5kTenv+Ze2q486eHp1jfHKWQFtkegeYbgbce+AQsws1in1DPf0ZsccWzOY6e0/97vd/RLp3GY0owZYS37GYmTrCiWvWMtLrUSkHT+3xrf+TqMWMMZtLIjm3A3XdvPT+5NM3Hzzru3cfQuUy+B1ppuYmOOm4IV51/h9y2qrOm6Kk3mdJe3EmttZ84bo7uOamu1kwPrHrYzmC008a4dUvOIcNOXF3Tuvb3JjA82Tf0HFrmK3XODw2Tbazm2ppnvsOHGD1mtV90k+9QNuk5+v8iTHYSdLosG0xVae+sUt13V9s25ipbbbTzrZj97OWc3MFnqJsuvI9vYUbb/0hTSGpC8liM0baHiMjgxvzwtqag++3R1IbbbSJRRu/56g1prc4dnrrTMDmSem84c6Z0P3S7T8mSbmI8gTPOn6ENz3vqXevUzy7kMl87qe+VzCzOQjrp8zWm+eF2ixL2c52L+1tnZ6ubokKnfJzd4z96J8//VVGZYZc/zAyqpJtzPGRN/0Za3xVHulK/11sKj05x9zYIc0N5566/r/juvqjyckZRqdmcLp7ibwUh2cX+PGuvUwthKeuXV1coT0rtX7j6Xz/5u9QDxZBGRJiBDF7du6ApuDEDQNlJaimBNt/1ee03pzZbFsP1BtM1MK/k47bOKyjD1y9dd95H//ePdS9HPXGPNPje1k+nOFZ5zye1av7CQTL54Oo54f7Dq35z89/gxt2HsB0D7CQBFiuZsOqHjY/90w25MXO7ij+zApLva6oxIeDxJyeTjtr+nuLHJ04wuh9exGeT2y73Hzn3fQuX9k33JPCsZmwkubcMtf/22qzfGbR6rzswcf+YFJxDB1wXQWe2lns2FCJE3YcOUrkpZEdndyz5xCDAyO4yn2qBzpniRvLtekt9cbC83wv1yYabfxeoq1j0cbvHaYmR98JUA9nN6X93suPzlcv0S7+jokmV1z9LRq2TbU8x0hG8JfPPot+od/7s7xvEosoSYw9mC+8C2keGGS9mfqXtx5576XfvBE9tAFSPSzOzjDkGf78Gacx4nLDsgxvDuPKUNZyblaNarFPpS6l1OCtzztJ/L/NL+Lxy7oIxg9Rn52hHhkWjMfVt+/kZX9/ZaGqQGUlf3XBn9Cdq2PCSRzVpFouUU4sfnRggi//6MjGnYt8+rDm/eNR/S2/UmIRa//Yv49W40uwPaYiXnntnbtHrrzuRhakx1wYEEQNli/r5WlnPY6T1ywjlHD3XJmPf/NG/uur17NzukzNdohTmkjPkvFK/OmzT2NVmlG/Vt45YFv3S2yvdcRzC4366OO6U7z4iSdx0vJeUrbN7MQ8YecA/3zlZ9hT55wanCrtpLEQzm7q8wqXTi3M/Ew6FFnMzW7YKL/suWdz/NoVaBLmA0mU7uFT3/wBO+YqxJ7oAijXS8+wbBFPz4y17dbbaEcs2mjj9wGZTGsnaavU9mnDlpp0Tp+EN3z4mh+pG7fvxs2lcMMSH/mbLRTq0zcsT2Uv+mnvN0O0uR42T+nyOz7luemtk7XZC3tTHR8FGIe3fOyGez50+fdvZ7d2qbgpGosLDFgxb3/pc3j2+oEvZUz5tn7lvz8v3evzVuq7vp29GSDl2dtny+VNhax939OesEFG5erQ3NgYrnSwnAyB8mk6Ka67/V5WnrSebI/NmU84iZu/+wNs5ZA4Lnauk73jk+wYHaV3qI+eYvpMJ9IzXZb1K2s/TS1pOowFXBxYcmRR8+xv3nKv+vIPfsRYKOgYWUepWqU7o3juM/+AJ25cxZFSlS99/0d87Qe3s3+yTqhy1LUgm/dxZZXj+mz+dvN5HJ+TdOvq51a5Ha94+Of2u/b7jQ4Hlvd2dw329HXeeddeVEcf5cjQ09dPdXGWjWuGRnwR7+5T+fcslKcu6O7ovT9iMdVMLshY8hHrJDKI27QKfINYNbx2Xe72HQdYjF0SK0ezHlFeWGT16uVnRqZ+bs7nWt+SQRSJJO1nb2mPuDbaxKKNNn4PMBtHm0pSPaMkOLckOOcT37jb+972faQKXZhGidf/8XN5cjH32T4RfMFW1TOleGSNghmizUlMTiTotGVtBcg4qdtGY/3O/eXwsz86PP/8f/3y11nIdiH7B/A9h56oyts3nc8TBlO3FmTjc30yc+mjLtKuuz3vyOsXynMvOG3juqkT1q5dvnvXTmr1BpHlItJZJmZm+MFN32Pvfds54/QzOPXkJ3DjD+4gXxikrm3c7n4Sz+Xe3fdAAhuWD2RUYsppJbb9Ss4tyabxUL9FuzKzoPmjb912OPWVG2/jULUBHT0sNBOyuRzPf84zOHFthqu/dSef/MyXGJtv0IhskkRhSxvRqLCikOIVzz2L5z/5BJb5AcsR714uut74aJ/dKdXX++BSy02/9LjVJxR27NqPsFyUJTl65AD9/b0s6ypEhsDudvMfnpmb3ZxOpbZNB3qLdlW6miRPzEr5iGQgh/P9alR5YsZLr84PjKh79oxTq8dIbKqVBY4e2cfjTjlhqNdKfyGMGron2/fB9khro00s2mjj9wBj8zMX96WzH9xZD340Y6w1/3PjLvvrP/oxVelR6MyxJid547PO3Dm/Y8fTVveveGEo6ifVksXzPJm7sR7ObrLVAwqOadS2jFS3HSMVAEcWmu+pe/ZJd8w0H/eWKz5NuatIlEvTPLoPVZ/h3S9/Ps9YnrpireR5QbB4SsVqnpEmdf/r48nqhTLj3G8aNplMX5hJ+Xcszk8++7jBnk+f/eSTVlgizuw7cBCNheXmKfT0c/TwUbbeeS97908xM9eko3OYUiUhtn2E61GuVRkbG6Mnl+9MO975w+lfTafIbNR4+VyoX3K0bp/53Xvn3S/eeCeHaxFOoUg9MTi2TdAMuPPOnfzg1oNMzVSxvQK+04FpRPhxQLcKeO4pG/jblz2LDZ0efmmMYU9eIZuldSkbFK3fYLoSbinFyTOyjrr5wcfQZ/NB15dPXzuybvn3v38DM9NTSM9hx67d5Do6l2cz+fOkIejLtjQu0pbYuqjj86SlGgHNVSnsh9SilKcnLnLT2VsKyvviZKl04UAxl1Kik+133UNXZ4H5xUUWaot0dnfTUcidL2LhdtvOVe3R1kabWLTRxu8BFsPaeYd18gGdSqe/8eM99ldvvIPpRkzP0DKm7tvNlmedxZBt3DNXLPcAqnHlqR3WwL9BK33yv73/vLBe9N0dUy/56HdvYl+9iejtJpwcY0V/B3/3omfy9OHOG9YI8cKDY3u+PtC57G8rYf3JGZW6n0g8mFRMxDMXNRJ9wvT83GsGe3re5YhktLIwcdbG9WvvO3njxoFdu/fTaII2LhpJ/7K17N01SrpnBY26wU3lSVwfbStiE1FanOfIfQfp6cjRN1hY1im4ZrRceWfObbVXPhaYkWZz4vq5a+86XLjy2u9zNBTIrgEawkK5KXScEDRjkGmM30UtAJ0I8p6LKc9x7unrePV5T+P8U1duLcJXunTjKyemB59RWpx8bTHb9WUdiMi2Wr9D2lVbH04qAGZnm5uW56w3lqvhO9avX8v2nfciUxkWg4i99x2lo6uXkaFOHccUMrLl/BpIsUqgdS/OT6h0uulWSqNand20Ite1qVLnvGVDqYH5qTr79u9HpXwix2HrvbtYPXIcxUKuH43KSW5sj7g22sSijTZ+yxEHkxdKK/OoNuF1T5w0Wm+87EAg7C/94BYm6hHCT6N0Qp+tuehP/+Dg49J+//3Pb9ZODVVzrSf+d1Kxt8ZXf3Sg9LJPfOcH/HhhkezKFdRKC/R6gov+8Im8cNXQB/LN6ZurldF/crLefWm749oHk4r7d8iVsYtdN3djVqZvqVuZjal04e7yfPnpQod6bX7gebFe7BpIedueeMbqJ4ZRF/fuOUTNKOYDxfKNZzE9UydqJKTyeWTKplGeA1dCymNhYZG5mWnSbvaUdFfnuZmMe8djYas+HbFlUfHsOWNe9tXb7xr+/E13cLiu0R3DRKlupJPDtdPUpmfIdfdjdw0ROxlQNo4FBSvirVuezwtOGYp6RLmWbzavH/H8C7LSvXl2fmbzQNfyiyzSW4+Rip+GVMrafnR85pITBnNPEZ776lPPPC1347btVLVkMVbsPThGPltY1dmRfaK0aWTgtjRia8PUT0iLn+wMqc+UNlcXZ1+Q7+77D4Bem8ubdfPUE9YNj+zasw+ZyjCXQKhS7N5zmBM2rLOzikEZB+GDo1lttPH7AKt9Ctr4XYNQsvFoj41V5y6uZ3InJbkCn/vit9g7NU9NK/K+IZo5wptf92r8INqJ94AZZleqeNnP8rnbStw3Kxi57Npr2T47j9VfRIYBmUaVt/zZS/ijwcwHMuXZrXlfF8O0Mxo5zugjvU81mtms0tYcwD3jo9uymb6bV+Ss11HoaT2ezG6KGrViRamzUn52p+3GG4QV42eyqHwvB+8bxXUydGXzzC9OEFQjnGKe0PGgqUkPL2f7gd1cdcNN9Az3nXmC7zMPLzRgp2FrDF0uHDJge7DPgFWEy6ZhS2LI9gv+fRq2NA2rI00RBQKi2KZQh5O+ec/+wmdvvI39M038FScSOTniWgzSQSqF5eSolRt0FHyiMEQngnq1wnQ4SSoDtaRpr053vHsI9Q/Hzkl3V8+VM1PVC3qKmft/i/n6xEXC1inbdkYzPNT4bWaxsnl4oOdtAEU3/lA6a595ypqR87+xdSdWZy+jpTL/+t9fxPuLTbncmsLZEhr1oHLSCjf7ukckKj35K1PkH/K39VnxND/igy9/9lNe++Fv3QwxZPuWcfjwUd5/1bf5r78+Z43Ajdojso3fuznYGNM+C2383mBPvfT1Sip/1iduvCv3mRvvQnX0Mjs9xkBK8ZYXPofTe3OcmU+LR3rtYmV2U1gPRnqLg+9aGJ95i+3ocqa7eNlMfX7z9qnyFdbICv7j6tu5af8+ZCZFUKthLS5w2Ztfz3qHrSe4nHbsvRJmNym6H5KDn202N2nbpHqVf/l0NLOF0KI33Xn5scejyfhCu8+6v9DzxzDxpa13933hB/dQtvPYXUXGD8/Tn13J/OExfOrEuoRV8JCFNPNxSLpQoHZ0CkqL9GVdRLPEQH83A0P99K9YgSMFy7q76fAcFuZn6enqwpEGx1YYY4iCkGYYYZBERrBQqTM2Ocf49ByTs3NMLiySpFLUgCaSAJskTiFDFzswEMQYElTaoakMxhYgEno7HHrsBtUjO3nxOU/mWadsZFjIK1bCq45939JU/YJ8MXU/sajWjl6iHGPbtnvQ4qeTv8Pw/rvrvOGfP/llbj84ztC64/FNgpkf51XnPY0nrhmC0hQj+ey7h2X6bYsLM5utxNiZ7t7LH+09a5Xxt6SzA/9yAD7137cfevlHvncXU6FNT3cfenGCF562jOecMMDGrPrHHqn3uenuds1FG21i0UYbv3PEAr5+w2j5ORe957/wBtYQS8hYAWeu6OL/Pf8Zo92N0qeHUx1v+2nvMTtVvqC7mLt/ITsSNd9zVLhv+uLdh/jczbcQpWwWpycpGsPbXrKJP+jr2npC+gFS8ajv26hs6vazV800S5t7vPyVj/ScufHmW+o5KzeXki/+/+ydd7xV1Zn3v7ue3tvthV4UBFRQsWDBXpLYg2bQhCToDDpqYnzHOOqM+o466sQwkYkyUWJM1ESMFRUsqKigdKTf3k65p7fd3j+uYuwmrzNJzPl+Pnzgc7l7nXXW2nvt33qe9TzPA6++3H7fUyuIjJtCumiSShZoa5rEUE8Zv9NN1GOSz/SBXEaTIanpeCMN9PTGsUyRWDCIpWskk0lijU309fWh2hXMQpqAR6VSKuK02yjmc5TKOSzDxG63Y3e6qFRNdER0S0YzBVSbB6fbD6qNdKmMYpcRKaCaOg6ciCUTR0XA5Q6gufz0peK4/Qr+oIPOzj0EvCqKUIFyHi2TZ+b48Vx2zgl4dXZMlRnfn8pfUR90f6weh0V8PqalCLpYRP3sF/cWeP3Jrd2zHn1zI1v6BrEkmbDXQ3Wwg/9zycWM9ttpVdRXhERGnxj2Hf1ZbWWyPdf7vE3XAWzOJNfmfaEZN97/Imt2DaHJLtpbYvRvfonLzj6BM6dPXD5OFs8AyMST832R0NLak1ijJixq1PgKsM6wEhvixdAd9z9BogglDbwumYijxPXfP4dT7Irwx7Y5BAv64Opn3u1u//flz1B12ckk+xgV9HLpiacyp7Vp7wEKo76s79BR4e4ek0v+/Te/5fcb3iAyphXLMBHLGheedBYTJjfx7Zt/hehy4tHzjK/38a1TT8Brk3l9zTpeXLOOrnSFjCFR1zKOYgUcdi+5dBlFVLHZRSqVJMVyElkQsDtkFFnEsgzS6TSqqmKYYAkKst2Jze7FFFR0Q6SiWVQ1g0hzC/nhXpRSN2ohTsCscviUacw9bA6uOpkfLHmdvnQGh5bgwrNPJp+Ks37TO6xZ/w6hulY004fLZqfBC98580QaxCrTwr4fNcAt/z9j12nqdwzo4mXvDCS586FHSBgipmKnXMjjkQWu+M5FTInaaYVVE+Hoz2svm++72utuuAVgQ6m8PYl93K33Lmd7osBQNktzsx9bOcvtVy7AX9KSM7xKuPYU1vhboHZ4s8ZXngT6vB7EG3711rZp//3Mq3QNFIgGYqiZLLMntHD9gpORcmnseiHttrm+0CHGPQXj3oQgXvB2X/GHv35tY+CXL6wii4UkGJx22IHMO/oIZjfV9TRL/JOT/7802psL+tq9Veue53YM/PMzm/YcfPcjK9jUN4AvGoVqiVF+J/966UImOry4FIFn12+jIguYeo56j4MTZkwiJsC0WEw7aeZB0hGzZhIJR9m4ZSeKy0+5LFCtiNhUNw6nC4dDwrR0JEVBVGSyhQKqw0ZF1xFtNjRBwO0PIipuCmWDYsVEN0Vk2YHH4yO5twNHJc+Rk5r4hzOPZ+HJR2ePmND4Tsxl7hVEufX367uRXG7Mgd1c8vUjObo1tOOgiZNCQa+Hwf4kqhKmaIgMVfKsXv82ZUsjb2rHGpL0z6aF26fIz33aWFnF/iusUu5IweZZXSkk5snqBwc9/YL4LGhi0ONqmbb/foFKtcJAPEGxChVD5d0dvXT3lvD569s1O/9YEphUrGYPeL8g2UexqZ590Sg6lYhPVTdPGj36YF3X6OjpQBcknMEwnf0pJu/f5rRMRgdFfld7ImvUhEWNGn/FDMLCd3PVn6/sSk/4xZptbO/LEfJGcRULfPOQKXz/tOkrXIL5TovTdbNgoruUj0cEfJTdev7+nN1+5Gvd6cPufW41j6zZgLOhBaOU46jJ4/n+cUdwsNO5pNQfn+iSlbfdivQGQLyiz3fJ4vov2vcujVvfNVnxdi7fcOvvn+aRje/y0u5+CrKXWKQJey7NvCMO5Qenn7J1IsI/xUThCZuA+OyaXeMqpoSim0iFImcdcgCjBa6coIgnWcNZt2oYB4wfG1EaWiawp7uXRK6Aqcp4Ij6S2QGmHzCO44+bxhFHTGD8uAls3PIOul5Cccg0NsWYd8HXOezQcQQjraQzaSpaBQQBTdMQizlaJIMFJx7OhUePYaLTtjxoDD/q1NM9qlXs0iVf7Ndb+kJ7+pOMsll846ApeNP5dTP9tjHj2ptaZk+fPq2cMujo6sLT1sCgXqGrkGPN5nd5btXLHD13zqFVaCnpTCrqTHFL7MuUaZmDC5H0kOho/BeAPxQV7+MVpRf1bDrY7vf+ZvTotpMbo430dqfJF0UG+8okcvDqOxtxhetsjXWOSQZlX6nQfZxTKU+QBO+HQkfjhdJ8l6qsB/BK6ot+gafandL1beMbj1Fd/tZNe7sZ1kU2dfVh2fy01QemqiYVj8Rq4kMLcLlq0SI1vpLUaoXU+EozYJiLXtud5nev7Wb3QJXW/WZQzaWYVOfm3DmTlk+wcbyQGtD0cioUcbg+HFmgZ+d/zPphlOYVZNuMN3sH2v/jsadZN5Cmef8DSCUSNLvtnDVzGg2auaYyNNQ2vT5SL5vV5PvXRmzyF/atJ2DenmL5ypf39LF05RrWJQoknX48o0ZTMir0d7zLovO/wfmzp6/wlfIrrOGkHFVYYq+yszqUwhjOY5fd5LJligUwwQnQEvFedVDE6WoTuPPQNplJUR+KlkRRCgx0b0V2Sbyw+gXi6TKaDuEQFHJZisU8hUKBgcE4mFCtQm9XJx17tlMsZHDZQdSGKfRu45ZFJ3L8eB8tJreNgzM8lSJRm5z0qmKpd7hvXCoTR5SgWioQdrFiQtR9fF/P4PX2XGVnuKqvufiEiclrv3M2XqOMYgnkNIW+qkw1NoqfP7eWTpOL+g2uLEuM/cMxq1YNryDZd1aKH6/Rkc7E5wNUc/H5Tf7gdWIpV2oQue/Q0TH+8cIzcOoG9Q0NDJdLDOrw61ff4KE3tyq9mjADT7inIsjJj7YZcTk+NJ+lSmIegL1c2Xn6rAkDx0yfjmQYBBqaeeSFl9jUX2J3snzzyMWffii0Ro2asKhR4y+UXZQe7EhXxr25I8vrG+LUN+3H0O491CkZvnXaDMZ5OANgTKTh/FImO+n96/opXDGIvjAie0deHIncvPf/TxPtsdd39E5a+syrbO5NIwYiOEXwa3m+f9KRTA/bX5msiIdMiEaPBwi73J94oDChZ+d90s/jWPP74YptxcoDu0rws9+t5LWtcWRXKzIOcgM9HDw2xG1XX8i0docWxnzAqmSVWCC0GMDuYGdj2Eu1kCOrVbEF/aRzBao6TYPlwr6CW60Cl+8vcNF5h+xPvSOPUerEG3FSKA0j+Vws+82DdO4ZQgIcip1QsB63N4ah2dGLkEnA66+tBWSC0QDFYpIxMZV//cd5RKwyh7oRWkSuAvA6G29M5gszBvOVKcFAPbJRRDEyhMIeRCj1Vo1rG5pi1zV4bLdMDsiHzHARnhlj3ffnzOTopmaiug2qLgbLKo+//S6/fn0rCRuhvMSsjkrx7u7B/psAbPaGWyC8zOZsvPGj4+qWoZofWKR6IksLpcS8iMOz1MyUHK4yew8MsuYfLjwDpziEw55H9DrZ1pvgN6s3snrPMP2a5zKP8EHUifaegPgoDlt4WVcpfesou+3imMXiMw89gDrJxIWJicotP3uQrNtOT4nr+7urN/3htTkrPj9b6ryj9tTW+CpQc4XU+MqyPq89ct/Tb7BxyELyxIj3dtDuEbjy7DnMbo/8uJKNT3DZRszRAbf/iVJuaEEymzzXdDnNVCF7plDVTZdqX19Mp08q5Msz7R7n60tfffu1f1/+PLsLFt6WsdglkdSOTdx3/d9zSDTwq/GCfMoX6ZtTtG0E6Cjuvacvn/xB0W6bkkY9NS0Ip27Oahfd/9wrLH3iBSxPBG+kgUR/Hw6txKmHTuXs2VOZGnQN+Izsc3bKexqdsX0vqaTJ+VsG8rP2DA9TlCVEU2O8T2V0yFuUhGrBp9ifo5yYp5eKUwolJWBzSy3B1rrIux07ScSH8fgCyDYXlUqVxMAA1ZJIOl8iOVzC466jUrLwe+tY/tgzaMiEoxFSQ/3Uu1W+9/UT2D+s0u40fhVEeRTA6M9dIXpsr5esSltVsof6dGnqE+9sp6LpHNxWz+GT2uNC1TADivT4+98hVRxcaJeFd9rCvm2RYOOhAwNJ8sUq8WQK1edhR8cu9nR1MWZUW5NeqR4c8gWf8kjC6s/cQamu9ZI6kjRNVUZcJEG78qilIifKXNBWr0rt7aPZ+u5WBtJZom1tDAwOsG33HupjdTjD3u8ZxWGvV3W8aOqZ40SjOE2Q3R8rWOZT7M8BeEVe1gSOnH3UlPZfPrYK1e1DUF28uXYHU8ePP7I+Jj2UT5QOdbuUN4YL/VfIslhSVGWwWMkfavuEdmvUqFksatT4M7O3wD2vbMywKWGyK9mP4tNpcZU5dWo7M5rr9jYi3Ci9V9xbr8bnV0sDiwTJkusiLVcpJW1wsit6SMQ9EvKZt8upZNA/9fZ3dlr/8co6UsFmrFA9xWySOlXnh+efwRiFNY5CYdsX7V8+2X1Tubj3HpeoxZwB38akYZybt5jVkWbWTQ89z8rOYYoOH4agoaX2Mjlg8c1DJjB/1kQO89kfaIQbxyrhsyLSSOhivJiaD2CJKPWNYWTRQlJEBFWkb2AISxQUEaE4sp2wFNkTXlbnV+5SdGtwSmsj3/v61xgXcCOl0ihFAY+znkTO4OmVr1G13DgcUYa6c0SCo3l59WYM2Ytk8xDv7KPR7uEfzvw6+/lttNvUV8bgPH/f7l62UgBhW/3tsqgmO/d0YQoihiDS3NaKDiGhWtUBEsURd0XQGVtsaVWlMJSacUCd9MAPz53N3805mLagE6ckoAkO1ndn+Kf/fIi9upu4LM7fU+HeRMWat7e77573P/uLlC3XKYUCNm15Hdw5q97Z8w8nncD0iIPCwA5wiZR9Hu554WXWZ/Q62RVIvbtj20rFXn+7oeshrTD4mSXXQxIPBU02zJk+Fb1coOyU6agW+dWraxmES3TVFgQIuOpvd4mRpXYiS4t/mJmtRo2asKhR489Pb6V8bXeOm/pKLPjdC2+T1iQUn0o5vYcpUZlvHj2+J2pnyZBWWBBUokvS+sAiWY0sFUqGF93wFgrx+VGHf5//uyczcH0xGJzy+JbtF/zkqZUM2QKYriCldBqlMMw5Rx7EKVObtoZMHmp0uW78vP4lsuY8AHeo+RpFEjSv3btKQ4oNpKt1u4aZceVtD7J5sERWdFPX0kJheJDxEQeXnXUc3z5q6kC7ZD7irlTWxBA+lBBKM/QYgAKDkaAPw9Cwu2yodge5UglJVLN2xb4zX0rMQ4ksreYHFgEoWnnAr+vZqXVhbvjeN2mQILl9N0rJwueLEG4bT64qUdEd+APNDPVnUewebKoLhyjRHAkz/8TjOSACLRJr3HruQ1E19oh33zkEXRNDm7fuwpIULFkmEokgQdYlSuveX4xS1RE3Q50reFfEJd83WuDCNoUbTprSyP/51nk4iwUK2QJly4EZaeXHS37J0lUbxyVsXNBnmj9qb274bmfHwN0A0UjjjX2Z+NVD1fSCRCX9ie6LZhzXONC2VvKZ9kDVWn7y/tGfXvuts4hoWSSjiuJ2kxZUVm7czZu95TsnjJt4NIDsaryxjPWZIiCqsMQn8Nwh+43BLKdJpYeQAx6e37iRJ9Z2TSq5xUkAg5XyQoCEZcyzBFstG3KNmrCoUeMviYKozyh6mPLouu0kDItyvkyTbDHBrvF3cw5kmkRzA9xiSaIMUDWVEoASbLxR0ZXBSrY4BaAvnbl6wCgvStg9F7zYN3jJrY8+RVzy4I62oBgWjmqJf55/Die1+zc0wM11EvsyYsbR5/dRvjqu5z92+DPsFZcNDQ0tACiqjq1ZU8p6CK5uD4dX3f7QsxSjjYieEKIhoGXSHDS2lfknzGZavTtpzw/tHCuJZ8Vsto9lmWzwRG8BMDEd9WE/qgSqKlPWNYazBcq6NTYs25a5HeFllXLP9ciCBuCz8VxUspZMEoUbfNki137rPPYLBpDzRUwT8joYdi84gmiGA0FwIJgWEhWsQoLLLjiOQ9tUohW2ThY5pEX2XPWp1gFNCnZ09IGoIisqLrsNJ2yMeuxLRiwVkaVBNbwsOTwyPmGXdxmAWEiXmhVuPrZO+OlZM6fRYnPgs7vZOTRMwuHh/tfW8u9Pvq4MKNKk5zqHrNa2uksBdg+k7m/wRW4RRXcxbPMvG0z1X/FJ/WoSnNeNc/vOUCrxQZdWXjfOpr3yzxfNo8WlQKlIJNrCEy++xaBi5+UsVq/OtQAVh5r8vPtRFeiZOi5IxCPjlkyK+TSGy8Hv1rzFC3tTZ26HJxKmcEFHMX93WJCW1av222tPcY2asKhR4y+IsuIeuwNO/v3bb2EpAo1BF2bvTi476xRmj45e1JsZvnawXFgYEx2LAaJqaEkhnpsPIAUjS4P1rZcDmHavY1CwL3yxY6j93x55mmF3CNPto7+jg2r/Hu7+wUUc0eJNeozyai0zEPvDPkSQlyqogxHZ/YlRINFodMneRO89SU2d1Fe1X/32QO7OK+5+dM7mgTg5rYxb1vFUc0wIuFh07slMjgaKvmphxSR39IhcYcTS8GmY1bLDIUuoEhiGQVUzyJarVA2rad/viFK2pJfHAkQcjqUtgnJVKTU06diwUxgfYMcN3/0atkIcsZKnnIqj50uYkg2by4usSOTT/VSSHZx40DjaHTDaziMRwbgPwDRG3Bn56scPOOqCEkrnyximgIiAIoio8LF6KaHASMRENhefny0MLWhw+W9plrkmP5ia9c0j9nvlpGmTyXTswCwXyedy2OoaeHbTNq64/T76ZTdvDFetPSXz3tF1wQs789U7wrK8DCAWrP/Ml3ajP3qjlU20TXLZj9gvGkou+sbXUIeT7N7wDjaHm+t+soy9JuzUuWEXPFgRXe1xUvM/q81SvjDJbTFw498vwKPncKtguZ10Vir8YuVqXhvQTsZhA9X1YctW4ZMtLDVq1IRFjRr/i/TA9bsKpUm/WPkWnblhfH6ZXPdWLv36iUwIODYAVI1yU8zu+tCO3xXxfDjMtMz8tCCcvHJHfNwvX9vKtt4C/nH7UynniTo1/nXBmYxVqrRiXiZker31vrqPvbAiiJ8ZWtoebvzu3qR8yeud5XG3PL6SjYUKRQxcQolgvosfnXM0f3/qUUySuK9ekm6zV8ydfcneaz2uurviyYFFifTwJ754FFMcVA0Tn2pDL1cxkciVLSrI+8z2Zd3w2twf5FBIpwcWjQ1Gz0pk0/O81fKL+0V45JIzj6bBaYJVwdtQh14pUDTymGQIuSs0uYqcNLWOiXZWiOlUqd4m3Z7N9V4rCIKm6UMLhD9YWXpyiet7q9q1FVFtK+giWtlE0AwckvSZ8+n1RJZ6XdElvfHd9wNEFP0+X1V7buHJ05684aKzaaRI2KOQzqTIWQqb02XufXENWzWJHku8aLvJE61u9fLP+oxEIb9vHPPJ3mujoabrdvT1PVbnlO+a0xzcesP5ZzHWbUMvZrGH6/jnnz/FUz0F3jE4r4Bthoni+Mx5dru+O12gvt1G9p8u+iZiIUlBK1Fyudk+XOW3qzfQlWcWskB/bvAKgGx5aEHY5a/VFanxV0stKqTGV4YtsOq5d/t45OW3cPnDGMkhjtl/LN86fsYaj6mvzqb75owNNZ7zwVulNA+nshEgnknONyjuZ5OdG4dkvv/SzsSp9618nXcGsgQmHUCiq5tml8wlp87hhObgulapcv3A3g13j66P/pcofLFER9lCYl6mWJ5VFBxTthd4em1fwf3Ai2/Sp4uUgAa/B2Gok39b9HdM8qvZMU75nyXDyCmlcrzB7b/V4/S+nEgMLYiEY4uddseHkj8NpRMLXHbnuqJhTNEVZeqb73Z4u8s6BhJitsBxM2fgVel3iazLG/lZPjm2eLgwuNChut+y20eiJZw2+8aATX4ilcme3TIm4ihZQmB3Tz/ZkoWp2tFLGWJBGSG3i2+dMJPTxoz+qVDo10d7oxf29+x8OBxpu1QQnBs1ozDDxHSo0kh0Q7paOlmTHfUJUzz80VfWUVC9yIbO2YdMplFlhQc+M6LD6wr+LpvvvyLkq/sPryK9nEimvjWuLbp5zpEzJuze1UUqnUayO8HpoiQIvLHxbVBl6qKRcflK+WulTGo/v9P11Ce17VTVfeOoOkcSYIU8noc6Upn/DDvsD4S8zsiY0ePqtuzaRaIKA+UKe1MJ7C4fMa99ggNLD4nKQ5/V/77hxNUBl+txn881TZck756hFOmiTmPbRLZv34XH5qS9IXDwBIf7+LIxuNClxn5We5pr1CwWNWr8mdkOT+SBpc+8TiavUs2bTGlp5cxjD8cDq1W93OP3uZ8CGB56z9cediyrDCYWAlg+lJSlzeqB63doLPjJE8+yOZHBHoxiFStEVIXvHnskJ7ZHB8KV4QcchaEp+7cf5CrlCzM+qT/JvuTV+ywgxfT8/uLwFSXZ6TX9QcfWAvctfemdun975Gne2LqHYEMzIbuTBqPCvdf8PZO98q+aVf1HDXBLoyTdGHN9YGEJf1q1zffKnEiqnBV1is2ROrRiFUm0UxUcJAoWVWgEiNhH6lsEXB/kZtAz8flGccR9MTboPcujV1afPH0s3z/tePTenTjJUVfvJJ/vYuGFZ3DCAftrNob3RhVhXSE7uLC+aexZ77dlV6JL3Eps8VCp72oAQVG1iii1p4GiIFHOFQnZnNiBalVr+pC1KP3JkRZe9wdujAmh4PHj4Iy6orHmsuOP5pxpU1BSA7S1RCk5BXaZZX6++iUefO0thlX7VN0eDnb3p2/6ovfSXsO4x+n3bhCMqhYVWXJog/ORWe31lKpJAm11DOZK/HbFal7Y1EVOcsz+w2u7M9mPfU5DIHxLFJY0wM1HtDWxn9dNs8vFcCbLsKjw5IYtrNzewwAsGi7qoaFUx921J7pGzWJRo8afgbiWmZ8yqmd36dLt6xPVwy/7z99heurBUmgL+PnOCUcwvV76VbvA9zyK+nrRTM1JpPuvrAu3LQLQehLXF82y2+71vthdSd3UndXPK7v8R97+2CqSsh3VH8asVhFSSW749teY0+gYaDK5LqY4FiulzHGCojWIkpwU39uZ5/KJebb30kg7Pc7ViUJ2Xs4yZlclpamqOFuriq3p7b7ij+554gWWv7GByNhJtE2YyI43X2eUXWLhKccxs85+kVLIJ+psnj/q5eJSnesAnIK4MW9x6I6+zP4dJY2CLmAXJKJuJ9Oa/bsDIo9/4g7D7lovKh+kwDYl3eUW5D2GaD/0tbe3YMgiFT1LKd3N2UdMZ7Ld8YsWHFfbJPcbqu2T8y64lJFaGnnLOrSoyFO352hY8dZG/IF62kJ+TjuwsRiU+Z0H8fV919g/P4dDvJScnytXjhzldn5HRmlob2uccejsmSxZ+l9oMjgDHgRZZc+OPXR2DiJh29/p8h7e7FWu/2hbqVTXrQ6Hb1/tkUG9utCUFWe5XBjnEYTVUUm+t2xYE/yx8Jy1e3bT1dmJJxihWtbo2L0btyvodIW8/xjPZOdbDput0W77l0/rd6mc2a81GF4+esy40wf6M7y1aRvN+02mbzjO+o3rmDJq1AmtkdgjMYf/4/3MDCxyvGdZqlGjZrGoUeNLJpHouhVAU8RYUnac2ynJU5/f3ku8JIKhELQrjA64GOWRGAPnA6TL3TcpYqU9EHRuGEr3XD80MLhIaQpf529quq4z03OHaqvvsUdbWfraXl7tGiBpVkkNdFBHnh+cNofDA2xoKnNdVGIJgOhrvRwpslRWRnb9aSMxz1S1GMBArvsmGIlqGDb107OqfU5ekmY++k7fRdf87CHWDeaJTNiPXH6Y1I6NnDt5HD865QQOqvPdZ2Q1b53be9efMi4laySaQhXojQa8qIiICBg2Ozv7+zBkvF+0rTD2ZS1wVZOMFjArqKUkZimNXbJwq+onHrr89O2LiA7BXUODVCQRVZQIO5y4BNZJmLk/9ntGHKGldZ7AXQDtLr7b6uDHzVaVh2+9lgMDMr5MGqduIXqjPLVpNz97fQMrhrK8VsHqhysAckMjWS6DwZarcukPokWqeqHJ1IqOiQ730WHFvgygURJuHBVyr/jOnMOYGnYjpPspF3NURTc/ffgp1sQ1b7/HO27AMC57rWfXvnLR2aGBRfl4Yt/hzojdtzQCS0dr/PSkMa1MG91If+8eguNHITaP4l+XPka/wZW7q9y/qbd3/R9+56Cv7q6BQs/1nyu6rPz82gpRoyYsatT4qHDQ9c88ER8Ot1wFkNSlc7Oi0v5yR5bfvLwGl92NkRxE69nFyQdNpM3PzQDDxb6rVZugqaKcNJGylsM+GK2L7Xt5O31NGzNIc5/cUuBXL7xFWbeId+6lQdK4+LjDOGW/8LpwhQeiDj61voNfCi8TVSkHUOdpvmZbdnDldswnig7vlE1F8/Cfrd469b5nV1J2eEil0pjJJM5MiokuiW8eO5sDmtw/GuXm4jqv8ieJCkNLzJNM0wGgivQ0hMMUUilkWaFkWiQrVarQ9IXnwCjNA1DK+qBULSIbVWTJwGm3IRgggP5F27IQZA1im/bupSIIFPMFbIKFZJHFMohT/v96GTbCjY12YclYydpx+/z5nNjajj+ZZWD7djzREGmPjf9+fTXPdA7SDTfvqRr3eqIj0T/ZwY67Pf4P3CzN9sA1btFa89HPCJgsP6S1Tlt46nGMdUr40Mjn82h2L/+0+F7ezcOQKDU5m0bt7bZyNwF4o3V3uSPhjx3ibfNz6cHN0VWXfm0u9twQWiZJoWpSdob52fL17V1VLgg2Nj46YJj7IoBylfj8OlfTdZ8rugT30toKUuPPTc0VUuMvjiGjvKAs6mPdgvKppt/OavGOlOI8498ee4VfvvQmguKiyWbDm4tz3pypnHpQ65Oj4GIATSrMcIsNt+QpHpCt6E2Ntvp/icP8oaL+/aQpnr87afzTA8+t9z74+rvodg+OYpLTpk3kyrNPZ0rAMVAvcXudIn6qa2IgP7TIrbresDFyiHNvvnCP5Alk3xgunPPbre+6H3ztTV7a8i66oiJUKtTrBrNiYS4+5gjmnXDQK81B8Y5SuTgpYFMe/5N3CJJzoySOmMrdIm+kFOWff7dmPRW7i6Jh4pCqnDZjnFwPXyhPglMcOdQ6pInf+93rb4UqLjdFEaxKidMOOpBmm7TKCy9/kbaShnbesCjP+vmzL5OqWDhROaC1niPHhp5qFOSbSlj7OZH+6NLyXZn8rT67+hxAQJSe0HLZhhi2pdPCox2T69tGN7bG6BjqZMjIUvGobO/rZ9dgWoo0tEwTVI40Dd0V8gSv//h3Vz/WF7fAW1VTb4oEfZ6D99s/JOoGe/r7ET1uSoLMGxs3kcxXibY0BkTZdriG3hJA/NT5rJpaS0NASoZC4UlrXl+DItowLQe7evvJaQaxltgcmyyIYYFlADbZtf59wVc0meIU//jxqlGjJixq/M2Sl0ozFUEYdPHxEub9xK9IlI2/GzAdl1z730+xI2+RyBRxOhTaZYOrvnkap89ovU3PDUXCNteDw9XBhX657m4AB57X/bLv2b166Z6MwHFlVZnw8s6uo3/y66d5qyNJTvUgGRWOn9TM358xm0mqcKWZTrhb3Z6R3W3hgzMUf0hJ1yalKsWz86JxaFZUj0lJ6tkPrFp/5E+feI41nQMUBDuCKGGvlgloRW655Dt8a864S1pDrlWySUZUKNpt4h4X4pdSRnugai4qq8IBL2zpcQ+UKug2FSppzj5kf3cTXP/HtNWj8a8PvfqGreLyUhKASokzDjmQVpu03A2f6fOvGol5kujcmDSq56dEZf+fP/cymuTEJ9o4aHQLM1u9q3zwQh59lgv5j/7uPrv63PbhxBOWTba5BGm9z+Z8oTyUPqGl3vU9m6CMbx/XtP/+0yfROdBNf3wIp8fP3q5+Xnr5TVRXsN0XCJ6cKeS/hmWIbkV5CyCZ6L9CEMoTFMW1vjyYWCi7nfvOfARk+QlDsAIBm7h1xtjGQvOEae2rXn0dRyDMULrAUKrIylfeoq61CY/PPQ2TiJYvx1w2+WP3sVeVXq5aVkvI654za+ZM6e11GylZCqlSlc6BAbZu28Eh0yaNdkh0uWA9wGAuuzBqd9+bMTkuo1dOqGi5dsvKT1Ml1/raqlHjL4maK6TGXxx2CtkIro+ZdFPGwKJ0uXpyr6Uu+O+XN7ByV4KenMiU6QdR6u3k1EMnM7vFcWUlPdhmM0sdAAE1tvjju3tHMS8Is57s2jTp31c+zupcBr2hHlHPU28VOf+IGTTBzYnu7gsmRGLH73sZuMKfmFsg4vQvLYmOSXFc8zcW+fH/Xf5q072vbWSQEIK9kWpWIKiLzB3dyl2LvsX+deJthqV5h4vDp2tSNVYPt0eRvrQy2mWtOlaWSAV8LqrVMoIqUhUsqpgMkV/wRdvpM82rCzLerCiTk1Sqoopkc2BhfqHrVWlkvARB0CsaCKKMrCoYhoGsiJjgGKomF1gYf3Qa68FybuGgWVo4PhA+JSKq++6VUEPwFoAxMfX8Jpt+8wynY8NVxx/PhdMOJLF+I2axTLIq8JNHnuOBF7eR8binFhyOGV1V/VaAULj+dv29zBT2WHgxgJ4o7XPNNQrijdVEukmukJzqh1u+fxFGcpimunbSFTfDYj33P7OB5zbH2WNwSdplO+kTrXLV9IJ6Qbi9TtbuOsTNnQtPmYtP1HF4XBCqo6sisHrTbgowA2BoaGBRzOMduZdlCUtVFMNmeU3FdOjmwCJTS9QSatWoCYsaNT4Np2V4y3w87DAo1d1VtvvHrh0o8ptXtuKt24+G6Gg61q7je6cex5ETGzTZKqbCTml5m6/10m2pHSsHteS+dopx5icKzMsJHP7irj3Kg8+/zq5chdD48VSoImT7WXDGsYzyqaua4Zr9m5sP+GgfMvnOOypa39Uf/blhd3j7K0L7q7t6efiNtyi7fLh9ATyiQp0kcmR7O3835wgm+VyX2YzsXlEbLoX9jmWmUXB8WeMWN/WRDKIiWSdscMkgWwaCKaDY3GRMi1Sl+o3Pa6dkjrykRJGS6gBFtmGZoOvGyHe1LHQIfiFxUh662hBtXt0Cu82DIqmYRhlJ1JAgK0oUYzgX/7HfNWb3LH4/e+qnkkvgr+afmmJ3rJh/+CzOOWw2Yq6I3R1Airbw4Mvr+OHiZ3l7iIt0VQ7uqCYfGySxsPyRZuSwY1miN3EtQH8yecW4sP8Ml6WvC2rWK9OiDPzDmachpuI4JQFBVNnWneShlW/w7OZOEpJw5hB8SMzF9eJ8UVKKAC2K4yopV8weNSa46sj927GLZQqWTk6xsbE3zruJ0iVDBgui0bp9Z28Ui0HRtEqWJcg6gm6IclJUwrWEWjVqwqJGjU9DT+UOH+weifwYLBT2CYM96Pe+vHeo6SePvUrZOQqvo5nczn4ODXn51uzJyYOdDtVu5BxmoTh1ZKesaJYp7ss4ubOYuTrh4oIndyRn3Lz0aZK5CPWhKQz3DlBNdPKfN3yPg0f58cms+PRtuJwqm3oIoFwaqZ7ZUa3cXRSYsrVvmAeefIaG8WNw+STM4S6Ezk38ZOGpXHbigTvGeuQf1cFdMcm3uE6N3mWZJTngVJZ/WeMWEeWlAM0O+zU26GjwOBFyOaSShCr42bR7kILimfF57TjEkZeUBFmK4NYtHBUDuyhgWhqGaKJD6Iv0SZBdmi6IQUQQDA9iVcGoZmlp8iFhZMNSaNmgXlz4P3EfNXvqrmlW3ddMkOXjDwHh3JmHMiXSRDaZpiqpSHWNbM2UuG7J/bywJ3VRSvScnsMx28TxMbEXbgzfCFAfCt0+8nLXBh16eVvEYumZkz0r/v60w2hWM1QzewjVBdkzNMy9T67kqfVdJOBD1oSI7FxqWg7nPgtdLluaKHD0t46dwoxRfgqFOBWHyqu797IlVWBQZ+FQ3tgnTpLbdi9oFJUb68Xg7UGiS2zUREWNmrCoUeMzUZGTzdG6uzbsXL/n/eRQCZN5XcgXLXn8JXR/Mw5/lPxgP1OjPn54/sk0S1wDYFTKY0OBlquGhuMLAoH65ZbNLgN0Zit3uFp963756s659z3zKt7W6VR0D327+plSH+Xyc06kXjaI2bT7GuCWT9x9Zzrv8KmNN1YFQUsxtMDuaLyxl8q1GdV23C+efjX0k2WPoClODK1Mum8Ph4xr5t+u/D5NAhu8ZV5skD/cbkwMLA7j/h95KRgW3ljAjUeWUEwJrSqwZVc3BVP6QoIgQW5eBHGpYppZ1TCRTZAsE8EysQSw4AuV9xZQdN0iNBAHLAVZkFElE4dqAdWRcZD/eIvFn8KEsPrTBd84ldMPORghm0SVTdwhL8OiwL8te5DfvPo2XZZ63oApLeqmui/RVSKe/ljUSsThWNrud3xXLlSTqk7PzNFRLjjxEGaMjpAZ6ka025AD9fzXo8+yfUg/fAgWdPf37WszKov7XF/hhrpbAELwq7kHTuLQie0UhwcpSRK/f2sdG1OFqXFRnA9QSmTnjZ80+oi+7qGbaitFjZqwqFHjCyKrto5SvjRp6tgDRgH05fNXd2nc+tNHXqQrb6dvuEAm1UujLcG3T51Mo4NHosJIKKjfNRJGGA1ElgjY9QTaBRv03Pac13b4r9d2nPfrl9+ht6KSw0FFN2h0O7j48FmcOb5pQ6Oce2AUysWf1q8GX+vlu/Nd96cFaWwC20nbYOVrQ9Ub/u2Rl8Y9uX4PZriRRLqAkBnmO6cez9nHzmZsRCn6VZ5q9/Ld/80xNAzT29RYhyyBJFpUq2W2vrsN3TT+qHZMAYcp/On9kEQxiwl793aBIIAkIkgiDocDEauUKX92UbUvkzaJSw9uVpb8w6n78e0jpxHK9aElu9Akg5TDzn+/+hY3/ur37CgJ47pK+o86qpW7e9PZa8MR/1KA3kzm2o+2We9Wb9eLeqjJwZKZ4xo5++iDGRd2oOgl0gUN01PH469sYqjKgub6hmsSPdtW5ordNxX0j5+JsEHHrOb65KkTWhmtVBAlgbc6OvmPx5fTrQizOirG3Xn5PQucas++f12+VDtfUaMmLGrU+OybUrLtVWzuNQDdyeGbNLc79vhbG+pe3tiJJ9iKUS3T4DH45rGTmRxjw1gXZ/3h9emh4gKAtFk9qYhjag/KuJV96Rn/9fTLpEUXijsImoGzWuCfvnMWh7e6NwSrhUdH478wZ31yaW2A3cnu+1FcaEo0NoDv9Od60nNue2wlv127BTHWTDKXZXRLPWcddSgn7jeeA73ykx6D1Q7Y+r89horMYCzkR68UUCQL09IZzmaomhYD8Lkv8zCeZTBimbAEsISPWiLQvkg/IqK81DDw7tnTCaKAKAtgGjjsKjGci9EM7//WmCR0bZ5VLMvebHnDOQeNHlh42tHUKRrFQhpnJIqjZQwvbuvmqtvuoaMkgGpDc3tiPcXq9QCNPt+NiUp6XqESn18qxfdZMTx2+ZVCrjyjTWHJgS0RLjrxaBpVAbcpEAk38NxbG3mzqzBjABaZbtc6Xau0CfqIu+4PsUxLccG6mQ0h5h19OLJpYjlcbBpMcM/vn6Jgk2bkHeqs3anC/Q0x7z7rl9tRc4XUqAmLGjU+k3zF8KrukXoWVbu/6fnOxGW/fGktli2AVS4TNFMc1ubg+Gn1e/d3cMBHr/dHnSNmZktBR2FdV4FbH3yavK8OyxtCK2RQhnu44aKvc1CYgXrTvK1Rdd0I4BE+ubR2MjGwaHSo+ULN9MQGdPnwFe8m+ddHVvF2QcRoaGNXfy9aeZgj9mvn3IMn02iUt/rhqQkSx4fhf33htyHudaoiermIIBqYgomoqlTNL37wcp/V4r0/74sLwfrj+lLVaOrq60eQFURRxDSqqOJIY4olFv+3xiQsK8tGOe0X7++3H+AvJp+aO7nxybt++B2agy569uwikS7jahhN1hHmh3f+N//1+rZLei3hkrwizerTilcDhG3+ZS5bZGlFt/a5gupVbt/PYz9QKKS0JswlR7ZFkj848xuMtzvoWr8Z0+3hrsef5P53tt6Z97cEA74x54vVke9d0hLzhvTUghHrjpUVy9XSRLf9shOnjtPagxGcNh+CJ8iL7+7g9+9umZW3qTOHxcrpHz23UaNGTVjUqPEZeAMN+3ZjCVm44M5HVtBVEhEllVJfF4e3hzjxgFY8ZmY1wJ7Od5/9pHaKkjBlza4ky1dvoidjgMNLYrCLqFTgB988iekRtLCpL9Oy8din9SWdGdmZhsJ1d+3NVu5JGercX63YxNInVxMXnOiqiqAK1IedHDq6gbNmTaIVrpxis0+OweI/1xjGYLFgGfjdDgQsBAEE2YaGhMEXT+1tCiKWIP7JFguAvA6pXBFJkpCxUEUB9X3Liijl/rfHJj6w955RwdDFAczHC0MD/Otl3+HrRx1Fg9OFWDGpGDLO+jbufOhxrlvyIIOIc1Gc9JST+3KA+D0fLgY3nB1c2OYKXurW9TU+ixUzx7j2/t3JR1HnNhGdIh1aiZ88v5pn+9MX7dR52O4dyaLpUMLLVNksAjQi3uhDWFEHd0VhyZETJlEeGMSoijhCTfznY0/zSl/3VNUf7EmUcxfUVooaNWFRo8YfyWtFrGe2p9mSVXDUjSPokDmgzsnFx05nbmvDZXbMnVu7tr48qnXC8cls/EMH7Prg6he27m1/ePVa1nfEqRs9kUy8l3ERlYXHz+CUdseTB6uo5dTesfWh2O2D+fQnRib4fZGlAD0G129PWwvuffItnnpnF33DJew+J/X1PjzVQc6YMZrbvnV6dpRReaAebs9nEvOyw0ML/pzjJ1sW40aPRhZAkhUyJQ1DlL+wsIjDfAswBDCED5SF+EdYLPrhipwORdMaERamhV+1YYMigOKOLvmf+O6JSvpTd/SRuvbvAlS04bZRIc+K8bDuW4dM59xp+xGrFqFQIJUvUj9lBnt1kX9/eDmvDgzebNlDHzuwWqgMLSgX+6+wSyNWrYjNtrRSLLV7JFZPHy0lL19wGr6QQcktkwi3cfNTb7PsreEz3xqgsE9IYzor+ogLLmZXFg8lKgtcsO6wljomOmxEVQfJVJmUGOaBVW+zvVCclLe0WfssQsV4rT5IjZqwqFHj89is62s1Jzz99ibcsVZ83gBWPs2ieV+nRWFrHdzVqARunNQy6YhEOTUv5I3sS5I0SHVhr2Vc++sXX2V9Ty82vwdRLxGmyPdOOZITJzWvCVJ4NGsk5o2rG3vGANlFpu3DIYZDleyChFGYB9AJd7y4K/7j//j9Czzy+jtoThft+43FSHXiTHfyzVmT+c5BU3qc6eSG0YrtQgC3L7zMG4guyWf+fAfrVFFidGsLsiQgygrpbAVTAg1iCb3yhfpliGC8Z7Ew31swhJG/S1/k+io05QFNVJEFGdk08asqqvlHFDH7Ewjb/J/qfspUEvP6y31XS1hZj2itdla1DeNtPHnWAQ0D3z/5GKa3xjCLaTKZYTTVybruFCt3DDIAi7bprOyulG6CkfodulaaaFp6yOGKLQ6F6+7q7ovf5FfVp4SqoQUEbfmRbaE17UGFgF3G4a+juzPHPSvWsi6Lc4/FvSOLcHSJKAj7aq9Ew7YlEVg63sN9F51wBEpuGI/ioqpE2JUUeOK1zRRVj3fQyi7MFLtuVZ2RWn2QGn9RyLUhqPGXRhfWrT0aM17eneTd/j4MNUI+l+SwUfVMi0k/FZNWCSBulucPZ9Kne2ThFewjKY87h7N3CnVN2k+ffN7ZbRnIETdWJU25v5Nbv/st9vcqxQiVpRFcSzNCYcHIwq6WNMmKDWZLC2Nex+I4lfnDlnmaaTidW/LWAys37OG3r7xNQnEhtLZgKFW6t67m6P1a+O4px3CQ03tzM1yD/+ORnG7fn+9gnWySDHu9oczwbjIo1DWOYvueDBPH+8bqCJ8bdqpjBiuaTrZUQAqEkQQTy7JQROlzw00TmaEFls+jpXGctDM+TNWmYrMs8oNDHH/ybLwyL/65xsVnCy/zfUiBffDP0OTIHWNHnXzZ8jfWsfKtTXR19BNtHs8zW+IMl3c7zzly9JwxiiPYDNd4bJGlFWFgkU39IHlVc0Pkmg9ak+ileO0lxx016+r/fJiNO98hPPEwjKrJdY+/ROexky86ZkL4ogYp94rfEJ9qkD7cT1cpue7U6S09Q/qRP77n+XcQnSFEt5cX1m2nPDDIv11w8th0oXuW7IzPdxFZujObeHisN3xWfzZ/Rb3XfXttJalRs1jUqAF0o930bkW4cndV5heP/R67TSAoZJk9JsiFJx2GZJJtCQWuAshn07O8fs+qek/s9p3DqYcNj9dbDjcpT2/udb65dwitbCAMJ2lRdC4/60RmRO076kXttii2Jfny0AKfGF0yZAwtENC1RtF+Y8zrWNxXLV9dxDbFsPu9OyrSnJ8//wbLXt5Av6YiyA5cgBjvZsHxs7ny7JOY5FRWKHp68C9015AMen1IgoXd7qRiyuzqHADAksXP3VSY4DQEEVMA8yORIeJ7roxPtRj4okuqltVUgfaUbmDY7Giahtdup97nxQ47/hLHrBUub3ewbs5+7Zxz1EwmNUTp39OFJ9DA8lfX80+Lf0+3xdR1VSOxp5S79w9FxSdafCoZb4vdtubc2Ydw1KQxFLt2kssn0X1u7vzd06yJVxhSPIcX7dEpm1Pda//w2qjHLBWH9k49fEwjR4xvw2NYDPWnyRpeOktuntnVfxmRCcm4Ls3YWxi4Z6w3fNauVOrBmqioUbNY1KjxnvWhKkpNGZS5j27sZfmrb2NKTnxUOGyUjwtPmMZ4Oz9uhBvfv6bdX/fdIfILug39ppIrOKnD4Mz/ePJ1Xt/ZiYVFu+JgxrgxHHfoAUys864JwUOSZmZRwW0f8e1HpZG/46n+KyLB+ttT1cqZvbow4+5Hn+bd4QqJqoJpdyMWKvjzGU47dBpHTzuBphCvmFbBWS6nxwoOn/aXOKY2QeiIhfzjdF1DcssUcmXWb9lOZe74dtPCyefmpxCxMDEF+NDvmtZnWiwqqcQ8WzC8rKwbY4sKyt54grIgIhSLeCWJ5miEL1pl9c9BAGP5OL99Yt3EUc7R0QZ2ZST+e/mzhGNhUtUKl/77rzl0bGvoG7NmXJQXmFVn5y5RM4thRfyYdUo3xGAA2/LjD5zU1tpSrRu3aS/PbdxOseTAF23htgd+z6Yp4zn1oHHnTY81v7Kz3PdwWJVWVdOpM6MB76rWkOcRu2buvOTEA6+s25Dl3qdfA0+Etwcy9P9mLdtn73fyt44YvSMk89BQJb9gTDB4fm01qVETFjX+5sgX4/MNQ4v5PB9Ef1iiXekqaTc8924ny557B3u4gVLXZqaN9nH5GcftcFaTG22Gcy+S60NtVZEaS5I8afX24Un/+eSLpO1OpGgMEoP8w2lncFiT/QGvk1VUDSKqtBSX80PX9/R33N1U33ZpJFh/+5v9vdWiP6L827JHGbBspHQZU5QoDw1x7AFTueHc/ZNygaTftJ5qRbgcwcWAKiz6U2pd/G+givQEvRKGXh4pGyap9CX60EDRTCOG9PmPvymIGIKIIIiYlohgjYSbflZUiC044v4xLcuhA7t7+kG1gwmCbhD2i3v/ku9P1Sr1xGRxcdBti7W5bUyCCyK+07j2P36GGoqRNgRe786wc+8zBI3ipOu+f849QUlcnrdKs9pUx6V/2JbX6V1lYHldpr7uoJhaagyMP3Py6Cj//eSLbOovEaxr4pm3d/LOlk0sOufIw2e2BbMixZIuQUxovLGY23Nviz98sVaoxL5+kPcCT/AEFv/+VcoOL0p0LPc9+zZaXh/3vZPGz/VbPJXIDy40TDsxr29xbaWp8eei5gqp8b+O2xlZWjC1fSGeW/Kl1/vg6s2JEvc98RKKpxG9DAFJ4KSDDsCppTaGhfJOiqlJ+fyHIy3imnTRU9uSp/927Ta2xnO4I3VUSymO2n8cx7Xbrxzt4kJ3sqpFVOkTD7g11bddCjAAi/oEv/KjJb9kY0GjI1dCH84wytC55uQ5XHHc/jjzbJzqYnyrR7h8nyAaLDv+UsdZxko5VbCrIqalozqdiKoN/Y948i0+khzLEhExEUD/vGslScpawGAyjeJwIdttVKtV7DZ2/iXfnxHBvdRR1raOhgsdsDWG9cDMqMWN3z6doJ4mFo6QNp1sK0is7Ejy09+/ypu9qdPLqmNsh8XdQ/nCvns0jGOZpOtZe7Wy04O+Okpu1dHt/nWXf+1oxnllMoN9WD4fnSjc+NByVg1mvP2ELjB87fKe4uC9Af+oiyvZgUWjXbYL6/Ty8uPHw8FjfWjpPoqmDU/LdB58YTMvbivNEu3uYtgdW6xbZqi2ytSoWSxq/O3deC7XNhgJaTSdDsfbe3PtT7y1iXjZwsrmcAomU5tiHDCqGbGaKsk2tUdRPnBh9JezVxRs3hkbe0tN969cw+aBNI2jWunfuxWfUuHrh09HHyak6dVrHY3qjZ/Wj36DK3Yn9Nu2pfP86vU36NBtFE0TM5/nkFGj+O4px3FAhCVOnQ2WllfA/aHr698r0/2XiICuWZZCIOglni+CzY5dVTEsvlCWK+sP1gdLeE9l7Gv78/NYSJKS1YFSpQougaquUdRKXzii5M8qLuy+pQCKlh5sUPy3KA5t0DY2tnD0DxY4f7zkceI5A2cgRqRpFk9u2cRguUiOw+aOjzrnjvO4bvjDtsKysiwsK8sAqnqpyZJ0ef96d3DhOce333TfbymaGqbsZDBu8eAL71A4bBoHN8UOn+KMrQKweUfOcYyz288YTCetb5+8H2VN592hBD19SSKhen62/AXaG0+4rUtL3jYzFBNqK0yNmsWixt8MCcrz9pZ776lKYmO/mb9Cg1iqyNSX397KS5v34A7E8OWTtOlJzj/mYFqc6hJd9ASzhjfktscWJ4zcvB4zc71h93pf31067+5HV/NOoogYCmDl+wjkurn+/DMY62KgOcY1wz59sCPde/eIdWPPvQU+KHm+F+7ZVuW2xzoS3PXqRt7QFLLOMFFL5usTxvG9uYcyOchyp17eEJNZrIoF7a9qsE0NLGhqagBTRzN0BEkkX6pQMSptX6iJkYJjI66U9xYMEWGk8unnXWuazlJBQ5VUqhWdYrWC2+/5yx+2oQ8sDhHFvzTB4EI72k5PpbS6XWbHD886jtOmtZKO76Q/H0cdN5mX+yvc9tCLvLhzmC0GP96O8USPnro+VRz8UH4Uu2TfKRiaLlSS2uGtvq1X/91puIcHkVI5ps86kfVv9bH0t2vZ3K2ThpM7C/k73r+2J99//QS//6LJMisuPrId1/A7NIV1TCfsKVX5118/Q58cpheura00NWrCosZXkuon5HAIY1/Wbm/8rlERvZrortuRrdx83zMreXbDJiy3H4/bwfiAzIITZnHIqPADRqXkCTlcD2mmGus1uDZh2C/IiL65v966+8e3LHuMd1MVfC1tSLKJEd/LT364kAOjrnUNErd0m5WbckppttPv39ht9NykKMqggJwC2FLIvr4pqS24/8WN/OqNtewpVRE8fqqlIlNjYf7+jDkc2uj6blA0HhGraQUgaIv9dfmtzTKKAC2NTdjtDlRVwuZyki5VKVT53PLpAuiiJSAwUtkU3k/tLWLC57qAqprZmC9o2BweBElEUk1aWutRYPAvelGMupZ8eJG0FKNa8kxw+Y+fKjP+yHrHDRceNZ2LTz0Cj1TBQEP1B8grTu757dP89HfPsC6XPjkju+YWFfuHsrpGbd4lLWr0Ko8srFYp9RzWHhr44UXnMSrgYvNba2maNI2hnMTdDzzO1gFjhuhylwASpeF5Te766/RyJughs3pmxP3IDy48noCYRLDKREeNYeNQnlsfepyOEjf0VPTr//Bz88XBhZVqrVhZjZqwqPFXjmKrtKP1X1HJ9X5sB1UdVpqKMGXZS6+zqr+PcmOEiqKjFwY5clKMBQe3CmIyWRpjc5wfhmVOWdo4mNIWllVl7C82dM/66XPvkAnFcDbVkRnYQ53D5Ad/dw5jPdKT+8nKgcXhXTMlIZeVZDObrxRmNktN1/hpvqZouIp74N5hp3fWD372Xzz17kaGKeP3q5T2bOaQeg8XnTybgGA8KUIxLEjLIs7PDin8ix1/Sxv0Cazwqi6MSpViKYkhm+weyFERfXWfd70EWckQkDUdFQFFVKjqOroofqHsnWVTHjswkEfTJCzLQjcytLWHv5C14y+JIHV31asf1JBpgusmu7jt61Pa+c6caUTLA/jJoDpN7LEoqzb2sPiR19mUlmYNyb4FO6qlxwbN0kKA/vzQFZ3xjrtHKbGLhXRGc1jWtmltKueccgjTxoTJDXWhCQKWP8pvXllLN/xop8nD2EeGu94evF3IFzUXpXUTY3bOP+FQ9FQf6VQSR2MTu6plHn77TeI2+aKeHPvEhdsZW2yzwMp118qt16gJixp/naQzgwsFu9qDApqif6zolTvqWvNKx/DcJzduIKUIlAWdSv8Ah44ZxTmnHPpKTy51fXsotK/UuKYTs0WUjifWD7Q/smYzfYKTsqoynB6kziXznZOPZWZrK/ZiaedQoef6UYEx55vlklcyrOwoW/Ti/mrxiq5C5daE5rrgha19F53/w3/DaGghZeoosklu71a+vt8ozps+iTa3tDWg8vifo3jYl4kqiVkJsgGHG61QQrXJZIpZdnT0kdcgYX52ISsBNNkaSeH9/kJhImIIAiY4P+vaOIX5piU548ksgiDjsNlx2AQa6wKfmwPjr4EWuGq0Yj1w1oTmHT8862TabTrDPdsYTg/hDDXw7lCRH929lN+s2VyXUB2np0XbSX1W5ep6d/T21kjbpQPxnuuDqv3RgCAs98Oaw8eFOf/YWdTbNFSq6Ahs6onz3IYBNJFYRZDaP5hXe08D7lvaVfcNs9obmNkSw29VKWbzWHYfK9ZvYstQtklX+PAhTlt4WS5XmFFbnWrUhEWNv0r8vthiiCzNVQXdUOz7ogCGMtqCrgq3bipw20+efRyjzo+oivhNk8Pq2zhlvwPwwipDNb2D2eQ+/3Sjgxvf7kzNevCF58kodjyxeoqZJO0uiR+fezqzvE6iGg/YKkpH1DVS4Mlm2jqa1eg1APWq8/Zhw3baL154Z+4/P/gU1daJJGQ7itNFvWpx2vgW/vGw6ZzRWndlnSrfFRWlJX/tcxC0RZYKoPkcMm6nDdUmI8oSm3a8iw5oBrEv2pZl/XElTU0TB7JEd08fpm4gWBamViUaDPxVHN78IoxGuHAqjD/Erz5y47zTmDuxEVc1BVaJoiiQdnn45atrebUzTRrx5EKVGf355BUAdZGm6yJO/1K5XE4qw/nBdpElB3gl/v70o2hx6EhGgYxh8eDKl3nwtQ2Hp+AbAB2Z+N1hR2BZHObboEOKJ7j2/ONoLA0jJ7Pkh3KUcfLqtu1gh90p7k+UmTeUKy8A0Oz+p2qrU42asKjxV02hKuKTRs4mDJSyi0puZeL2Elfe8Itl9JQrJLIFHKYOA3384JsnMq1eXlWqlCa12sKXV4qVdoDesn7tQ9s7rJ8sX063UcVUVdLxfuoUgx+efxqzo/KGUZJ122iffGFdyLPPbRFxjUSQDBosfHZv1vr3x14Y99sN21DbRzNU1qhmC4QNizmtbSw6+UTtkJBTqLcLt0dFYUlC174S/mjB0HXFAo9NoZjPoVkmvfE4gg0kic+tLGoKILxXgMyyLHiv3PnnnbGwBFGRFZL98SSWJWBUyhjFAm5V+aMqo/45GMJaEIfPLOzVHe+4+/1/O3P5jSGjsua6b52x4+tHHYibMqJZRfUGyct+ljz6PG/36iQN25miOzSSjj414pII2+3LxgXcZ9iKhb3jfLbLZrSGuGLeafjMAvligcGiyRNvbuHN7uTUt4vF/jZf5NKtiaGXi4X8lAgsPbwhLDQ7uO2a75xLq1NkbGMjeU1g7e4+VvflL0lI2gWWHSXqsS/pTqVvCgX/Ot16NWrCokaNfdS5o3cB7C0N3ZN32GYOSFz2m7fXs7Y/hSAHaHBHqezq4JKvnUS7jw1BlUfG2hxnAbTUNVzVn6le8U5/7oZ/+fXv2aRJuMdPIr1nG1EzzzXnn8oUJ9lYyVjcYhOuev8zs5WRSpEAnQZ3PLc7+9PbnnuVh3btZSgaoiOfZFRDBP/gEFcedRyXHz1zeZMu/PgP+/1+eOBfOw5J3hpygpbLgmChWSZFw0QXQRA/+wVvgPf9oqaGZY1k4GREaHyeODAsyWsKOPIlDUlUsDQD1TKwixYS5P6SxyyKsCQCn1nYqznSti8RlmQVs5MdtkPK6fi4i4+ZNfCdrx1LvUPAGM4ji166Mgr//uAqtgxDn86PevPatZFg8zXmexEj6VzXrYqUK+XzfTObVfFH02Jy9tIzj8ctCwhOPwNagBuXPM5AxVm3Ybi0PewPL2t1ufflUmkRuWpslEfmf+Modm9Yjc0eoDtnsOyVV0l7FTrL2p1xmK9hxmorUo2asKjxlaC/nL7C5ojuHcZ2+vItO3hzcJjY+KmgKShZjXNnH8HXp459Ra3me6jkiOeH5wP05bSrh2R1wT/d9xCZQBNyQysDA4O0xvxc8fXjOTSmvFIvVW8TUgMxgMHknnsBCpoeAljdm7d++0bPZT9f9Q5rk2V8EydQECpQTaBkOlh2w3c4elRgwziJMxq83PKVHPyqhkeCSjaF3+1CsalYNgepIl8ossMaURL7LBbCyPmKzy1CZoqyI6cxrqKPRJNYWhWfTYVKmSgs+aoMb7GamFfnjd7VVx2+erQ/dEE1l6g7sDHEP3/nfCaHg6iFEh5viKQmc/2Sx3n4tYGmuKjM7yuUrxadscXp4Z0Po1iyahO0Me6G85PDnee2CFx1WItr69wDJzGprYWiJkNgDFff8QDbhq1xQ2XhQ0niunLJWwWros0YHebs4+dgFauUDTtvdvWzckcXOVHy5i1z1qhg8OLaalSjJixqfCUoV81xZRj7XGeP86E1GxmSnCjeGOV4jvFuP+ceNgtnpbBxvMd9itNWLkXcgaX9ReOKlFs5c/HL68dtFtyk3TEU2Y27WOT/nHESR0WdA16rvKrRpt4YaWy8MdG968FYaNTFg6QWVpWoYyc8/Ju1/fznS++yteqm4mtAEaBJqXDujBZunHcM3mIqGVZLD7zfz3gxNf+rNO6Z7NACq6IpQsliUnsLWBqmKCE6PQxl9M+N7DDBIYiAYGIJJtZ7hcgsy/pcYWFYojeRgaIuYCKgCAL1QT8OS/9K3dtONbysRx++XlFdg+lM6qTRntBF9ZXimokyAz884yjOOHAyfsmgKlokHW7+c+Vr3Pns2+1v58yb++Bqf2DsWX576+U+Yot3ZLsei/jDS7VqISaXK8mvHTQWfe8mQg4HuuBhU1rl+t+8yLphc0Yn7Mtv0eIJXaXqid6woK/6+pyZ+AwRt+wkZ/Ny33Mv0ZkrUMSY0ldOXF1bjWrUhEWNrwSazRPboXHRr55/nc6szkDvEL1dexkTDTD/tBMZG7D9uM3muhTAI0eWdpcrN/Up0o9W7C3MeKmjl9jYCYimQWH7Fm7+9nkcFXM+Ml1V6u1aruP9zwg3jzm/n9wVOfyzh2220//ziW1nPrFhB1VfDNXvp5JP4a2kOPugCfzD0UdwiNvz41ancFm97NgXRhhxBpd+lcbd540uafQ4b/TZBU497mjQNGRZRnK4SBernysO9lkthA8f3rQs63OtHRWDtmReo4KEJMq47Q7aIhFCDsdX7v5ukgPXRVCXjvGFz48gLJ3s8h4yXaF+fz83Lzyubc0Rk+ug2IvdK+NsaWDFzk5ufPgpHt/Zc/Pblt6/sZDasqeSvjfobXxENOVSo+q6cZLddsT4gPzK9888Hr9VJDHUS2zCBFI2D7f86jH+68VNl+2weGxPdvDe3sLOh12KkNQyydh4G8tv/P7J1NkUWltGk8hV+L8/+wV9RXOWYfd5a6tRjZqwqPFXSyU7koynVy9em7Upc/77qZfIVB2YFZnmaBDiHSw4Zy4tMdANMwgwlOy5fsAoL+q023705EAxdNuTzzEsqpT6u4hl+viXbxzDdFkjgLUcIKxGPiQEBvBcttkUz3uxl/ZH127GCvgR5CKVga0cFIMr5s7i9NF1tFG80mPmNJtm/E3MRcjFKrdk4rIrVHQNU7LRnxj+3HwSFiiCAJIkYZomuq6P/BvrQ+m+PwlBRh/MFMBmxxJEHIpMQ8iHQzAH/laegWa4xg9PHTvZx9z9/ajF3cRTe9EaInS6A9z4u5d55J2hupI9OCld9J5kWJI3KtmWAOwe6rjfS3nVlCb/wGmHTWLaaD+lUi85CiRdLh54azO/3tB1+oAtfFFBCSoW7p56Z/A2R5GtbSYDcyc0YSbjqIqPtObiwRVr2VrUf7QNbWWvWa5l5qzxP0qtVkiN/xFs3vCyhJGbl5Hdx63c0e19bu1mAu0HYC93Y3Xs5ubvzmNmnZq1ChlZdfl64jBfDDXtfDerP3DX6rd4J5Eli4CYiXPSpNF87aD9OCzmusFOaWeYkYOVXaX0rbJgTzbY7be8M2R1PxFPND27bTtD8QKW14FpJAmJMuefOI2DR0fY36Hc59CTW4O6kFINBcEWXva3MBd2gZ0Rj2MOegURG6Yg09k3RIHGz8xpYFko5nuGCkEQEASw3j9v8TnWDgvkjv4kZUNEEhWMSpGD9zsAl2yt+1t6DhrhxiMaQnL7WXN/vHJPNys27OHNrm5MxUM03Mq9T65mx+YWpjfF6o45qP2nJSeTXIK+bnS07cK9uf57/C7lqVNnNp3Z0tbkXbVrJ0+veYNM1sQWDHHPs6vZk5jMSdPHnt7uVOYcaFd8KCOCJjmhzlr+5itEVD+CamfF27vpyQ1z8VnHzxnvsI010R3NyNfUVqoaNWFR46+KXlO+dnulNO7Ohx8HT4hkRxcHxsJc883jaLZp6+zF+I4xrsj5b2TSluTzZ59+dYv3wVVvUm2dzFDexGWWOXJSAz84ZebAdKgfzvVeG/A0LgPoM0pXGw6/N2cw+5WNqZsfWPkqL+QKRCePI1noxq3l+PtzT+XQ9nq8RibZLHFNFHEJcuRv7s6XBZKxoIJZriDYHIiyna6BIYo6Uz5rHCwBeZ8H5L0w05HQU/Fzo0LKMLZrMEHRMLFbYGgV2oIqQiWjY7P9TT0HSjWRbVTE2742Kjbz0FHth28twj2/eY7Nu/ZQX9fGCzt7GNIkfv3qGv5h3mmXTGtwDsTLQ/Mn+eqPGNAKi/Lp4qzDYoGeCbGxc2e0OPnlUyvZ2LOHQOt0frUpziNrt/Ov3zvbm8hUrakR9cpivHdqk92xavHl8+ZcftvDZJQIXXmDStHJ3/3bf3Hb989qOioamWuvFnZGVNdSLZ6ar0S+Wm7AGn9eaq6QGv8jDMCiuOIYd+eDvwNvCI/Hg9/S+LvjZnOgn4vkoe7kGGfk/ATVeaLHX1y1Y9D7xM5OOgUbZU0kKNkJVvJ896SjmA71O/a+VQh4Gm8E6C5nbspLjlkZOO7Rtbtn3fTo46xN5xGDYXp6+mgIeTh19jSObK+nkfzyQH5oVRTbknS672/y8JoskPRIaGhlBNMCUSVbKKNZn58gy8LCeC8aRBCEkbMWI+Gmn3oKc8hiQUljXDybRxNUDNPCJokIAFr5b2783SaIw8mZgUpq3X6YF02Rq1w6dzZzJo1Cy6UYfcABrBvsZ6dmcveTK3ly0666nCN8eGe1dIdYrZamBAOTQ3r+oWaqt53Y3LjiH844if3qIpRLBSrFMvYx07h6yXK6VJVtucJtvlhkRdCnPtIg88iVF55FOZWkrmU0Sd1BxVXH8re28m4+NyMvKrMAClWtqbZi1agJixp/0fTDFe/kzDuf3tTJpp4UkmzDzA1z8elHc3CbY0M5lR47oXXU8QCDaeuSDXszzl888yIb8gWUWBi9t5cJlsb3j51NzCqs66z23zGu/SDXUCm5YF3n3oRu94V2DBdO//Evftf+36+8Srwugt4Yps7rJFTIsL/LybzDDyJgltc4K8UNo3xjzwLw+xs+MaRUqw4sMvLx+V/dh9woiVCyyxKiBaYpICh2qgZ18arxmd/bsqyPHdyEzy6bXqoaExFgaDiDYnciSRKqrIAJHpv6yt/a8+Cy19/eFJx0RAC1R8kOth2uOoSTG9w//udzD+Ps2fuza8dbWE4BIRZhc6bE0lc3s2TFW/TlrMuirsASgIjsXloZirfZdWPnZLc/+YOzvk6wOERLa4jEQBclVeaGXz/GZlHhldTgA2VcY92wZmKUnssu+gaqmcXr8YAjyNo9CR59dSv9mrwgYTLP3xi7sbZq1fhSNzO1IajxZTIICzMwd1euyn/c/wjhtjHYEZjc3sSxBzThwVgtqkIJYFeFBzurtllLlz/J7lQWdXwbAYed0tYtnPu1C5izX3iJUi4NNNnrr9tVTD5oOENeozXkfTmVX3Dvb5/g3e4EJdWBK6ZAuYgwOMR155/JlIiNdrhBMc3BmC26OJfpvRZL7fH4Rw579le4QpT1kigMlxyiHpQoj7NJas9XdU4sw1CQJOojEfqTBoIqo9qc5CtQtRtNIH3qtYZlgWC+nxTrY0LjE4WabsRMVWK4UEKK2TEsAcsysAkM1CuB2/9Wnw27rf52uw30Qnx+oytyY9m0xp44peUCf12Ah19eQ7xYwV0XZW9fP30vrqHJ7aHuqEn3iJlUUdAK+tho81kAqkmPJyrN+vvTjj198VMrUC0HkjdAUtP4vw88wpmHjCcYbLgsWKhuUATH4MFjaXpps4OX9vTh9gYol3RWre9gSqSe6PSWk/7aa+LUqAmLGl9R4uXh+ZpFrGD3zxgQhLl3Ln2QhrFTKRSLRLwql551FO5Sbp3dLu603D55Pex5eme6fdnTrzCU1whFG8mlk+jZInff8j3Gi9JWR56tdW7HXUMlFiQrvvM6TYMXOnbx+7XrKYsKSiBGzGajd882JtWF+efvnMcYm7hqop2jR+7ukTpZHt+IC6XTMO8oWMIM1Sb02KDDYYhbFVPQJeSkJQvaV3VuLFOXJVnNjmpp8749uANZVqmWCiQzBUyn+qnxnwZ43xcRliiMJMsShc8VFiaiM5EE1eakiIBVqeDyOZAFUik9Pj8oR/6m/fmya+T7j5aFC2WvlIx5Ahe12g73PvLiG7ywaRPuhiZ89VO496UtyL7GBUfvF0QfyNMCVyVKlXkNDtstCYt5Z06s2xlyzb3yjt/8nmRBJy3YGNTh2W39tLZNYJZdndri4IbBfGrGd782He2hNWzsz5OTfQwbBr9ft526iPc8vdkTClBZHsO5uLaS1fgyqLlCanwplHRlUlZjTtoQTrr3d6spiXY0QaWUy3HohNHYiwZeh7IqU60c1wW3rRoot//67c30yQpywIelVfBXyiw44Sga1AIx2fqpUS15AXIms/sqMi/u7uU3r22g31QoCA60ik6+u5tT95/IlV8/kdFy9ZV9ouKjlhQjv1CVxB6vLKxSodeG2BGWQstsYt1dstp8jaQ03PLVnR0TGZLRuhimYaEIJpVCluFMGsRPt1aI1gfFwiSEfTVDEMzPjArRBCG2t28AX8iPaVWxzDzRqBcRSn/rouKjtArC5Z5C/pWZje6tl55+DN8+6SjcZoFkaoi0aufmhx7lv55/C6OhhTXxYatoilMBwgLLVFPvmdkcXXHpSXNxJAbwY1EXaWB7X5GVm3vIKwq9ucyPx7iDd7bAjguPPZgoZShVUL0RNg5kefDltxhCmtuZz99Zm40aNWFR4y+KVFH5Rt4RmPWr51c7n35lPYG6UfTH+3HKOkft345PqG6QsSeLtuDUpzYPcN8zr9Av6mhekapUxCOXufTU4zhl9KiBBuQlMWyL1YCtZ+OwsWVbgQt++dJrPP3WdoqmC0lzoBZ0HIUi3znxeK46dW6xtVJmkst+xKf1Lya5F9fD7U1wXQtcFUVc8rcyN/Wq+3YdQk5fgLKhIepFnIrJ1u1bMQTxU5MmSYKVFbFQBBuGZiELIlgG7yX6/lTKoji2J5VER0OWSyjKMOPHhr8S5dK/bHpKmev9bvtTMYmfTvLxwIVH7M+35swkIpVxBSE4oZmnN+3ghz/5Jb26SsWltPXDFTvSyce0cjHmF8Snjp7Yet+N3/0u3mIKMz1MrHEiL6/v5qUdcSyPj6pZbaqH26eExQ3nHj2DmMPA4ZSRG5p5qXOA/7P0foruoNIFt/amcrUcFzVqwqLGn5fBsrVwT5l7dZ8t9PQ7u7yPr9mC6I8wOBCn1ePg4tPmElZFIg7H0jjM35Ezm3714qsMGpAql4iEfdj0AhccP4c5oxqzzXCNC2nd7kr8/h2p1H0JlzTpxl88wKu795LKlYi5w9hSWfb3ePmX71/MKQeNoUnmx4c2NQi9w/21RfFTUGDQ6VSxqQqYVUy9TF9iiLJmjv2s6wRMLEsA64svFRWE0FA+h46OKFRRhCLRoAMVemoz8WGaHL7rMKpIViXro7oiaFRWHDdhDFddeC42I4+gGKQNi+4S3PHwU7zRXz6zG27W/b4gNid1cNcogYunNTmXLzrn6/iNCnqmgCGoPPTsi7y6tRe3qK4pFSsTyVc4cmqUUw4/AC09gCCJ2MMNvNOfYemKl4jDfDXoqc1RjZqwqPHnpSzoY+Ni8aL1qYT35yteY9jZiOHzg1FkmsvOaRPqcUviuo6Keedbg8PjbnjgfgZFnYxVwSGLVAf6+d4pJ3FUex0HKvgisFTEU6zaIk0Zb5h/f3wF5bp6UqYB5RID697kuIYo15x6FAf46KlXuK1e4PahamlBY6C+drr9M1B10AoFTNOgAnQNDFCxrLYvcq0lAMJ75ccs43OEBfTGE1QME8uyUASoC7hRYLA2C59gTZOdiylXKaezYwOSsnyUU1gy3mnjvMMPI9+xF1WSGSxU6RI9/OOSX3PPy1uVt1Pa4RlJnru7WL2/I1O+2wXrDhoV6vn+10/Bnh/EKxmkKhpLH3+GR19Zd5vTadsYdtse0FMVDp/k49BxdRhDPWiFErbwWJ7d0sdLnf2hHaXyfXGT+bVZqVETFjX+fMJCFMcOy7B4+W/pKlSRog24Q14afCp/f8ZcrIEswxoz1icy3PqrJ9gaL1LQLZyCSMTQOWfWQcxpCzHaxmW9g4VrAVImZ3ZpzPnNq2+ztrOXnmyG8ePHUq9IzGlv4soz5jA9yI+mOWlukbiqv5i5Iqo6lsQNY/5AubyoNisfxwurgnZwy+898qrMYDaHJkt1nyomsBQL9pVL/yLEYb4uQX8qS9W0ECywA36Vz/Og/E0TdniWNfnD18UkcbFbZ02TwivHTmph7n6TcVRLjJ8wke6hNCmbl6c37eGOh59hR54ZaVk9yXLalOHh7OkBgeUz29zad087loBYxuHz0Vs2eejlN3j8nR33lWGcN2jb26pSPPXgcbQoJhHFTrFsZ7Bk594nnqdbh7TISbUZqVETFjX+LGwbqqwsStLUpcufY0eqhNTeSslmoYgVfnjJ1xgb5Ob6iOu+uAq3//55Ok0vTZMOxywqRDWRS444ivMmNhYPVxCMVM4rRV3Z9Tp7NpY4/eaHVvDk2s3g9mNUyoiZYb51zGyW/MPX7hyjcFkDI2XO45nea+udvtsBejo6b6iz2++qzcwno5RA0TQsy0Cw2SiLEpXPqHAqMBIps+/QJiAIFoJlfmoeCx2CJSCjmZiCjCrJhJx2VA3Qasrio6SG4gs++rOIzNIQPNRo8cqPzjhi70Vzj6HYvZdINII/0kBckxiSvNzx6DNsLxPak9cWKAHvgAFeD6w+apyLGU1hXC4XRbefXl89//rEszzb17cgR6VdpdIzyW/xL9/5Ou5ciXKigsPTQlbw85OHltOncWacmtWiRk1Y1Phfpt/kClvUtnfp4681rX03ieKI4JDBrqc4dGIzo0XImtU5RVWa+uirG+jIC1i2KLlkBb9m8o0ZB3D6WNcDB6m4OuPJO5SAZ3BAYNH6Au3f/7d7WN+XoIKEVSxzyJjRfOf4ORw1ug4zoznrnNxVScfn5zNdtzpUQetNdtw9VEgumDZ6VHNtZj7F+lAxZIdh0uT3Y5k6qAqW20O6YvJZwsIShZGS6aKFKZiIgCQIn1rAzABvsgCaYkO02VBkiWZ/AJtuoVp6zX//EYLRyJLhvsGPZYSNqSyeJHOE02LjidNaWHTmyYz3yISoUuf10dMbZ0t3ih/d8XO2pCsMiZw8VOECHYIe2HvqrMmIw3HCvhAJ3UXa3cR19/6a17o7KaGNC6nKGrcI804/lqBHRbAgXbXx9t5hNgyU6YNaifUafzK1PBY1/ii69MytGU08LmHYpm5PmKzpGKZsNhKQbMR7NjP7sP04eXILg3qZXdXyrA1dPTz5xi7CgTEUczq2aoabFp3FoV5W+dKVFfhtlFy2SXvhsqUv7eLZd7YhNo/BLUG+p5OxkQCXHDOL8S4ecVWsdQ025RYAmz+y9P2KE25HbV4+j1abdHnBxoyjDz7w8F+s24whScguD0P5PEN274KoxJKPCwv091N5f4AJmAhYOnzcR6JBXWc8jaU4EBUZ0dRoCYfwWAb1NuX22kx8nEBD7FNDnY2huDfscq/5xljvugPHHHnJsife4Lm1W2m0ealKduyxFu597i0clPj2WScxxiZMjaGtOjjkfOrK046/5P/e/wwZKYatvp287OC+FzYQnzLE2dNnz7BsFWIxi1kHhHlpYyeKpwG13smq7T2EfWPGeVzcO0ri4nIyPt8eqoUJ16hZLGp8iSQyyXmDxeTCjurw3XHdmJ91eKb2KjL/suxXpBUXDqeb4c4Ojh07igsPPxy/olDUZbbkTR59YyOyw41QytJiq/J3xxzMKC9kM5U5Yb9tGUCP6J579+Ov8PzGHWQthVKlyHBfB21uGxcecxQT7PwqoLG8wSbsW4Azud5aBMgfiQ06GoMeJEaqlAp2F+lyFQ3rU2uGCIKACViC9aGfve8m+QSLhacvmUFXVExRArNK1OXCCVtrM/DHMzEWOXqy23GIapR6RgvcsPDEmT3fP/ZQRskWYVEAXWBbdz89FZM7HnmMXiCJNKffLF8yqcXL9QvPJmyaZHsHsTsj7Ng9zK9f3MgTe3YrecmGJZuccdz+HDmlleJAL0bVYlNXPzuzJeKWdRFAuloeW5uJGjWLRY0vF9WNbpdCeaE0axg59MZgnMW/eRarrpWOgSFaHALfOv1QTj9wHFYZMho8+tI2Vu3ZQ1bTiEpVDmxyMO+4QwnJ4DRB89h4IF6ynnn9bbZ2JejP6yi+ACFFJ2SDAydP5+gxY5gR8zw5RuL8j2ad9r1XkKzGH7GL0ClNGRNEeR7KJhR1KBqA8MmnMw0sryWAYZkgiWhGFVEUkAQRAUv7JIsFwJadu9EFCSQRvVxmxuRRqHqhp7bc/Ok0SI5bAOxCaecpk5suOXra+CkPvrDZuXp3F43hIBlTo2QJXP6zBzl0chvHTTuAaW4YFYGbFszh+bd7eG7HdlRfI5rfxz1PvssBTUnOOelgGoFvHLof7a4Iz6x5m75UmYdWvgj7N+GdNmllKBR+CGAgUV5UF/6DM0xafD5itQnJthfCtbTgNWrCosYXp6JZ7QVFmJGVHTOeXLeeB199F/yNDHX2EvLZOH72RI6eNg7Vgh27De58+AkGBQkpHELMdXDMQW1ccOyheKlgw7Z37Z5E+9o9A6zc3YESqqOnKCIaAmJ6gFmTR/HNk2dRJ0GdyQOjRS58vx+lfHy+w10zyf7J+lCweuwIiNUyyHYMJLIVDY3Pr3I6YqkYsVqYpomIUPqk3ynC1HS+SFW3I6oGsmThtYFXVFbVZuD/n7DkWBYOsqwjb9x96en7eU/U97vgp8tf56k33yQ2fiyDwznW7cmyc/dKvnnELGY0hJlVx32hmU0XHTC9idt/9QRd3UlcsQbW7c3Scc8TnHbU/hw/pZXQoXUYwiSe2bED3SZz24O/Y6C3f84/nDKXXLo4e3TYeeEf9kU3LUU0TQdGYYYpGF5ZidVSgtcY2cTUhqDG52ETlL2GIXlffbeH363eRkFpIp4Bl0Ni9uR6Zu5XhymUeScBdz71EttLIo5YG2Yux9Sgk7OmtjCW0k+rFNmYy7ff9PBKfvl2H4XwBN5NlHD4vASdJt85fiYXzZ7AARIPjKJy5R+KCoCaqPj/3UXoSVUAyTAQdQtRdpAramiW9ZnCwhJMEAVMYSRi1LD41JTeFWirlDVEUUSUBVSbiFdlb4NLvaU2A18iwjBeWBWh0vP9kw7ip1d9F6W/j7G+RuK7qhRyER54ej3x94rbTwlVrjwqVt1608Vz8atVbDYHBSXM3qKXR9fs4aUBnTJwzCFthBxVkolBPOMP5OmdaVZ2l+YUfc4pgzl94YfuJ1t0iWhrvkYzxZJlWUptUmrUhEWNL75L8kjLkkXmPL5qI0M5OwY2rPgQbSEXXz9mNkE1zLbuPn769OPsEctYYTeZfJxWj43zjj6c9nB4Xc7SZnemDW5/8ElScoi85KVvKEmd14mtMMglZ8zlrOmj142yC69Ihb6sozKs10b+y34Z6cgCSZckIxvgVN2UKzo6VugTBQWWPGKp+MNwUwFR/PRlQwDdMCxkUULAwG6Ta4mxvmR6CvHr3S51TSq76xtmarej3VZ98uCwfe9//Z9v402nmRCto5yrUrWH+aefPMTzG7ZeVDKrk1wU1o33KtkbLj+L8tBuFFFH8QSIa3bu++2z7BpIogEHTR6DHSiKXsrB0dz525W8M8hUPJ9s4LbZm69R1LpamHeNmrCo8cXoG05dHYf5b23vZWeXjs3egF2sEorKnH/asTiALT0VfvHEOt4d7sdosvA36Uh6FycfOIYjx0YGyoJz7BPrU1OvuHU5GztBckXx2ASc+b2Mtvr52ffP5pR273KxUC76JPW5NlfDpX5bbaH6srGoKqJFyW93QdVEle1UqiaGZXo/WSSY+kgUyHu5rd4TGJL08cJlg2ZlYRzm6+A1NR3L1NGqZZx2+VNzXtT40zBtqjNjluZWzHL7jOiksJIZHAwUM8tbNJZfc95JRPU+/LYiyVKBnK+Bmx5dzX0v77goIbgvsDDlCXb49gmTiQgDOK0UJhaposT9v15JZ2+e6WMmELY7kSQPGcPF7rzMjUsfoQ9+VBv9GjVhUeNPJlEuzgPI2MS5uw3ue27ju1gON+ViHvIDnHf6sTSHnKzdnuXnj7xCWgjjaqyjVBwk17uF6y//FrOmtdBXpu7Rdb3e+1/aglw3GV+4jVRPJxEzz8WHTefab5zINAeXBaqF5WGJZY02R+1Q5v8AQ2QWWKIuy4KVrAuHMEoVLAPK5SpVXWv81JeYMPLnfauFJQoYloD1kfNZumGFqtCUyYEkyEgmaFoFn9+NaeCszcCXKBAtS9Z1Mxj21z/QV+m9dlSg/eJWp+/ycQpnzGi0//hH3z6DA9t8iMUhqrpGztvMw+/0c9Oylby8o9epA8dPHcM5xxxMzFnGrKZw+d2kDYX/evBx8gU4ZvZxVJLDaIUS/vo2xGgrdz72StMbWtUaJLfPJRKvFmqJtGrUhEWNL0bY7ly208o93GtzzHlkaz/r01l0exmXI8vsA9o4pNnH7gz8dvVuMq4GCqKDytAwwUyWy046mVZhJJXzG0MJlr6+gZ2anapixyHpzBodYP7s/fj2tHFbj7NLQrWvt0kuFpSo3b6kNvL/AyKRwjwTyyFCSUEYHNXUgqCDpVtUylU0w6j7ZAuHJf+hwEAcERe6riPAh11VkkTJZGJ3Tz+qJCOLIqJlEg4HQTBqk/Al0qr4L/epwecqObm9wfZBdFSi1Hd1I9zY4tEeOPPwcUxyZiC5GzlQz24hxqqkn2d2wYtv9RMA5oyPcNrs/Qk4shSqPSTQSNs8PLnyHSaOcXLU/hPxlNIoWHTnyjzXEWdVb5ourXorQJn4fFXLBveJjGK2JjJq1IRFjU9mYGBgEUCvqZy5swSPv/EOZbuKRpbRY8KcesxMVnelueeh1xi2XBQ0Cats0ay6WXTmN5k5ZiwlA+5c/hT3P/08RiCMv7EBiRI+Ic+Fxx7EMeNjTHEwGaClofGqgD+6BCCZGlxYm4EvWSTiWlaH/64YocUO2NocDaOKFrqlo5kWpvHJvnMD0WshIlogWu8vFyKaVvlQCfS4ps23RFmualpT3+AAumBgYCCaJkG3F0mUsrVZ+HIRyrpmF207EoXqvH3z7Gi4ZUDvvslHccWkqG355eefxJH7jyLe24krVEfOcvPmziRrtw3ywNNbSJfh0HENXHD2KShSGYffiejxs3sgy/pNMGdmjP1GNZDJ9IPLRtYZ5MHX17MpVXBuZejlgq4HdcvY50bTNCFWm5kaNWFR4wMxUaouAojnh+dnlOpxO+CxTtPOkidepSTasajS0uDlhJOP4p1ckV88/yIlX4iCDg5NI1ypsvD0MxkfjVACfv7Is+xK6PQmqmDpuKUiE+tkLjnzSI5sVl9pkMw7B0vlD0yqWmp+rhifHwrWQta+TJLa0IKilZhX0kfEoh1rZ11QRBDKIBsM57IEnPYVn/jyQtJ1g5G8FaaFiISu69gVgSo07bNmKLJDRChVLaNp++4dVGQdbAJWRaMxGEG3CALkh2ui8csiZnctrnfZbw+71H35I+JGZn6d3HyNg4pTKSUGJwXDqy489VhOOGg8rkI/IbtAOZ9jTzLLY6+9wyOr1tFtwMSgl/lnn4usFVFkyOkijz3/Inu7Kpxxxnicdg27C6RwhE39w/zipbdZ058/PC+Hmiy3d2dXOn3rUN5Y0ODz1CJ/atSERY0PMGXZMVAuLbIcdsUfanpqwDRP/82Kt9jen0eTHeiKwgEzZ5HIV/jNUy+jBhrI5LKIYhmbleHM047E7YTBYfiPB57lnc4EySq4vE70eAez24JccvJBHN1gX+O3eMppVTZiagxV8gvien6+IMiax1kLJ/2ysWRBk7EUUdeDADGExW4bGNU8yFDRDfJ5Zn30uiEqCzSIGVgImIiYiKKIJCooosj7pUqHNBbolhUqYUzSLDEWz2SoYGAJJk5Zxq3aUISRqBCpVoPsfxTDlL1xIzMf05LbHa3flbR8tkmGy06cwLw5UwlbCdy2CsPVPHmXi7Xdce66/0nWD1SoD9j59tlnolQKJFNxKgI8/OQT9KfgvHPnkksPks9lCLeNZ8uQxfI3utheMi/LYJ/b4vdfVSgkZ9RmoEZNWNTYx2CptFBVhB7sdlIV4xtFU5z69lu72LWjH4+vnlTFxN3UTsUV5XcvvE2qT6eYNQi7BVSzhzO+MZWx42FPucoN9/+KrcMGFX89ZRkEI8MZB7RzyczRzJBYMhkOaRC4JeJwLI25PIujNveSiOxeGpa9tcx9/wOEhchSVYgstSxBN8uJeQAq4LGpqKKNfLFKWfx4hVMRqWiBbAkW1nsVTTEFREvANC0MLC9AVGGJgKmZFg7JrmazJW3kcKdhYpNE7DLIkARw1KxR/6PUKa67IpJvqUuMLY4XU/PHKd4z2iR+ZBsY5mvjbfzggiNo8heQPVXUxih70mU6KnaWP7eWxBD4DPj7806gIWKnKhSxfB7+Y+kvsckwfWwrjmIWl6FSMKKs2Vnl8de6KKJOGTDyi1zu6kBtBmrUhEWNfcQcjsVapRoTEUoV1d329Ks7Fry5pR/FHaWoG4h2J3XNo3n5rW30D+aRA3VU01lSfTv5ximH0drs5uVt21j8m1+hNLeSsVSQ7Vj5LCdNm8glcw7JujLxrfZ0/47aaP+ZLFKilDXesxgIVZPmWBBVtlHSRQTXJwgS5GUC6JZogKBjWlUwRsSFaYJpGftKv4kWJVMQHbpAKGcICKKKqRvYFQHBsD41mVaN/zkizuBSgAa45ci6gBCs5J9sUfJc9+0zaPIKCOUMKHYU1Ysv2MiDDz3JUDyF0wUHHLwfmlxB9rhx+ELct/QRDpo2haZIA709Q1QlPzklwmNvbGXlu4mpiapxQdTVdN3WgY1baiNfoyYsauzDKFa9CY15nQnGrd5dYk1niXjZAlmhks9iVAwKOR2XL4pezOH2q1zy3fOY0uTjtbfW8NgzK9D9AVIGBBvqcBsmZ+8/hdNbWwmUh5dP8UUm1wfra9Ut/0wIopxUHCP1HBxUqfd7sAwRU1TpyUMPXB8vpj90qt/CkpF0BNnYV05EECQkUUESpNz7vydB1jQEZ6KCUrJsSIodyTIJul3YJfNTS6zX+N9jvM19SqtqPNJAiWu+cQpHN4Y5MOwnWCqzYdWLZCoa9z/zAtcv+S2TZrZQNUuoqkggEKJcFnngwec5+vgpCI4QeDwIAR8Fl5f7nl3JoOScsYfsveFQtBbVVaMmLGp8QFPAc922rszhv37hTdYnqlTDrQzrJqVymWkHTGP7xs2UskWMqoHL7+L0M+aQyaT5+cO/47mnVxINxZAtAbGSp9K9i//7ndlceuyUvee0NQqj7YELAQr60ILaSP95cCgfFInyKOKGgE2hlC9hSjbe2NZNv86VEaf/Q2dcBAxdlEwkyUKUTCRBRBZkTEFERkzu2x2L8lJBQutPg+HwIUo2ZEGkrT6G3yHVMm/+hTBW8J3VhnjZoQ7phh+cdHDyjCmjabVXaawLYJlViogowSir1+7he5ecz3A6RTyepKLLiK4oy363h/1n7o/DpSI6JNK6Rkpx8E8/+yUbhyoXVRV/MFmJ10JOa9SExVedhMm8z/udIViwtkjmzb0JXt7Rw6DqxKyLoWlVZhw8nc6du3BYFoqpg6Vx+FEH0z2U4fFnV9HbnyXoakTKgra3m5Ziltvmnc4ESDaZ/PgPP8cl13Y0fwn4beJToxsimBUdzZTZ2tVD1rQ+lsRKQNAECUTJeK8AmfCe3LAQ4UNFyAzw7h4Ypio5MS0RBWiNhP4fe+cdZlVx/vHvnHrP7XX70otgodhQVOwVG2iwoLGiokYN0aiJGmM0sf1QYyVGjGKJLbagYhRrEBVFrPS2he27d3dvO2V+f+BMzl1AQSl7d+fzPOdhd4G758yZ8p133oKgCmGx6EaUQL+7ArgBa2rxixGJ5y4Yvzd2K9dR5JMR8gaRTFr48pvlWLKiDbuP3gMUBGq0FAjE0d7agW+W1aGiNAxit6JyyAC0Kz583a7i8Q++w2rLc30r8R0kWlkgqpv2cOISNukUWUsxrY3i8GXNOPz5dxfg85pWpAIxIBpEY6odiWHD8OU3S2Cnssh1dmDnXUfAH/Hjo48Xgjhp+PwRpFvaEVF1DCoqxoXHj8ewcj/KHbpyJDBAyNbuSaWsXDtsQL9rtPfrkaYSOiiFoxHUWp3TShUfP66SQZIyKIhEQeGAUgrHBijdUCx0ZrH78tpGtGRs+AzA49iI+T0wADiOaUASbhbdid37lMbX5jpuGVns/yh88pFjvqhNYu7ny/HFqmpYPg2ffrQAxdEiDB4+Ai05DWtXVgOhIDKpNqxd0QBVIahvbEc2I8Eb7oM5X1dBpu/g4uPGnaHCqesD6UrRysJiIehlVMO8rpngpI+ac4ff+sZ7eLMphaXEB+/AoWhuq4VPt5DuTCHdaUINxlA0YDBW1Nbg00VforW+HchpWLeqFjGPjvNPOBJX/uJA7OdTsYtp3lWebRJpubs5/aPyXMlxICkaalpakQZgka7FyGzIkACHrs9jQRRAVkAkJS+PRb2dnaLqqHv348+gBcIwbcCQVFTGQvABK2VKhcWiOwpMzX9tENm5/RR8dERlsOnq8aNw8y/Ho4+mQc44qG5ow6Ily7C2vhp7Hbor0F4LyUrDSdtoq0uDOCEUl+2CLPHDCpfhteU1eG7RMjRBOqURmPxtfdXb7He1Nq+5XbS4EBaCHkyDkzm7E/Lua4ExLy5YhMVZCc3+Iqh9h2BdRwYBrx/JxkakUin4i0vQmc4iSySkkynIpgMtk0Prku9wzJ4jcd2USRgc0hFOZeeOieok3NG2IIBMPzsnkiF1ZzSgyqdrgGMhR9fn5845tKLL5JCWQCHZ7BhEAoUE26Z5FgsbJJA0UQHdgxyVIBEFCigiXhk67FWlsiacdruruIB+bTDdOTduO4/3Ax4f7gEm7jECcnMd/BKBqutARxs+/mABBu48CLpCoWoehOLlyLRlUVffhop+g5BRDFixSny4sg4r06ioscxrtFi8iv2ecLSPsGAIYSHosaKCOmdbkidam7WOn/3pd3jrq2VosHWkHR1ZyYCVoVByKjRThiRJUHwa1EQEbcl2EItAaWnHUE3C+QeOxql7DMAIFd/sEvL8cZhXPxgAQrH4LKroq2RN5Czo7sIiEvCCwAGRFTgAcpTkCQsCyZQcAsmWQRwFdH2aLNigeSm9s6D9O2xA9nhgUcBxKFRJRlABZDsrrBXdXVwYvmv7ytIVAyWcOVB3Lj96aKTp8mMPQefSb2BkOhAI+eHRFbQlWyDrGtpzOTiqDni9AC9Qp4DoMSypacfsjxahxpSHd8qe3Zcj91i92SactoWwEPQksun/eWnX2c7UNiodVgdc3KlrmPmvOVDDFTCipQDRkVnXhFisFC1rm+HzhhGNBdFavQw+hQLJNpTKMkqtNM49aHece8Awc8+A+rjUWZWm2ca8A3RDFxk0C4GAVwWcLCRJQmq9xaJ8A4uFSUFsCYRKoJIEB4AsqXm5KUxCiiUPQGUJRJJAbSAS8MMAoNBck2jpwqEE0t0lyN198OASTJ92HnytdfB1tkFPp0HTKdhmFpKmoD3dBl8sAE/Yh1UrlsPj8QO2Akr8eP+r5Xjvm+VoA4bXpawzUrK6m2hZISwEPQjdWL/IrzPTl6VkaUQjxamfVqf6//q2xxGq3AUtHRTp5g4g2QFkc0g2NCPSfyhyko50ugVAJ1qXfoFSpDFcA26afDyOHRp8ZC9Ai6N5TkKz36/U49eKli4sTKDY65HhWGlQ20FdQxZZy+6/wQRhy5BsGTLVACrBoRSqKsMEeMGpLKX9HQA2daAoCgghKC8qgQ5UeSWySLR2YVEuaTcN0M0Ldg+j6qYzTsAwHbCrViFdsw4+WUE4qAJIwSYpWCQLpNLQdQNS1kHAE0RKCeD5Dz7D160OqNeLDkcdI1pVCAtBD4RCViwgWpsCHvzXazAjleiQAtD9cSiSAo/XgNejQqJZJHMdgEeCk+lAkS5h10QARakWTD12L4wpxwxvsn0RAHhgFntVVeQoKFCiYT8UmHCsHKqqamCT/NANAmLKVILsyJCgApK8/hhEWh9eyv5djqK8PpmD6ZhQ1PUFy6KRCCTQVIkUulu0dGGRtRrOVswWlErmHbsn9JWnj90VUw4fi4E+FZk1K5CuqYEOikyqE1YuB7m0BKlsBnBMEEVGzhPAOlPGc3PeRxMASVFTq53sdNGyvQcRbtpLKFW1Oxc4aHxnwZdY3JIDLfYCvjhyaROak4PkmCBEQtZOA14Dql+H2ZxCrrYK7e2tmP6ry7CTF3P6a7gAWmC9NQSld+qiaQsSFagrLopCkwErZ6KmpgbSzv+ret0IZzIBLMkGZKjro0MggVIC22HOnEAj6GST0pKvFy8GIRQSKEBteHUNOsgq0dKFh64kZtZ3rJ4umVbzSG/ZgMSg6HUVfuWP/SOj8cr8r/Hx2iZACcBUAEdRoRsGUu2tkBUHGZnAIR4o0VJ89N1iDJ9XAmPEwP3LJQfwiLYVFgtBj6IOmLqqPhV75Z15KB2yG7JKAJ2OBG84DM1QAWSQSjXBMCx4jQyQrYPTVIVdS2K45dILMSiMBTv5ccSKlWv/zj6zyWyc3IA2kWmvACGAGQypoMRBLm2huakdVFJQjc7rAIBSqgISHCiwiQRHIqDEAYgNy7J4VIht20EHBEtXrASVAYdYkGVAVQi8gDgGKVC8ft+Ccm/ZTclcw9l6qnnlESVBMrYyUnXWofti97IowlYHvLkOINeOVGP1+i2qJsEkMrzRBJqTJvwl/TB73ud4a+G3yHiMwcuzucdEywphIegh1NrmtHpgygdfLYccKEN7WoKmewGJoDPTgnanAzmpE16vCZ0m4TQugdK4HIfvNgTTzhiP3Yr1j6IanlvduG76gP6V53Y6DWe3o3FyTI3PIqCmaOHCxGMADgCvEUbVmiZoiraOUqIAQILIMwlg2pKGdtgwNQk2TMgyhaIoSFNnOAAUy8r9uayFZStXQvZ6YMk5OCSD0hIvUsjsBgBmbt1lorULixjWp4APaomZcW90FgCM8qFydIn07wvG74N9+3vhy6yCnl4Dr26CSDYyFkBlL5qbU4iW9UdjSkYD9eHp9xZiQZ1d0qRqp6yyca9oXSEsBAVOjZ2+ukVWj19HMeLdL5ciq4exrrkdRPNB9mhALgNJpvB7FRCzHWbDGgw0gMOG98c5R+6DUNpEHHhc7mxP9o2XXNHStvaW9bvZ9cQRFuXOCxAVqNMUQFVVEEmFRRWYQInp0BL2bxwKwyaAo0igCgGRHEiwYFMLMpF4GGnOAVKmA5NQOMQBITkYKuCBstRE/RTbzFWIFu8ZBGT6wdCI8s3Jew/HmfuOwqioB3p7Azy5TuiaDMuhIFRBJm1DC0Qhh0pgR8rw0IuvY8GadjUtY3i1g+vY5yWTQnQKYSEoOBocnL20M7P/k299jnZvFOtMgkBZH3SmUrBtB0YsDimXQ1tNDfxZCztFwzhu1K6YOHpn9AMWDPepF+Qa2yqKfYH7ASASqrxWyUipAOJCUBQwBLA0AF5NBdF1UF2DBUCRNR4e6gBeACAEIMSGTB3AoTBdRyH1tjkl5UhIOTJAFChEQq6jEzABFVIdtR1DleUkADQ6zuR6QOQ0KDCqkbzu21zN28vs+icpMqo3l/xiv7hxxtm7D5x74oAh2EXXEbWy0GgaBDlk29uhUBkWVdCatSGHi/BVTT3mLV+FlTkcVGfZPHleMFhyNwCk2kTxMiEsBAXBEpgv1smeIR+vbcGrn3+H5cks/GWVaM9kAUKBjjaQzjaUelWU6wqGF0dw1lGH4uiRQzHQkL4JWtm5RcCMyngoL5zU4xOiogcM/JSXAAHDADQFtqqiLQUQqPxoiwIKJYBDc6BODpJjQSKA6VCXQpHQYUuwNR8kVYMMgqKgH4YEKKBNkkNMWVKaAIDalloEiEJ03Ry6LnNZpqr1RgBooKmzU3Zut7SZG5bJZYfYuc7gIF/wtFxTZ0Uogzkn7F750hkH7ovhYR3+9nok5Cy8JAeYGQR0A30qBqCuOYX4wGF4ef7n+CZpoV2TS5bBedL9O70hkfumJyGiQnoY9S3JKUWR4IylqZZn097IsA+W1eK5T75Dk1EEJVCG1rQJmUog2TRUKwXS0gBZTuPgETvh8L2GY4gPVSGamaM7navK9WJR86OHEgdmBRU8HvZ6UWtnYSsyVlbVY6chRfzYghKoDgDHsUDNDOBoUIkEB9SlKySzMW1C8scgqR4QK4O9RuyCogBQDPn+rGldp0jrLRbEdkyIWmTdHlLiudvzfQhHgnhnJmTvTPjief+mLOb7CwDUOZh6wE4+pW//A45598vlmPPFYihGFNXNDVDaNNhtPniDCdR1NiI+ZBdc98jj+NMZJ8IOqacO8vpOA4DOZN1UX1Bk6hUWC0G3oTHdMhkAGlOdkxvaU2dbkhxdZ5mXyd5IclESQx5/fT4aSQTUXwqq+0GtHJBchyKnE8W5JuzsIzh5791wxK4D0M8ASoC7vE5qUUARhaN6On4JiBgGTBCYqobFq6vhAIbLYqFSAtjUhu1kQRwbCigIIfzfOSDGqsYkHG8YFApk6mCnPuXwfz+zqJKchGe9uTvu8QhLV08jQxEDnh6i4759y4I4ekgZQh31qPDYiBsysp3tcCCjpP9QrKtqga90EP728huooQo+zaXbVpvJ6UJUCIuFoLvtPI3IrAYzdzbVdLVIUWaso7gsaeGg/yxqPP7pz5aChgchSf2AZcJKdSIkZRFAO/pQG2N27YNxI3ZC/5j8hRdYpCJbB5pCiRy9u8ES1Qh7Ol4g6deUYI44oJqCpWtqQDGK2xRsIEAJQKT1YkKmFuDYoITwBFk5oGJpdSMyxAMlZ8Nn2Sj2aVAtJKEA0veiQtAzKfaS+4H1FrB+ZYlLKkPBryOaf/g/3/8M69QUAolitNpptFZl4Ev0R6azHnU5Bbc+9QLOO+qA4Jjy0ssbW+vP2D1cFBetKYSFoBthOXI0R0jFKop7TYLitxe3Hv/4nI9RpURQL9vQioMgag5O4yqo2XocOXIgDtu1P0YWeV8ygG9kaibLiPoXQAfI+pRXmur9QrRsz8ZHsMAnSweZ1IIFCVUNzUgBu7ktFg4BIEmQJAkOISDUxnpLxXrHzizQr6opiayjguZykC0TJSEgqGCuaOHex24+fWcMrvx63N6Dgv/4tLriX598BSdYgg5bRTyaQHWyEbIeR12uGf/39L8xcf89cOZeo5OrgHv7AZeIFuwZiKOQAqe2tn1aqS7fCVnCmox58Zc5nPTwux8hGatAK/HA8EeRaqyHWb0cQwMUk8bujEnjhmHnOD4Kon1uJXDtelGRT0gSDpo9fldhoykaMJDNZmESAlPWYQGxWsue5v53lEiwHNf/kyTIQHKtnbwlBYzoyNmgsgYrnYWUSyGgArIDcZTWW8VFVN9Zac00TdqjHOcePArBztXQrXVIdtTCkgCqRJChCdi+AXjlo6X4tMXuX01xcQMgIkOEsBB0B0pLA3cCQG2zc3m9pGL6C6+jStWwPJ2CNxGBnW1FkZRFid2G/fpFcdzeAxGX2leGpM45XqTTKad2Ws5unCxashcKC4pmD7EBxwIgwVJUdAIxG4TXAXFA4UAGhQJI5PsfUlhAVJZ9yRxQ0dSegiwpMFQFqZZmqA4gO8JHpzeza9gzUmqox7hBcfzuzGOwa4hCbVmLIkOGrnhgq2E0mF506MWYNec9tBOg1XaOFi0nhIWgm7C6EdOJV8KbX67CVx1ZNHgkWGEFDpJQMzUoo40Y1zeIM8YNRQUx3w9Ludke2M0ExIQkt2uysE70RlSKdT6VQLJMgBA4qo7mNGBBirnsFXCgwpE0UCKDSoBEJUhAOgNpcFMOQdOyIVOAZlKIGCp0ABq1q0QL915WVK36e0lQuitsNy7Zw2MtufiAERgpZdDXycHs7IDkD8KoGIgm6sN3q5vwn/e/giZLos8IYSHYkXzbsvpt9vXaZPryuQvX4J0vFiNJNChBHYrSCZKqRh9PBkfsUo4Ljt4XgVxqSRC5uQakb+IouTuAxEwvikRegd46+AlNez0yJMeGJEmApmFdiwWLIsrsFTZs2FSFQzRAViBJEhSsFxat1Dq6tqUVfn8QMG2kWxqx25CB0AnWyZKwWPRmBlT0O1cjZlW5pt4Upa3Pj0n4Ztx13glzjx5ciV1CHqC1AW3rqgC/B07Ah89WrEQHMOaLlqbFXY/iBEJYCLYD9WbblHik9PG1du6W7yjeWCNR/PuLRVjd1I7ionJ4rAz09nUoyjXiiomH4OS9hzb10XOPj9C8Q1Vq1xUjJsK7BJAlKxn0qlCoA4VIsBUZa+obYNrr03oTUJMQAocosCUPLFkGBYFKZBDAtIgSa+pIQVEkKJYJ1bExpF8FNIJqWRI+Fr2dUq30zmymfYTZ1rJ7fxgXDAMOPnNUxSOTdxmA/mYzKks9MEIWGkgHVnS2Yd6SujG+UGxBk+mcuiyXe7ImZ14tWlEIC8F2okgNzSBQTMga/rum9vBH572HaoWguHIgck1J6M2tGObz4tLjDse4hP++cjl700DNcyYAFJOgEBWC7we/nQ54dSiODZlQWBRYVVMD03K+r59ugxJnvbWC6KCSDEoAGQQ5oEIDqWrs7EAum4UiOYgHfAh6dShAU5yo4nhNgHJPnysHhHc6glsyvDj30EGep+669DDspHUivXIR+pfEkCUSnn33Y3y4qu1U21AD7QT7d4LsLlpQCAvBNqQ2k8wzD1ptVqwVOPqxd97FIrMTVRJFU1ML5MZ2jAol8LuTj8X+FcXvy6lkskT2iFwCgg0hDgxdgwIK2QFy1EbVulqYznphQUAtQigIFFCigBIJDlmfDZ4CqgXE1q5bB+I40EHhkYGgd31+rUbkhEOwYAOqqmpuHOTFaaWmOfe3R+yJS/YeAXvxdwgbQby5ai0eW/QVvknZQ9KyXOFoivFtZ+fbotWEsBBss0Ugvzp5tSVdN2PughHVloz6VBaw0yghaUwasxuumbQfKilW+lLpBZXe4LWpZK04sxRs2KVgmZpEoTgOQClyDkVDRwdyhMQAQAaSKiUg66uQgRIJFACBDQ2o6gSCVbUtUD06qGMhk+5ALBQAgW0CtmhgwQZUVJTdsGzdiidDpGPOCJmcceoeu6WuOf10tKxdjXDfCnzZ1IBXPv4ILURGChhhS1qw0YYQqUJYCLYFpXrsTgD4Np18ez5A30x2xJ7/egVWtVso1nwYQiz8/sR9cN7Y8m8ire1LimHf19drXAEA3mDpnaIFBV2JK8FZGqGmR5Hh8XiQdYDWrIk2UNQBUxXITXZHGppCQWGBEhk2CCgycAAjS4Gm5ixkTUPWTAGOBWJbUIG6OAxxFCLYgFXppnu9RdFFNnWCcWBWH1m6co+KUPLUww+EIWfQnm3F659+itc+/QLtQIXHUJdkWp3BouWEsBBsA6qbVt0LAJIRTK1I5fDWos+gBoKIGn7sVlSCv0w5FXsWhz7ytdUvKPeQm0oVWYgJwWZMAE467PeB2g4oUWFJKtrMHDLAYBVKnV/zQCUOQG1IkgJZlkFhggCmQoDaulZYDkAUCTKh8KgKJCAtWlbQlQaYZzuqbHSkU2Mq9di1AFAM3B8C5hy1984Yu8sQhHQJiqLgldlvoCMHtHdi/4qYdINoPSEsBNuA8li/S1bnUtPbc+n9l37zJWq/W4Q+soUxpXFM3H00iilSgRz9YGC46My4xy92i4LNQpHkprLSEhCHQpZVQNaRNm1kgME52BUUNqhlAzYgUQJqUVDiwAaCKQBZ24HlUMiyAsmx4dUIFEhNomUFXUlAnelTlAVDfGUnuH8uZ5GMAU07JxLYp39/hC0LxX4/nnr8n8gBFTU2rl7TnBO1i4SwEGxt6rOY0prOHa1rxsovP/kI/QIGrjntGNx43D4rDy1VH+lHcEkfQ7lStJRgS9BleVX/8krI1IGq6JBkDRlHQhbonzTbD8qaWTi2DRUSYMswcw4cmcAEitclgWhJEWwqQ4aMsN8HjwRoINWiZQUboxj++wGgLfu/bL8DdJxbDNx37IDydb86eH/c/ZvLgJZWrF25HA89MgPNWXqS6SHFq1vbp4sWFMJCsBWpbm6/TgmEm9987+0RQRm46oxJiDUnMRIYMAA4NwHMFK0k2GKLBUFTeSICyXIgQwGVDKxtSiINDLckRAmhUCiBTGVIVIEkKaCyAhMoaUmlYYTDgKzCsSh2320XaECqCBBJ1wQ/SEjPz/ZbAdzgBRZJHRnEKVK3XXstRu+6E6pq1uDf776+e4vdebwe9q1qSHeKeiJCWAi2BsvXZB4riQXuev/d/47pTLbj5GOPRlQhC8o90h9F6wh+DjJFMh4AiGnCsSXYRMPni1egHQCVNVXWVEggoKYNO0ehKgYcAlhAMAugI2cCkgbHoth/jxHQqCPSMgt+mtjImnMqZeURb4e9KCbjizMnTVh50dTz4cgOPpz/YbCxpfGMhOETG6hC2LCIJuj+DOzjOfO5F96nI0YMRqTvXnM6s227FxmhGZLdmRKtI/g5qAR1QR2QHQsUFBZRsbRqDToAhECKTeoAkEAcAjNnQyMybCIhB6DDyqIjm4NsEBDbQWkQ8Nh0qWhVwU+hVFe5w/nqHKanbGdEv/JitbQ4XNGwdg2WLVm8O020Ltx1wJCRorWEsBD8TJJrM7ecNGF/0pDF2baCIM3JasZqH9xHCQifCsHPExZAnVcCdMcGJMCRZLTbFCaALKg3Z5nr64PIGmzbAUBgS0AOQGtnGlBVWA6gwYFlAQq1miHLomEFP4u+Gq74vLFxrT8e+Sihhb6J9u8/IqnUHBQPxR4XrdP9EUchBUCw0nMtACR0zJQsJx2VPc8JUSHYGjhZ24jIgAoLtpmDBQLoBtoB5ECgeAyksxnkzAxUVYVDCXKmjRyAlGlC0nSAONAVGR4ZMBR8I1pV8HNob2yfDABl4fCfVdOsy1kdFQFJeX+PvkNCpeGYCKMXwkKwtSlSpBnFukfU+xBsHYuF5NTpAIpCBggcyIqKDAE66XphYVIKSVWgKBIsasGycyCyBgAwbYBSCmpZ8OoqZAAKaLNoVcHPIRAPzAKAYkW7X85mkiSVseSs1S5apnAQRyECQS8moaoza4CrK0uiQz5tbgbR/LCyQEsnhemXYDoEsqLAUSTYVhbUsQAiwwGQSecAm8JGDsGgB5IDSLBTECchgq1EpT96rWgFYbEQCASFZrUA6ipLorDtHCARUElGY2sbbCjrj0YkCkgUDpz1dUMgwQGQTZmQiQRi51CSCEMlSMVln0jOJhAIYSEQCHq7sCiKekGdNGyYILKM2oZGWJDgSAosQmHCgiPbkFQJBDIIADNrQldUKDJQXlYETYIINRUIBEJYCARiErDTfo8CSi1Q2JBVCbXr6pGlFJKswqQOLCcLojiQJADO+tql2Y7Meonh5JCIByAD4hxcIBAIYSEQ9HYUOE2q7ECS188IiqKgrq4Ouay9/miEADYcEOLAoRYoBRwA6c4MHNOCmUvDHwCo8NkSCARCWAgEAhlmUoUJD3GgOA6IoqKlvR2mbUGSAEIdSMD6/BXf57sAgJxJQakD6qTg1wAZSIrWFAgEQlgIBL0cC9lYQCHQU53w2hSmRWDLOgAH1LKhUwJNUuBIBHYuDZMCaQtIpk1QiSAeJsh2JGEA34rWFAgEQlgIBL2YOrRNJbBNHyHol4iBdqZAHAWWpKHVNpElFIQQqESCQmVAUpBTgHYboKoGSZIQ0SkSHgmylW+xyKBBFIwSCISwEAgEvQrTgUpRF9SM5MghQ0HTGRCHwJF1rM2m0SorsGUNKlR4HRmQNGQVYHVbBpZKIBMbgyIxVOheqBTrRIMKBAIhLASCXkyxGrlfc0hVSNbmjB46EDoFCJXgqDpWt6fQBsCWVahQoDsyZKKikwDf1lUjJzsgtoldKvogIUlflKoQ6ZYFAoEQFgJBbycux2Z5KFk6sBjQHAoKAlszsKo9iSQAS9JAoEJ2FKiShhyA5XW1sBQCUBvDKyrgyVmiqqlAIBDCQiAQAJ3pxsmSaab9AGTqgEoEVNNQ19KONACbSHAIAXUI6PfpvJs6U6CyBCIDxREPJNNMd/1cDxIzResKBEJYCASCXobPiM8CtUEBKJINSiiIKqM1mYIDwJYILAkwCWARGTkAFAookSBrKhQJUIjU1PVz007jZNG6AoEQFgKBoDdOBBJJAYCqURDJBiUEZsYC/f7vbQLkCIEtKTAByIoOmwKKrMEGIKnKBhYLQ4qLuiECgRAWAoGgN0IVqA4AXScANaFJMmRHQSoDqJoHNqHoSKWgGH44AFIZB5blIBQJwwZg2zQoWlEgEAhhIRAI1kMcAEAkHICTToGmspCIio52QPHogCRB0g1YAJIZgFIVlk2hqx5IADRJEQXIBAKBEBYCgWA9DmxDAtCnLAE5nQXJWpAkDQ2tHaCSDEgydN0DUAV1DYAFCbZNEfT5oQPQZFHZVCAQCGEhEAi+RwFtlgCzf3kpdBvwEg2EamhOppCxLFigcCCBSCqqalpgOxIkECRCIXiAqrgM4U8hEAiEsBAIBN9PBA5Na0BVaSQK1SLQqA4CHZkcAFuCI2swLUAiGurrmkBtwCNJSIR90IGVANDaIlJ4CwQCISwEAgGAIik4QwXqIgYgWwQwCRxbRTYnAR4fqCLDAQUUFdlUFsR2oMsSwj5Aw/pjEEWyhQOnQCAQwkIgEKxHo7RKA2DoBswc4JgS2pMZwPAhRyVAVaHqOmRJgmxT6JTCkAECWACgyKINBQKBEBYCgeB7VNup0ywg5vNAsnKgNkEmmYEme+BYFFA8kDQDquqDRGXodhYGBSQgDQCqpDSJVhQIBEJYCAQCAEA/Rb5E6cwi6nEQ8pD1ZdJtHchJgCVB0bywLAntWQIQBSHVRFg1kTU7+wGA7BUJsQQCgRAWAoHARVBVmhJhA9TuhEQBQhQQKgFUgpW1kDMtQNKhaRoSES8SPhU+VVsgWk4gEAhhIRAINsDvkz8aNKA/ZAIoMoGirp8iFFUG4EAiAHVsyJKEkNcPLwAZUlK0nEAgEMJCIBBsgKKgefCgCBSZAsQGQGHZOSiyDMgSNE0DoQBsC7q63lvTghUTLScQCISwEAgEG0AcmDEvQKgF287CphYcywSlNkAd2I4FWSaQHAqPokEBUgTEFC0nEAiEsBAIBBtgm3ZQBSDDBIgNWaGQJIAQAgAwTROE2qCODb+mQgOqJNC0aDmBQCCEhUAg2ADHyhoUgEcnIJINQigkmUAChaxKAKWgtgNiWzBkBSpQBzii4QQCgRAWAoFgI1ATKgCPQkBhwXZyoJYJ27YhyzKIBMiEQnYc6IRAAtIOtQzRcAKBQAgLgUCwAUNDofEKkPQbOsxsBoQQWOk04DiA7YDaDhSZoL21BRXFcQCARuSqhmyjqBMiEAiEsBAIBBsiA8mw3wDggBIHkqYAoHAcC0SikCmFAgoPIVCAJgJYhFDRcAKBQAgLgUCwcWFREo8DxIFtm9B1HRIILOqsd+J0bCjEgSFL0OGskmClIOqECAQCISwEAsGmhEVRPAyJUsDKQZL+N03IMgGFDRWAV1WggDQBDr4PGhEIBAIhLAQCQT4EMAN+LyQZgG3Dtu3//R0hkCiggMJQJCigzRS2SiSqipYTCARCWAgEgg1QgGZVkaBpCiBJyOVyXFDAoYBjQyKApgIJSDMdWAYBVUTLCQQCISwEAsHGJoUUcSi8Xi+gaXBy649DCCEwzfVJNgkh0GUkAYBSKwY4IuRUIBAIYSEQCDbEA3upN5dBRLLhlxzAopCIDkplwLKh0Sw8dhoeB0sBQLLkJKVqnWg5gUAAAIRSESYmEAjy+dK0F977xdIRb65sR4tdBEuOIec4kNNNGOBpwVF9Arh938HCZVMgEGyAsFgIBIINCEt09oBoAEqmAxKVkHMAmWhQKIXs5FASEicfAoFACAuBQLCZaLJSVVZSCjOXA5UoLMeEAxNEITDNLBJFRaKRBAKBEBYCgWDzkIFk0CtBlQgcx4JDbGQdE4qurBcWCU00kkAgEMJCIBBskbiA32fAhgnVIwE0B0kFHJpDQDSPQCAQwkIgEGwucWCWRIFgwAsiOZBUAigUFNb670UTCQQCISwEAsGWoBPAq8mgMGEjA1kHMtkkvB5dNI5AIBDCQiAQbBkeACoFCM3BtrKQFQe5TCeCXg90oEm0kEAgEMJCIBBsibBoChkaiJ2DqgG5TDs8CkVZIgwZ67NuCgQCgRAWAoHgR2nMmZM1oCrs9YIQE4RmAbMThOZQFo9CB1aJVhIIBEJYCASCzSKuqbM8wNK43wdqZqEQCwQWArqMslgEKrBOtJJAINgYoiKhQCDY1K4j7dc0OJkUiGNCtnOgVgphjw4VELVBBAKBEBYCgWCLJoemkMcDQ1VAJcABBU2lodkOFKBZtJBAINjEpkQgEAg2JJdGhUwdaDKQS3fAUAh0CdAoFc6bAoFACAuBQLCFwiKVrfDICkI+HzKdnZAphS5L8Os6CGCKFhIIBEJYCASCzSYW1J4ellCX7DagPxKGDyFDR9CjIuElKAbuFy0kEAiEsBAIBJtNiUruVmm2blAwDF/Khp1sw9677YwwMFe0jkAgEMJCIBBsER1W7bQgIXMHxMMIEhkBVcHwAX2hmo4INRUIBJtERIUIBIKNYjsABVVDPiDb0YaMlEXYC9CcrYo9iUAg2BRidhAIBBuFqEqzBSvmVwGP40A1TUQIINk0LVpHIBAIYSEQCLaIIEnMpI6jqA6gmVmQjg7IABRQUYBMIBAIYSEQCLaMerNuKiHEUh0gqkjw2RZIDtAJWSVaRyAQbArhYyEQCDYUFenmKVQFdKKtjCj4aI8hg8dUN/tRomFBCbS7RQsJBIJNISwWAoFgA4qM6AxZ0ZMUtipbSA5MRFEZ9sPJwRCtIxAIhLAQCARbTHsqtb8ObaWHYml50Ivd+vWFj2CBaBmBQPBDiKMQgUCw8V0HUVJxyLPiKmZlA75+IWgjBqo4U7SMQCD4wblDNIFAINg4BPU0NwUAgjKdG1Xl50SbCASCH0NYLAQCwUbRVE+VY9kGVKA0pt8pWkQgEGwOwmIhEAg2CiHEopYtNh8CgUAIC4FAsBWEBZVMWZLaAYA2JieLFhEIBJs3d1AqWkEgEAgEAsFWQVgsBAKBQCAQCGEhEAgEAoFACAuBQCAQCARCWAgEAoFAIBAIYSEQCAQCgUAIC4FAIBAIBEJYCAQCgUAgEMJCIBAIBAKBQAgLgUAgEAgEQlgIBAKBQCAQwkIgEAgEAoFACAuBQCAQCARCWAgEAoFAIBDCQiAQCAQCgRAWAoFAIBAIBEJYCAQCgUAgEMJCIBAIBAKBEBYCgUAgEAgEQlgIBAKBQCAQwkIgEAgEAoEQFgKBQCAQCISwEAgEAoFAIBDCQiAQCAQCgRAWAoFAIBAIhLAQCAQCgUAgEMJCIBAIBAKBEBYCgUAgEAiEsBAIBAKBQCCEhUAgEAgEAoEQFgKBQCAQCISwEAgEAoFAIISFQCAQCAQCgRAWAoFAIBAIhLAQCAQCgUAghIVAIBAIBAIhLAQCgUAgEAiEsBAIBAKBQLDDULbkH9fW1k4rLS29syc1QH19/ZSioqIZALBu3brLSkpK7hbdQrC9Wb169fSVK1deXlVVBUIILMuCJEnw+/2IxWJIJBJz4/H444lEYmZPfP6eOLcIfj5iTi5MCKUUAPD555+vHTVqVCUb5B0dHWMIIabjON6mpqbj99lnH9JTBUVVVdWNiqI0y7KctCwrum7dusvD4fDs/v37X8D+fXV19XXl5eU3FdpzLl269NnGxsaTmpqasGLFCqxYsQJVVVWwLAu5XA6maYJSClmWoSgKZFmGqqrQdR2xWAx9+vRB//790a9fv2SfPn2uZG0m2DKqqqpurKiouIF9/d13313//vvvY968eVi2bBlaW1uRyWRgmiYcxwEbl4SsH3aapiEYDCIUCmGfffbB4YcfjsGDB5t77bWX1h2fd+HChSsikchLXq93ESHEjMfjs2pqaq4GAFmWk5lMZnDfvn2v6E0LJKVUKS0tvXPNmjW3Z7PZfpRSNRgMzi0pKbm7sbFxcjwenwUAy5Yte3LQoEGniVEj2FyWLVv25GeffXbq119/jblz56K6uhq1tbXIZDJ8LpEkCYZhIBqNIhKJYOjQodh7772x1157YejQoRds1bmdUor58+fnKioqqMfjoQCoz+ejfr+f6rpOZVmmfr+ffvXVV/MopSj06+WXX6Y777wzVRSFFhUV0crKSgqAqqpK4/E4BUD9fj8988wzaXe557q6uimb8++WL1/+9w8++IDecsst9LDDDqORSIT6/X4aDoepoigUAJUkiXo8HqppGpUkiQLglyRJVJZlqigK9Xg81Ov1UlmWefsMHz6cHnvssfSaa66hTz31FP3iiy++rq6uvron9Ivtcb366qv05JNPppqmUa/XS30+H/V4PFSWZUoI4ZeiKFRRFKrrOv9793sCQMPhMPX7/XTy5Mn0tddeo93pOdesWXPLuHHjaCwWo5qmUQCUEEINw6BFRUXU4/HQcePG0d7YB5YuXfpkeXk5n2s9Hk/e+FRVlSYSCfqnP/2pR7fP7bffTo877jg6duxYeuCBB9J99tmHHnzwwXT48OF04sSJ9OSTT6b3338/FfPGxq+GhobJX3311byrrrqKDh8+nAaDQT43BAKBvHnbMAyqqmre/OH1emkkEqFer5cSQmhxcTE9+eST6V133UWXLFnybENDw+Sfc3+glGLhwoWLVVWlkiTxm9B1nRJC+M0VYuMvW7bsMff3c+fOpbqu00QiQb1eLzUMg+q6TjVNy1t4BwwYQGtqaqZ19+errq6++r333qPXX389HT16NJ/EvV4v9Xq9ee+QEEJlWeYdjn2vqip/fiY0WFuwiS8QCPCJkF1MdAaDQXrCCSfQJ554gq5YseIhMejXD3r393fffTcdPXo0VRSF+v1+Kssy1TSNGobBBYbP5+Nt6hYSHo+HBoNB6vP5qKqqVJZlqus6//u+fftSj8dDzz33XLpmzZpbuksb9OvXjwKg0WiUlpaW5k1s7DnmzZvX6xaOI444gmqaRhOJBA2Hw3wsBoNB6vV6efv84Q9/6NFtc9xxx+U9OwBqGAaVZZl6vV4qSRI98MADeRvU19efLeaW9ddLL71EBw0aRP1+f96YYnM/a1dJkvI2j5Ik8Q00m0O6zjeaptFhw4bR3/72t/TLL7/89GcJiw8//JAvJuyXuBeZUChU8J28vr7+7NLSUjp48OANOnQwGKSKolCv10tHjRrV7Z91zpw59MADD6SaplG/389VJ+sYTDD5fD6qKAo1DINKkkR1Xc8TDV07IPsM9t7ZQkcI4b8rGAzmWTvY7pop5T322IP+6le/olVVVdf1dkExd+5cmkgkaDAYpJIkUZ/Px9uYWYXcY461I2vTjVkq3JMHsygRQqjf76eRSIReccUVtDtMwgMHDszrJ7IscwsNa4OzzjqL9rb+EQ6H+Vj0eDxUURQu8tk7VxSlRwuLr7/++r1+/frxjVAgEKCSJFFN0/hGj4nS2tray3qrgFiyZMmzlFK42+D888/ncwSbH9hGRdM0LjDYRpEZDNzzPfs/Ho+H+v1+6vf7+ZwTCoUoIYSGQiGqKAo95ZRTKLOG/yRhwW5A13X+J7tZv99fsJ181apV0ymlKCsr440bCoX4sUc0GqU+n4/Kskzj8TjtauXobqb0Qw45hMZiMS6EWKeJxWI0kUjwwcnM6u7OpKrqBkKCHX8wKxV77x6Ph+q6TlVV5Z3YvUh4PB7eidn3bGEkhFCPx0OLi4vplVde2et2pbW1tZcdfPDBeeLLLShYGxuGkfdzduzoXmTYosMWIrbTYKKCWZMMw+DHmIMGDaIPPvjgDhV3bLyxfsaOeFg/9Hg8tKioiL755pu9pn8MHz6cer1ebp5mX0uSRBVF4Zacni4sLrvsMj5vhEIh3neZBVRRFL6BOf3008VxyPfH4XvvvXeelcJt1WSbSPdxt3veZj9jc7V7E+meywkhlInfUChEAdADDjiA/iSLxX//+1+uWNguinV8tlAV8ksZOHAg77DRaDTvPIq9DE3Tuq0pf9q0aXTAgAF5Z2jsntnk1LWzMeHhFgRdhUbXiwkN9+exz2FmSvbv2ALptnQx4cJ8OJifxpAhQ3rNAvL111+/V15eztuLCTO2e+96pMT8YNzWCrbz2JTFgh1FuY++DMPgooRZrE488UT64Ycf7pB2r6ys5PfCjlc1TeOmV/ZsRxxxRK9ZOFh7EELy2oONJ3Yk2dOFxWGHHcb7rntz4hZX7GgwFov1emHx3HPP0eLiYj7ndvWjYH3IvZ65LRMbm0fY/Nz179zzEJufFEWhhxxyyBbNJRLzPHccB47jwDRNAIBlWbBtG6Zp8p8VGjNnzqRjxoyh9fX1SCaT0DQNbW1tSKVS8Hq9MAwDhmFgzz33xEcffVTljgLZXpEpG/v5M888Qy+88EK611570XA4TO+66y6sXLkS4XAYAGCaJhRFgWmaSKfTAABFUfKiCAghsG3bPalBVVVomgZKKQgh/GeqqkJRFEjS+rQmjuNAkiTIsgxZlmGaJvcu1nUdfr8flmXx+1AUBYQQqKoKj8cDAMjlcrz/1NbW4uijj0a/fv3omWeeSZ955hm6YMGCxp7mmT179mw6adKk/RsbG5FOp3kb27bN29SyLKiqinA4DFVV0dHRgY6ODliWBVmWYVkWf2eO4/B36/V6eVSIruvIZrMIBAJQVZX/e9M04fF4+FiuqalBIBD4Yke1h23bPPKIXawdACAcDmPevHm44YYbaE/32i8rK6NsTEqSxMcpiwByHIf3k57Mc889Rz/88ENQSmEYRt58JUkSn1NSqRQopWhra8OTTz7Z4/vHptavfffdl5500kloaWlBcXExstksvF4v2tvbQQhBNBqFpmnQNA2GYcCyLGiaBlmWAYDP7+xrr9cLr9cL0zSRy+WgKAr/exYZqGkabNuGYRhIJpMwDAPz58/HnXduQTQ4pRSffPJJW9czdmaCZd8XmsqbPHkyV3c+n48WFxfnKWOmlv1+P50zZ063eL4rr7yS7z7dPhPuc3h2vs52qOy9qapKvV4vDQQC1OfzUcMwuLVJ13W+i2XnaIFAgBqGkWemZ+/c/fvZ72bmNOazYRgGjUQi3GzWdTfN/t5t/WDPwp7jqKOOoh988AHt6guzMf+Y7t7frr32WhqNRvMsDX369MnzU2LmSvfxldt72+/30913350edNBB9Mgjj6RHHnkk3XvvvWnfvn25VYOZMruaMdl7MAyD+nw+OmTIEPr111+/t6Pao7y8fINzXXd/Yj+LRCK0T58+dOXKlfduif9KIV2PPvooHzPMsdrv929gBXTvOnuqxWKvvfbK67vsYhYctyWDmf3Lysp6ldVizZo1t5x77rkbWKjZ2E8kEjQej/N5RFVVfiTqnhvYusD+HVsrmLXT3ffYXM7+HXMWB0ArKiroL37xiy16B8r38a0pAEFCCN/NMtFRiPzhD3+gs2bNAgDoug7LslBXV8d39bIs8yREZ555Jg477LAdmqPjqaeeojfddBNWr16NVCoFTdPg9/sRiUSwZs0aRCIRtLS0QJIkZLNZrijT6TR0XQcAZLNZmKbJlT/bBTGrQzweR58+fVBRUQFVVREKhZBIJBCJRKCqKrd+ZLNZdHR0IJPJoKWlBdXV1Vi9ejXq6uqQTqfhOA63krDfr2kaj5NmPzcMAy0tLfzvWJvH43FQStHe3o7XXnsN//nPf/Cb3/yG/vrXvz4DABKJxMyGhoaz3YmgumtSqNWrV0/v27fvFX/5y1/oLbfcgmg0ytvfMAysW7cOABCPx9HU1AS/3490Os0tPi0tLTjiiCPwi1/8Av3798e4ceM22Q+/+eab99599939FyxYgE8++QTV1dU894Xf70d7ezt0XUc6nUYgEMA777zzG5ZwakfkYGF9QdM0EEKQy+X4vGLbNoLBIO+fa9aswZlnnnnxe++9d8mmPo/leChEFixYgHQ6jVgshqamJmiaBkmSuGWJ7diZRaOnsnr16ukrVqxAKBRCKpVCJpPhO2ZmqfP5fLyvOI4DXddRU1PTaxKoLVu27Mnrrrvu1Jdeegk+ny8vD4VhGHxuNgwjz6rc3t4OABg9ejQOOOAAjBgxAjvvvHOqsrLyWneCserq6us+++yzP3788ceYP38+vvvuO1RXV6OlpYW/i2AwiM7OzjxL0r333nvOFuex+Oyzz9ay3aj7fMV9Pt/dVR4LD7377rtpLBbjO4Suqs/t5Hb44YfvkOdavXr17cxp9sADD+Q7lWg0yvNodN3luePeo9Eo3x2zHbIsyzQajdJEIkErKyvp+PHj6T333EOXLl365Na655kzZ9ILL7yQjhs3ju60007ceuKOOGE+Gl29u7vuVJl6jkQiPGzyX//6V0HsTNxe2jfccAMNBAIbjBmm9v1+P981MN+eSCRCr7nmmp/8rPX19Wf/9a9/pWPHjqVer5f7srDIkGeeeWaHtyOzWLgthG6/EjYOWb+urKykPTWkcOedd6aRSCQvf4x7bnW3E5uHe6LF4sYbb6Q+ny/vmZlfEOsHfr8/z7mQ+Z/cfPPNPdZq4c5TdPHFF+dZbli0jNuvzuPxUEmSuH9dPB6nV111FWWBCptzrVu3bir7+rHHHqN777133gmFqqq0X79+tLi4mF577bU/zXlzwYIFtRsLNWUDoFCOQu6//37q8/loIpHgz8AiJMLhcJ6ZaOjQoTs0lOmtt97ikSmBQID6/X4+6Jg3riRJeaFYhBAeCcKcAkOhEI3FYnSvvfai9957b15Uy+Ym1vqp1/vvv0/POOMMWlpamhdaGI/HuRMaC4VlYbGaptFIJMKfmZnmmLNWZWVlwUwg8+bNyxMLTFAxp01mymW5UQD8pEH6Q9d7771H4/E4FzK33nor7Tpx7Kg8FuxoravzsNtz3ePx0FAoxPt3T1s0Pvvss7U+n4+PaXY06fbEZ+3hjiLqicJil1124f3AfaTr8XjoyJEj+c/YpoQdZRNCaGlpaY8/Dvnb3/6WdzTBxARbF1iKBNZviouLNyq4fuqx4ezZs+lRRx3F52P2O3+K4AelFJ9//vmKromRunqZdveX8uWXX37KdsYsfJQ1TkVFBT/XV1WV7rzzzjv0eVatWjWdDaLi4mIaCATywjrZYssGFlOvLAzL5/PRwYMH08MOO4wuWbLk2R29iFBKsXLlyntvvfVWussuu/DoErYDcZ+bsudz7+jZe2GDpri4mP7tb3/r1n2uvr7+7EGDBnHfHXZ27vZqZ1E7AOjw4cO56Nvagu/dd9+l4XCYDh48uNu0WXl5eV5os3t3ztrMvZmJRCKUEELfeuutgl9A2MS+evXq288++2y+IDBxwcID3TvzrsLixhtv7FEL6bfffvuGO6SaWWbYHHfFFVfweZq1E7P0sTH08ccfd/YEn5uNXYsWLVrojvZw+98EAgGqaRrffAWDQbrPPvvwKMbFixe/6M6+vLkWi01trF977TWqaRotLS2lM2fO/En9sOCFBUs1fv7551Ov10uDwSAPeWQWAZZOWNM0OmjQILoj01D//e9/p4QQnjbdnVuDpWrWdT0vCRITS2ziueiii2h3dXBjxzyTJk2ibqHnzm7KBg8TU27rUjAYpLquU7/fTydMmMCzSXa3TKgTJkzggoktlGwSZBMmW1B+//vfb/Pxw8RldzlO+CFhAYAmEgneF0KhEJ9E+/fvT7/99ts3eoq1oqioKC//CxPPLEfMpiwWPU1YPPbYY3lzGRs7kUiEappGr776ajpu3DjuVMgsgbquc2vz7bff3uOsFmzcDhs2jDvuux3g3WsE21Qyq+RPKfuwJdfUqVN/cnv3CIvFvHnz+FkdG6zuF1RcXEwlSaKJRGK7P4f7aOKoo47i6ZvdpiY24Nz5NZhpmAmOSCRCJ02aRN99992CGVxLly598qabbqJFRUX8DNmdKKm0tJSLp647OGYG/N3vftftnvett97Ki/BgYoLdN3u3iqLQWbNm9co4/B8TFu7zXPbO2ZjtLlFaP/eaOHEif0bWJ9x5G9xt0NOFRb9+/fJ8KViGR7bhuPfee+kdd9yxQbImJkKYj1JPHCsXXHBB3lEHE9qGYdB4PM6PgmRZpieffHJBtEGPEBa77LILX4j8fj8PvWFOjgBoeXn5DkvS9Oqrr9KDDz54gwnFbQqMxWJ5iY7cE+11113X7QpNbcn12muv0VGjRnFxEYlEaElJCQ8lY32MZYtjkw97f3/9619pVyfdTVlKtsc1duxYPkmyInZufxnmnHj//ffT3lrj4IeEhdsRuet8o6pqj0ia9e677/J5aGMJ7Nzhpb1BWHR1SGfHv0x0ffzxx53Lli17jAkw5kvWNaHcF1988XVPapf6+vqzvV4vDYVCfIPZNRsms+7puk7nz5+fE8JiO1yjR4/mDkDuyYrdfygUoqFQiD755JN0R00wbPFxe/oycZFIJDbIssjO6CdNmkQXLly4uKcMoJtuuonvUNjAKSoq4n4YLHMnixRh77KsrIz+5je/oW6z38b8Sra1syoz6bqtSuxemUhkmeqmTp1Kt8f9FKrFgkUFuUW2e+F54403CnphZXl0WB2HjWVPdafV78nC4tFHH83LadO1HIDbkjx06NA8yzP7muW52B7HijvCqsWyYEajUZ5PIhQK0aKiIh7x9cQTTxTMsxe0sBg7dmxeGKnbzOae5G+66aYdcv9z5szhFhPWOdigYvfNdrusHoQsy3TPPfekL774Yo80+61du/bGww47jA4YMIDGYrG8CAG3b8mQIUP4gGPOnm5xsb2tFOzaddddaSKRyHOwcieqURSFHnDAAXRH3FshCYuui627Zk04HKaHHnpowfb///73v3m7zK7Wma7F/9y1e9hRYU8SFn379s0LNXZbY9lGgv3biy66KC9ihI0pth4NGzaMFlLivB9dgL9/JjY+3PVj3M7vhSaoClZYnHLKKfzeWNVIdyhXMBik8Xh8h53Rz58/P6coCo9Q6TqZsgHlDsvUdZ3+6U9/2uB+d6Sz6db2lGfX448/zp2RWFswHxPmd8LCzlRV5b4mxx9/PN1UToltfb3wwgt575NlIWUOZqwvModiISw2Lizc7ddVYDDHXk3T6KefftpYiM9+7LHHciukux4DK/C4qcrCPVVYuCtJsw0VCz0HQI8++mjqPjZmhS+j0Whe/2BjzB0dUsjXL3/5SxoMBnmkDKvt5Bbb0WiUHnjggXRLq4sKYfETrilTpnBP/MrKyrxUpix5CIAdVlnz9ddfzyuTzTx83aY9ln6ZtfeYMWPo559/vmJzE6kU6uUOjWKmQPfxVTwep9FodAMnTneRs4kTJ9JNJXvZlteRRx6ZZxVjVgp3/oqfUgmwtwmLTRXBcycG0nWdHnPMMQXVluvWrZu6cOHCxZqmcWsc86lyh2BvzNeCXSwMs6cIi3vuuYcGg0Hq9Xq59ZZZcWRZpuFwmL788svUHYrPjo7dPgfM0iHLMr3tttsKvm1qa2svY86p7vmEHf0yS42qqvTtt98uuOctKGHx3XffvfqnP/2J39fw4cPzTEbsJUWjUbrTTjvtkDPuf//731TXdVpSUsIXQ3f5a2bWYwp+4MCB9Le//W1eieueFqP9Q1nfKKWYO3cuj65gTl0scoadtbKcEEywHXvssXTNmjW3bC9z6Nq1a29ku0/mlOdOgMWieDYWCiaEhbTRLJNdKyqyBYdFAHg8HvrSSy8VVHtOmjRpA8sk6xvunejGhIW7bXqCsFi3bt3UaDSaV5uJCScmGgYOHLjBc44fP566F122wLLxt/vuuxd82zz//PO8vycSibwoRnf9pUGDBv2o47oQFj8z7ekdd9zB456ZWcwwDFpUVMQ7naIodMSIETvkfh9++OG8nAbuCA+W14DdMyGE9u/fn/773//utQsRy1HB/CXckTPudNgsMYy77SRJoueff/52a7tXXnmF7yrYhOfOS8DE46uvviqExWaGm7qtdmyeYefqbDwfeuihPJdJd0gE92NCmZnsmVBmIoPNA25fC3fbsEW3Jx2FVFdXX80sjizFOwvRZv5mffr0oV03Uw888EBeaK7bsdvv91Nd1+l33333aiG3zWmnnUYlSeIZNt1imgnN8vLygnUA79bCgnW2b7755u3jjz+eBgIBfl/MCdIdnhgOhzeaMnlbT0i1tbWXXXHFFdzUx5wN3eZ8ZuZlE8ypp57aq6MGNpW98+mnn6ZHHnkkj9tmixATZuxrlip8//33p//4xz+2ef+cOHEiFzfuHQV755IkdavMl91dWLDJ1O38qigKP/oKBoM0EonQaDRKf/WrX3X7dmUm/FAoxBeIrhU7mUMnmwPcYagsK2VPigqZNm0aH7PuuZsdEauqSmfPnk03Np9WVlZyXxvWjm4/i0suuaSg24etq+7cRexrZuk+55xzCjZcvdtbLGbPns3rLLA8B8XFxXklZFn2w//85z875D6HDRvGJ4lYLMZT9rrPCFkSJUmS6HnnnScWoB+5HnroIRqPx/kRCEty5q4fwBb1WCxG77zzzm3WplVVVdcx8cpCgd3Jsdgicemll4r3uhnCQlEUuuuuu+YlBXLvZln2XOaf1K9fP/rhhx9267Y94ogj8iKD2ELorhPSp08fWlRUREeMGMGdk7tGxfQUYVFXVzeFiUY2Tpl1j5scjR0AAI1HSURBVEWBBQKBTT7jr371K27RcofssuPRYDBYsDktvvrqq3ldSxy4I2UA0JKSElrIR+JSdy4h++GHH9Ljjz8eK1euRN++fXmZ3ebmZti2jUAggIaGBoTDYRx22GE45JBDCAA0NDScvb3u8ZhjjqHffvstTNOE1+tFU1MTMpkM0uk0L2ntriR7/vnn429/+xuBYKOwdzdlyhTy8MMPQ1EUpFIpNDQ0wO/3I5vNQtd1UErR2tqK4uJiNDU14c4778Rbb71Ft8U9tbW1HZbJZKCqKggh6OzshGVZvNy8oigss6p4gZuB4zgYNGgQBg0aBFmW+TixLAuO4yCZTPIJStM0rFmzBldccUW3fZ7Fixe/+vbbb8Pn8yEej8NxHJimCQBQFAXJZBJlZWVYs2YNLrroIvTp04eXBWelr90lqnsCb7311kO2bYMQAjZ2stksAECWZaiqigMOOGCT//8Xv/gFb0dCCCzLgqIoyGazkGUZyWQSzz///PBCbJuampoxrA1s24Ysy9A0DZZlQZIkEEKg6zri8fisTc2P3Z7uarFYtGjRQmYCKy0t3SC3fklJCdU0jQ4YMID6/X76zjvv0O0dOfHmm29SRVF4WFRXJzS3ClVVlV522WW9NhPjT70uueSSvLBi9/tnXzPT8tixY/NSnm+tvvD+++/zHaY7JTlzxGW7KPFuN89ioWkaPfvss+nNN9+cN2aYdSocDvN3GggEaCwWo6qq/mjU1I66xo8fT0OhEE92x/oIO+5h1ZUTiQStq6ub4k717T427Uk+FoccckhenQv3+2c/d0eDbOwqKirKOzJy+6mpqlqwR4+PP/54Xkl4Npew4zCPx0MPPPDAgn7/3VIef/vtt28fdNBBIzRNg2EYaGhoQDabhaqqAIBoNIr6+npomob6+nr86le/wrhx4wgAFBUVzdjYZ65bt+6yrag4rwaAxx9/HLIso7OzE7lcDpIkwTAM+Hw+AIDP50Mmk4GmaTjttNNw1113kUQiMVPsWTefqVOnzmXt2dnZCUmSoKoq2traoOs6AMCyLCQSCXz44Ye49dZb+f/dVF/YUmpra2GaJizLAqUUqqpCVVU4jgNKKSzLgs/ng3i3m4+qqpg0adLje+yxB2RZRjabhaIo0HUdra2t6OjogKqqaG9vR3t7O2zbxsSJE/t3t+d455136Ouvv4729na0tbXBNM31E6skwbZtOI4DXdfR3t6OK6+8EkVFRTMIIXkbO9av2PeFTk1NzdUff/wxMpkMZFmGYRhwHAeGYUDXdXR0dCAcDuPYY4/9Qcvt+PHj876XZZn5J0BRFCxfvhwrV658qNDaJ5VKcQsVW9OYNVSWZZimiZKSkoLuA91OWHzzzTfvXXzxxQepqorOzk5uOmWdyuPxoLm5GYqiIJPJ4PTTT8dll112wY99bklJyd1b6x7Lysr+8u233749e/ZsZLNZ2LYNj8cD0zSRTqfR1tbG79vr9eLkk0/Go48+Ko4/fgLDhg07+NFHH4Wu64jFYnwwptNp6LqOYDCITCbDhdxbb72F//u//9uqs3MymeRmSgBIp9PweDzcbGmaJoLBoHhZm0kul4PH48HAgQPPPOWUU+D1eiFJElKpFJ90A4EADMNAJBJBLpdDIpHAihUrUFVVdWN3eY41a9bc/sQTTyAUCsFxHIRCIUSjUUiShFwuh0wmA8MwkMlkUF5ejiuvvJI0NjZO1nUdkiTB4/HkiQlFUXrE+33zzTf/zMQgAG7uZ6JA13XsvPPOP/o5xx13HDRNg23bUFWVt49lWfw49P77759SaO3D1jVZlpFOp/m7N00TpmlClmUMGTJECIutRX19/ZS77757/3fffRepVAqapiGVSiEQCIBSinQ6zQehbduYMGECHnzwQVJUVDSjrq5u6va81yuuuOKg1tZWPjGwc3ZN0yDLMt+xjB49GrNmzRKi4mdwwgknkCeeeAJNTU2wbRvZbBZ+vx+UUr4ramlpQWdnJ2zbxg033LBVzyIzmQwopfxMHACy2Swsy4KmaXAchy8Sgh+HEIKWlhYAwOmnn35GLpeDYRgAAMMwwDYVuVwOLS0tUBQFTU1N0DQNDzzwwPXuz9qalsgtpbq6+jd///vf0drair59+6KzsxPNzc0oLy/nojOXy0GWZVx44YUAgHg8PotZX5nPAVtY2EJc6Dz88MOQJAmKosAwDLD3a9s2Ojs74fF4cNxxx/3o5xx//PEkl8shGo3CNE0kk0neR9ra2uD1evHYY48VpLB2+2e5fUdkWe4Rc0m3Ehbz589/6NFHH+XOOX6/H5Ikoa2tjTtBmqYJTdNQVlaGf/7znwQA6urqphYXF9+/ve7zX//6F507dy43XUmSBMuy4PV6kcvluLWivLwc7733nhAVW4Hdd9/9vhtuuIHvYAKBANrb25HL5eDz+RCNRvmOJpvN4rHHHntka/1uj8fDJ3622zRNE4ZhgJm1e4rT3faAWSjYQvuvf/0LnZ2diEajaG1tBSGEpYLmCwlzcqyqqsr7rK1pidxSbr/9dni9Xti2jerqar6Trq2tRSwWg6Io3BHvmmuuIe6FxXEcEEL4M7ryYBQk9fX13HKwdOlSbmVmz5fJZGCaJnRdRyqVwoQJE57anM8dMWJEngBjGzfWP5iFq5CwbZs793apGwLbtiFJErdqCGGxhWxsp3HdddfxHWAkEkFbWxs3iSaTSVRWVsJxHAwYMABr1qwhALBy5cqHtqeoWL169fTf/va30DSNm61M00Qmk0FJSQkkSYKmaYhGo/j3v/89d0fuqHoS/fr1u+Skk05asPfee0NRFKxbtw7xeBy6riObzaK9vR2O48C2bViWhWeeeWar/W5d17nnPvNwZ0KDCUl2/CX4cRRFyYuWGj169MVerxft7e2QJClvomVHX+yYcd68ed3iGd5880365ptv8l0n87Nhi6DbonXggQfm/d90Og3TNOE4Dv8ZWygLVaAyf6bPP/98bWNjIxdQ7ugYYP0xxujRozFo0KDTNudzL7nkEmQyGei6Do/Hwy3Xuq7DNE10dHTg7bffLihFxvwq2Ltmvlrssm0brA2FsNhCuu40brnlFvr1119DkiQ4jsN3Lu3t7YhEIkwV45BDDsHjjz+eBIBly5Y92b9//wuYM+X24M9//vPlS5cu5SZ4NgH6/X6sXbsWsVgMHR0duOeeezBs2LCDd+SOqqexyy677PHYY4/dZxgGFEXhZmbm56JpGneuXLx4MRYtWvT11vi9oVCIWy6Ys53H40Eul+Pvn5n2BT9OKpXK25EVFxff//zzz/PFVpZlfubMxBxr5xUrVuDll1/e4QvJww8/nOd46RYE7AiXUgq/348999xzA2ElSRI/LmECigmMQuarr76qsG0biqLAcRxYlsWtToQQ2LaN0047bbM/77zzziOmafKjFdM0uU8b49NPPy2oNgqHwwDALTo8kuL7PpTJZFBfXy+ExU+ltrZ2GgA88MAD9Oabb4au6zyGXZZlfqbd1taGcDiMaDSK3//+99hjjz1C9fX1U5jqLSsr+8v2uN/Zs2fTRx55BIlEApZlcWtFLBbjFoxUKoWpU6fi9NNPJ27zoGDrWS7ef//9JaFQCKlUCpIkoaioiPu0MFNpMpnEXXfdtVXi3EtLS5PZbBYej4fHnrPzcFVV4fF4YNs2Pv7445x4Qz8OIYT7VADr80AceeSRJBaL8QVEVVW+aKfTaRiGAY/HA13Xcdttt+1wa8V//vMfdHZ25jkXtrS0wO/3I5PJwLIsFBUVoa2tDXvssUfe//f7/dyXxC0u2M61kFm6dCkXSMx/wG2R8Xg8OOCAA1ZuyWeWlZUhnU7n5cFoa2vjPhwdHR0F1UaJRCLvnTPYsbppmgW/UdmhwqK0tPTOt956i1588cXc098wDMiyDJ/Ph2AwiHQ6zX/+97//HQceeCBpbGycvLVCCbeEG2+8Eaqq8qRcbBLI5XJob2+HLMvYa6+9cN999/1g6Kvg5xGLxZ4+/PDDUV5ejlQqhZaWFn4MwsyvkiTh6aefxmOPPfazZ+p4PP44AHR0dPAjEeZcnMvlkM1mQQjBCy+8oIq38+M4jpNnsRg6dOh4ALj33nu5BYpZK5jZmDlHf1+MEK+88sp2X4HXrFlzOwDcdddd/P5zuRx3vmP9gS0WyWQSO+20E8aPH5/nZ2VZFr9s28479il0Pv30Uy4mmB8JAB5627dvX4wcOXLAlnzmOeecA2C9f52qqnwMMofHRYsWFZywYNYu1le6HoUVvAV0RybI+vjjjzsJIbSoqGiDtKahUIgXqwmHw/TBBx+km6olsj2u+++/n6flZe3j8/mo3+/nKWfD4TD94IMPRFrnbXi5K/wNGTKE91eWPMvj8fCUwQDorrvuulXex8CBAzdIauNOhEYI2Wq/q6cnyIpGo/Siiy7aaFvtvvvuPLU1K0mvaRp/nyyV+z777LPVE6FtTprqOXPm8PHO6pqwlN2stLeu6/x+n3vuuQ2e8/DDD9+gfDpL6V3oCbJYMkN3RVOW9AnAT6r7snz58r+HQiGqqirVdZ2Pb/a5oVCooNpq8eLFL7rnDZYYjSVKY2nu33zzTSoSZG25sm07+OCDveXl5aivr+fOOZlMhucGYOE3f/7zn3HBBReQjewkZ22Pe/3oo4/oE088Ab/fjzVr1qC4uJg7mTKVqes6Tj31VIwdO1ZEgWxjKxf7+q9//Sv69OnD258dg8iyjFwuh3g8ji+//BIPP/zwz97djhkzBj6fL8/HwnEcsCRulFIsW7ascFLu7kCYBZLhzk1x/vnn82gw5rTJjrkIIfB6vXAcBx9//DGef/55uj0tg0VFRTMeeOABbhnzer08QR4hBOl0GrIsQ9d1ZDIZjB07FhMnTiQb28wRQvKOChzHyTOLFyJr1669JZlM8iML9zEP80k7/vjjN+uz2DE5AAwYMOBcNraz2Swcx0Emk0EwGORH5d988817hdJO4XB4ttvPhvnqua1XyWQSzz33nLBYbOnl3u2xinVMibJdp2EY9Prrr9/hqm3mzJl8J8LS0SqKwitsKopChw4dKnarO+CaMGECLS0tpYZhUEVR+K6R7SRZ0bqf+3tefvllmkgkqK7rfEcdjUZ5FUuWdliUTd+86qZTpkyhm6pAPGzYMP7v3POEu7hXnz59tvuYq62tvcxdSdn9fGy+DIfDPDXzXXfdtdH7mzRpEi9KyP4fm3ML2WLx8ssvcwsFGxOqqnIrtCzL9OdYDJllSJblvHTh8Xiczpgxg9bW1l5WKG3FnoX1Z7b+SZLEK3ZXVlbS6urqq0V10824br31VmoYBg0Gg1xQRCIR3mmYSXv06NF01qxZO3xwzZkzh8bjcerz+Xgn0DSNEkJ4fZARI0bQb7755u1CrkZXyNdhhx1GVVWloVCIT8yapvG+5PP56EknnUR/7vHZ4MGDqdfrpfF4nFexZJMA+/PEE08UwuJHhIUsy/TCCy/cZDt9+OGHdPjw4bxybDQa5V8zAcmOIy6//PLt1t4VFRW8DLqmaTQYDFJJkvjcwJ6REEJ/85vfbPK+jj/++Ly51i0qUMDVTdlxoaZpXEwYhkFDoRDVdZ3edttt9OduRtk6waqkMvGp6zrdnnWifu41Y8YMLkRZHaxYLMYr/TKBdvDBB1N3lWUhLCjFihUrHnJ/f8IJJ1BFUajf7+c7Ebe1ory8nAKgJ5xwAv3yyy8/7Q4NNGjQIH6v7BzUPXBisRh9/vnnxWKyg6/Ro0fzQen2tcD3JesJIZvcQW7u9fXXX7/HPn/EiBG8T7CiWUzQbMsS7j1FWJx//vk/2EaPPfYY1TSN+zCxHaokSXwhYe/5xRdf3Obt/eCDD/Ix7/V684qNsfvz+/3U5/PR/fff/wfv56ijjtqoj0UhC4unn36az+eqquaNPybAf26RviOPPJJqmsbfvWEYeZaLQmqzqqqq64YOHcp9T9yWVp/Px/taIpGgo0aNosJisYmLmf8A0GAwSA3DoLqu868TiQT1+/106NCh9KOPPuK/b+3atTfuyMHCTFOKovBdqmEYVJZlKkkSnThxohAV3eBix1Xu46mu1ouKioqf/a5GjBjBdxOlpaV8gWETXSwWo+FwmP7rX/+iQlhsXFhIkkTPPvvsH22fMWPG5E24zELA3jOrOLvffvtt87Y+99xzaVFREY1EInnHM2xh8/l8fJGYO3fuD97PMcccw/sMExSFLiyGDx9Oo9Eod9yUJIm/O4/HQ/fee++f/TwvvPACtxa5RVk0GqWGYdBhw4YVVJv985//5H2YrSklJSWUVXU1DINvvG+44QYqhEWX67zzzuMmskgkwj+bmaorKyuprus0EAjQ+fPn57pL4xx44IHc14NNbO7IlUgkQp9++mkhLHbwxY43RowYQQOBALcesFLccJWw/7lRO6+++mqebxAb+KxvB4NBGgqFaCwWo2+99RYVwmJDYaEoymYJixdffJEahsGjL4LBIN+csEU9EAhQQgh944036LY8itxjjz34vbPxz/oZIYSyqIU999zzR5/r2GOP5X46XQVGoQoLdjTMLFKsfYLBII1Go/Sf//znVnkeZhWCqxQ7E3Rer5d+/fXX7xVSu+22225cnDJ/LQA0EAhQn89HZVmmsViMJhIJ7m/4cy0/PUJY/P73v6der5f7JXQNDywpKeGT9LRp0+imFg63c9f2uphJz+2c554Ehg4dSoVfxY67uvaJ2267jVspWJgim+RYXz7qqKN+Ul92n9/ut99+3HmPEEJLS0tpPB7nExwzi8diMfrPf/6T7oi+292FxTnnnEM3RyyyRbir/wxzpGbz048dP/yca968eXxn7BapbE4wDIMLnnfeeedH72P8+PF5c6HbcY9ZSAtJWLz88stUkqQ84cdERiwWox6PZ6v5P+y77758IQ4Gg/xr9ud9991XUILsb3/7G+9bbksYs1rE43H+s9LSUvr666/TXm+xuOOOO7iFgsXmujsfa8iioiIaj8fp0qVLn9zesembuv70pz/xe5VlmZ+luhU5cwgUV/e4Vq9efXtlZSXvt2wh0nWdC1lZlumqVaum/9w49JKSEu5Ilkgk+KLA8q+wxSIQCNBnn3222/gMdRcfix8TFux65513aCQSoZFIJO+dBoNBvqNj5uR58+Zt9Vw3K1euvPf000+ngUCABgIBGovF+KJGCMmLFNsca0XXo5CuwqIQo0JYXg7W95kfDJvjd9lll632LM888wzvQ2wD4fZ9GTNmTMHNyQcccAC3hpeVleUd/3m9Xjp06FDeXw455BD62Wefre21wuKVV16hZWVl3Gva7fnM1H5xcTHvfA888EC36hBMbbuPQNwd2u/30+uuu04Ii252TZs2jTv8uY+xmFUsGAzSJ5544me/t9tuuy2vbzATOROgLFKEEEJlWabnnXceXbRo0UIhLMDbY3M/67jjjuO7X+ZnwdqVTb5+v5+GQiH67bffvrEpS9NPuT744APurM2OZCoqKri5mj2Pruu0q7P6jx2FuH0rCvUopKGhYTI7znZbc1giM0mS6B/+8Iet+izsvbOQf/Z9aWkpBVCQIZrMQlFWVsbbkF1snolEIlSWZRqNRmmvFBZff/31e+4dvsfjodFolH9WNBrli3YgEKD33HNPt2soFvLj9/spIYQ7i3k8Hu4guDlmT3Ft36uurm6KJEncKsacyFjfY7kttsaEetJJJ+VlhUwkEnnHfO5QSV3XaVlZ2c+2lvQEYUEI2SJh8e6773JPeWYaLikp2SADqizL9JNPPmn7oWytP3U3zuYxNrmzIzBm8u/fv/9mP4/bYlHoPhZvvvkmv2f3TltVVe5/tLV/58EHH0wJITQcDlNZlnneDGZFKiRHx5UrV95LKcWTTz5JvV4vlSSJCyT3UUgoFOKOq6FQiIZCIfrMM8/QXiMsVq1aNX3w4MH8jEjXdVpaWsonFvZzpsJuuukm+nMG/ra47r777jxFzO6X5a1gC4fwr+ieV3FxMVVVle8o2btjvjKSJP2kZDpd+2l9ff3ZBx10EBfI7t85dOjQvIRObAenqiq99dZb6aZ8OHqK8PgxH4sfCzftel1yySV8PgmFQnwnxxYvtjjvtNNOWy3uf86cOXwDxLz2ZVnmRzBswldVlS5cuHBxbxQWxx9/PH8v7ogdNlcOGTJkqz/HX/7yFy703M7ZbOwdeeSRBbnh++Mf/0gjkQiVJIn269ePKorCS0gwsRYMBvm8IstyXmr7Hi0sbr755jyv7dLSUv4Z/fv3p5Ik0aKiIqppGv3Vr3612ebD7XmxMy1JkvIcAFkSHEVRRF2Ibnzdfvvt1DCMPL8KJiyYE/Gjjz66Vd7fJ5980nbIIYfw8Glm0fJ4PLSkpISPI7dfkdfr3Srhd4UqLFRV3WJhMXfuXC7q2We581u4xYY7++nPycbotlawJEZufwj2/b777rtFz9JThAU7BmH9nh0/Mv8XAPR3v/vdVn+ORYsWLXQnyXJHGTJLyfLly/9eiOPmqquuyjtSAkDLy8v5/OG2CrHAh0GDBuUd/7BNyo4KetjqwmLJkiXPxuNx7lvhjvFn/hQssdCECRO6naWCRRq4FwJ2fsrO69nzPPLII0JYdOOLLTjMcZOZr5m58bDDDttq72/x4sUv7rnnnryPsF0uO/dlkyybFNifO+20E3333XfpxiJcenuCrI0tYhMmTKC6rvPPZQu7LMvUMAxuJt5jjz1+9rt966238pI7sY0Fc1BUVZUWFRVRSZLohx9+uEXWy54iLGbNmsX7PCsY6W4nABv4vGyta6eddspLksaOCdjY+rlZPnfUVV1dfTWzzjHnb0VR+DGru8Ad28x4vV4aCATo//3f/3GBsXr16tt7hMVizZo1t+y33355mejc5kLmdKUoCt1rr726rSPb7NmzNzi3ZVX12ESmqqoQFd38SiQS3Guf9WFWi4Y5Wm6N3BkspnzVqlXTDzjgAG6aZfks2ATAnDwTiUReCGw0Gv3B9M9CWPzvmj9/fq5rim+Px8PHKjuPlmX5Z2fDPeqoo/i7dOdNcB/xAqDHHnss3dIolJ4iLI444ggaCoXyLLrsmbxeLx04cOA2ewbmPM1S6bPaK36/n6qqWpDZKt1HrNdeey0PsVZVlR8vBQIBbh1i7czGVSwWo+eff363sNZsFWGxatWq6WPGjOHe8GwB9vl8PIENa4Ti4mK6YMGCWqbOuttLveiii/IGCBs07olxwIABQlgUQAgXE4Tuydvt97BkyZJnf04+i41dI0eO5CGQzDTMJgZ3dFEoFOLiW9f1bntW2l2OQtwJhTweD48sY9YoWZZpPB6nhBAaiUTo2LFjqXui3tLNBft8Fq7M+o37TN/j8dD//Oc/W+zT0VOEBdssup2l3ZFRU6dO3WbPsGrVquluMcMsVoQQvvAyx8hCvW644QYai8W4JSiRSGwQ7kwIoT6fLy+8d+TIkVvk87Mtrq1SNv2iiy66/KOPPuLlo71eLy+PnMvlWDgNNE3Du+++++/Ro0eXAoCmaVXdqdJrY2Pj5DfffBOStL5ZFEVZ30hSfjMdeuihovZ1N2fvvfcGIQSUUiiKAlmW+fesZPWcOXNO2pLPrK+vn/JjJbrvuece6LqOVCoFANB1HX6/n5fUliQJgUAAANDZ2YmysjJks1nMmzcPV155Je0N7+b7qKufxPjx45HJZEAIQSAQQGdnJ2zbhizLaGxshM/nQ0dHBz788EO8/vrrFAASicTMzf382traaQ888ABM04RpmtB1/X+TpSQhl8vx93fSSSfhkEMO4WXRy8vLb+ot4+vZZ5+l6XQajuNAVVXIsgwAvEy6x+PBqaeeus1+f9++fa/Ya6+9YJpmXr+ilMI0Tdi2jX/+858Xd/d2bGxsnNz1ZzU1NVcDwB/+8Ady7733Yuedd4amachms+jo6EAwGOQl1uPxOHRdh2VZCAaDyOVyWLhwIc4666wh99xzD93UZ3f7suknnHACz03BlKJ7V8iUZDwe5+fJ3d0ZiSlAd4U+tktSFKXX14EohOu+++7j749Zy9zvU9M0On78+G3yHpcvX/73ioqKDXZz7rBrd/y925x8++23055usdjScFP39Y9//IPKsswjANgOlZmI3b4tgwcP3uLf8cknn7SxOY99njvjJpvXwuEwffPNNzf4/M2pbdQTLBZHHnkkt7ixgmPu6q7l5eXb/P5ZoIC7KKR73Rk5cmTBjiV3P2JuBm6/InflZmb1ZCUM3NlIL7zwQrojqqL+oLBg4S3xeJxuzLlp//3350cfbgdHdjHT82mnnUY//vjjzu7+Mh955JG8SAJmXmLHOQC2SfiUuLb+9dxzz+VlauzqXMYcdLfV76+trb3sX//6Fz3jjDP44seK7bmzRbJ+xsQOE+c33XRTXs6LQqgPsK0SZHW99thjD95Obudc9l5ZNkZd1+lll1222b9n0aJFC4cMGcI3SmwOZCKGCY1YLPazEvoVurD44IMP+FhikTpsYWfOrtOnT9/m979ixYqH2NzMHB3d96AoCn3//fd7zHz92muv0X322SdvHgsEArzCMju+Y86sLA9TJBKhV1555Xb1vdiosGBhlmwy8Pv9tOtu0Ov1ck9VVj3SHdrHBnjX7JQ/J/xrW18XX3xxnl+FO2UsG/jbapcrrq17LV269EnmzMUKJLH+7f6T+ftsy+ubb755e+zYsTx0mU2AqqryMEnmHCzLMh0+fDgFQAcPHkxPOeUUWojiYlsKi4ULFy5mjppMNLorjLpT72uattn1FY444gie/M6dc6NrAbTJkyf/rDmgUIUFm7tPPvnkvAXcnQjRMAw6atSo7baIXXXVVVyUs37ALEyKotDhw4cX/Hztdgiur68/e9y4cTy6TZZlGgwGqSzLfD1mTuvuZHIsInPx4sUv7lCLRdfBxP7DAw88kCci/H4/N9HE43G+K5MkiU6dOrWgkkiNHj06z+Ob5T1gL0vTNHr11VcLYVEgl/v4ik2AzILBJvPHHntsu73PyZMnc+9ultiJWTPcC6Lf76eJRIL/fMSIETvcGas7CQtKKX75y1/yMeretbojbpiz7A+FFrOQ948//rjT7VgbCAT45M0Sq/l8PlpaWkrnzJnTK4UFc15m4ou1jfvISFVVeu655263e1+8ePGLzHnXHfnlzvfQ0+a1hoaGyf/3f//Hx5SqqlxUeDyevAKf7orcoVCIjhgxYru4JGxSWLDkIyyMi9L1VezYTbNMg/F4PM9cyMKxuqr6HXHOs6UXm6DYLshdbY59/9RTTwlhUSAXq+nABhc7rmPe44qibJMEPj+063j88cfzakwEg8G8cEm3WT8SifBJu3///vSVV16hQlj8z2rBdmLsbNm9wDDBxvLnPPvssz/4+w466CCqaRrPbOi+ZzZpA6C//vWv6c/NE1DIwmLGjBk8Usbt38BSbEuSRGfOnEm31w6e0v/VDnEXcnMnmepudai25Oq6bjKrUXV19dVvvPEG7du3L39uduzBcuWweYQJbnaVlZXRO+64g3bNQbVdjkLY7o6dA3/11VfzWG4Adj7sTjcaiUT4hD1+/PiCC/Wpq6ub4vYvcZvW2ASp6zr97rvvXhWLduGEnLIdqNu3wm2Rch81bK/r3XffpXvttRcdMGAAF+nufBvxeJwL9EgkkpeafNq0aVQIi/XX1KlTufByO1u700uz45Fhw4bRTYUL/+tf/8qrJskc5Nzmfo/HQ/1+/1apUlvIwmL8+PF8bWDzpNux1efzbXdnQXZ06D4eYJYL5shbqPksNvbzrknHDj74YD5vsJBo1o8VReEhqixdOBsTxxxzDN3c3Ctb9SiEefuWlpbS4uJiWlpaSv1+P79plvGOTdzBYDDvJbJ03YVQ/+CLL7742u30w9rCnYRE13VhrSig6/TTT+e+C0z0Msc81r+3NB3z1txpnXjiidzMzspys8HPqv+yvtenTx8+UR555JF04cKFi7uzz8X2EBaLFy9+cfjw4TwxEhuz7LiJCQR25r6xXdmaNWtu2XffffMERTgc5rtvd+6Ryy+/fKv0lUIWFu409SwSwV3uYEfk+DnnnHP4/bBaLvF4nEdkSZJEly5d+mRPnusuv/xyfrzK3glzaB06dCj3HWJC0J0d2O3gurWyYf9gHotMJgPHcdDW1obm5masW7cOlFKk02koigLbtpFOp9He3o7y8nJks1mceOKJAIDVq1dP79+//wUs5ri7xxPX1NQMZ/kOusba27YNAAiFQiJBRAFRWloKx3F4rPv3ZlNIkgRCCBzHQVXV9kulEo/HZ9XV1U1l37/wwgvk6aefBiEE7e3tAICOjg6ed6Ourg6ZTAaVlZVoaWlBJpOBrut44403cOCBBw6ZP3/+I7313dbX108ZMmTICccccwxs20Y2m4WqqvD5fMhkMqCUQtM0KIqC5uZmGIaBp5566iT2f9nnLF68+JrFixcjlUohEonAMAyk02mwHA3t7e1QVRW6ruOiiy56qTePp2eeeYa2tLRAlmWe4wcAZFmGqqqQJAm77LLLdr+vyspKKIqCbDYLQgi8Xi8aGxvhOA58Ph8SiQTmz59/akNDw9k99d1Mnz6dTJ8+HcOHD4dlWTAMA2VlZWhvb8fixYuhKAo8Hg/P4ZNOp+H1eiFJEg499FA88MAD9Ps5886tcT+bFBaqqgIADMNAKpWCaZpQVRWdnZ1QVRXpdBqEEJSVlcFxHNTW1kKWZdx3332kUMSEm3Xr1iGTySCbzcKyLL4IUUqRzWYhyzLKy8vFal1AFBUVcVGRy+V48h7HcXginYaGhu16T8XFxfe7v58wYQJZvnz5HyORCDKZDB93mqbB6/XCcRysXbsWjuNA0zR+77lcDhMnTsQpp5xCe/M7vvTSS//s8/lgmiYMw0BnZyd8Ph8URYHjOHxxSafTqKmpYf2CJzmbNm0ampubEQwGUV9fD0II/H4/stksIpEIT7A2cuRIDBky5ITe3NZ/+MMfeDImSZL42CKEoLOzk2We3e73JUkSdF3nm4fOzk6epMs0TdTV1eGss87aokRphchZZ51FnnjiiZUTJ05EOp1GVVUVZFlGIpFAMplELpdDLpeDLMvI5XJIpVJwHAeEEEydOhVHHnnkVptLpE29KMuyuNWCkcvl+MTs/ncsq+HLL79csC/F/ZxssDBLhSzLsG2bZ9wTFAaRSASEEC4o3JaKrv18R1JRUXFDc3Mz2W233ZBKpRCLxdDR0YFsNguPxwPDMJDJZJDL5RAMBnl//D5fB6ub0NtE44zvd6vX3nDDDXzTI8syPB4PMpkM0uk0FxuxWAxPPvkk//+NjY2Tn332WbpmzRpQStHR0cEzpiaTSYTDYbS2tvLMmwcddBAAwG1x6m20tbUhmUzyBVxRFORyOXg8Hvh8PlBKMWLEiO1+X6eddtpTqVSKZ3zWNI33gfb2diiKAgCYP39+jx8nI0eOHDB9+vRr/vznP0NVVaiqiubmZkSjUWiaBkmS4DgObNuGz+dDJBLh8+Ibb7yB3XffnbKMtVtdWHAHDNci68ayLIRCIXi9XtTX1yMcDmP27Nl56W0LVVi4d7UM9jXbTQoKg1AoxAcN69dsx+9+t27T+I7kqaeeek6SJDQ1NcEwDD5ZA4DX64WmaWhpaYGu63zHSAjBH//4Rzz11FO91nIxefLky5mJV5ZlNDQ0IBgMQlVVbgJuamqCZVl45ZVXKLD+WOqee+6BLMsIBAJwHAfBYBCEEFiWhba2Nng8HmSzWWQyGRx66KGorq6+rqvFqbfw3HPP0ZaWFv69aZrQNI1bdi3LguM4GDly5HY/nhs0aNBpbstFJpOBZVkghHALi+M4eOWVV3rFuyorK/vLWWeddfkrr7yCWCwGj8eD5uZmhMNhvo55vV6YponOzk5YlgVFURAOh/HZZ5/hggsuwLRp0zaYT7ZEVG9SWHQVGWznRwiBpmloa2tDNptFUVERrrnmGhx++OGkkF9GR0dH3jOyNnB/zcxtgsIgFotxUcHeIxMX7D3btg3LsqLd4X4HDx58sm3bhO2+k8kkJEmCLMtob2+Hbdu8ZoBlWfD7/bAsC7ZtY8qUKbj66qv5wN1uNQF2EO5JrqSk5O577rkHwHqrqqIoUBQFkiQhmUzyd22aJv70pz8BWO8v8MEHH6CtrY2b9BsbG0Ephaqq/Ag0EAggHo9j1113vaA31QLpyvTp03nNJCbi2Lz4/RhCIBDAgAEDzt0R97fbbrvxDWIul4PjOHD7zAHA888/32veV0lJyd1HHHEEeffddx8/8sgj4fF4UFtbC03TkEqlYFkWr+PF2ktVVQSDQaxZswb/+Mc/MG7cuDxxsSWierOLkOWFkrgsGccffzymTZtGNlZMpZBIp9MbtdC4FyZhsSgs2I6fCeONCeXvJ8Zgd7nn6urq6zo6OsiNN94ITdO4k5Usy3AcB4ZhwO/3wzRNPmnGYjEAwK233ooTTzyRsl1LT363XSe5Cy64gHg8HpSVlUHXdW7ZYc7muq5D0zR8+umnePbZZ+mf//xnRKNR2LbNN0uUUhiGAUVRuOOnruv45S9/yY9eeutRyH//+1/4fD4+ByqKglQqxX1ZKKU4/PDDd9j9XXHFFTBNk1somX+caZpQFAWEECxduhRLlix5sTe8r+XLlz8GAAMHDjzzueeeI3/+85+h6zpkWYamaTAMA7IswzRN+Hw+xONxNDY2orOzE6WlpWhtbcV7772HXXfdldbW1k7b0t+/SWHhnni7wnYFY8aMwYwZMwgzLRb6y+gqnDa3PQTdE0KIWWjvj+2Kr7/+ejJjxgzstttuaG5uhizL8Hq9PDqkX79+yGazTIygo6MDZWVleOmllzBy5MgefSzCNjFdF/lrr70WNTU1/EydVScF/uewK8sybr31VixcuJCLCubUxoQccwRlu/BLL730rp+ya+sp7fziiy9SAGhvb89zHgbAz+wdx8EFF1yww+71l7/8JWFWFEVRuNUpk8nA7/fDtm1IkoRXXnnl+N7w7gYOHHim+/vLL7+cXHzxxejo6ODrNwtG6Ozs5NY6RVFQW1sLVVURjUbxzTff4Oabb75jmwkLSZLyyolbloWPPvqId75Ct1gYhrHBjpZ9z+gOjn6CLbJCqV3FBCt/7X6vsiwnu8s9V1VV3eieLO+//37svPPOsG0bRUVF3GGusbERmUwG8XgckiRh6NChaGpqQjQaxYoVKzBq1Cj6+eefr+2J75VtYrou8r/+9a/JsGHD0NbWBp/Px029LMzOsiyYponPPvsMkUgEHR0d8Pv93DLh8Xi4ZYiZh88555yCi3Db2u08ffp0eDwe7qug6zqPUjJNE5lMBl6vF4cddtgOVe4HHXQQd7hna9j34xvA+qPsZ599ttfOh3feeSc5/PDDUVJSgra2NqxZswaRSIRbd9xrPdvEBINBPPjgg3j//fe3aLPyo8KCXezckjnqqKqKXC6HysrKx2fOnEkL3WLBIj7YWTwznzGR4VbpgsKgtbU1v7N/L4yZsHDtbuq6yz1XVFTc4P5+7NixZOHCheTVV1/FXnvthUQiwRdFn8+HtrY2buY1DAPJZBKZTAYLFy7EOeecU/F9aelew6xZs9ZVVlZyCwRzcnUcB7Is8+MRSils20YqlUI2mwWlFKlUiuc5cRwHJ5xwAi644IJzevMY+vLLLxf+97//hSRJ8Pv9UFWVL9TMMgQAZ5xxxg6/10suuQSJRAK2bfOwSgBIpVJ8U/HFF1+wTKu9kjfeeIP885//xHnnnYdEIsF9t2KxGHRdh23b8Hg83DLV2toKSZIwceJETJgwYfPbbVOZN2VZ5jnzZVnmletYylC4yokbhkEnTJhQ0FkpZ8yYkZcJz50WmGXFO/jgg0XmzQK6/vGPf/D3Kcsyr3/DMlgqikI1TSuod7p69erbA4EA9Xg8vB4GS/nNsgxWVlbyLHylpaX0xBNPpD0x8+amrgcffJBnWWXF3Vi21a7zHPt3+D5DZzQa5WWot9X9FVLmzV/+8pfU7/fzDLFw1eRQFIV6vV7q8/koy7K8o6/999+ft6NhGHmVV9m4P/roo8U8/v21xx57UI/Hw9PWq6pKCSFUVVUai8V47SLDMGgkEqGVlZX0J2feZHHyzGGRUgpd15FOp/PO1liMcDqdxgsvvIDzzjsvT9EUUqazeDzOVbiqqshms9yzmEURrF27FoLCoaamJi+ih3n/s1A05qxXSPTp0+fKZDJJDjzwQCQSCb7bliQJqVQKgwcPxtq1a6FpGqLRKNrb2/HSSy/hlltu6RW7tIaGhrMvuOACMmbMGB4BFAgEkE6n86Ia3BYsSil3iG1paQEhBFdddZUYQOstQDw5IutnLPzecRykUikMGTIELMvyjmb8+PGglMLr9XKrFPOjYWN9/vz5WL169XTxdoHZs2efc88994AQwjPWMqfOVCrFLRi5XA7JZBJVVVU48MADf3Qu2aiwYOdUkiQhm83C7/ejo6ODJx5hnUuWZRQXF0PTNADAiy++yOPEARRUprNQKMTTlDNfCpaqlplUu5rWBd2buro67iXuTj/sVtYsoqLQeO2118iUKVN47gVVVVFZWYnFixcjGo2ivr4eqqqio6MDgUAAd955J959990eLy7YnHP++efzjUIqlYJhGHyDwCIF2PcA8koT9O3bFyeeeOKc3j5+3nrrLcrWA+ajIkkSfD4f97EAgHPPPbfb3PM+++yDUCgE0zRhmib3m2FrltfrRWtrK5577rnLe/O7ZZv+RCIx8/zzzydvv/02vF4vDMMApRThcBjZbJa/a9u2uS/SvHnzcOGFF9ItFhYAeFpbv9+Pzs5Onukvk8nwDuU4DhoaGpDL5RAOh9HU1IRHH320IBu6qKhoAcvKqGkaVFXlNQhYaJ9w3iwsVq5cyfNAMEub27mLUoo+ffoU7PPddNNN5J577uGO1S0tLVAUhWdHZBn32trakEqlcNlll3WbZGDbmrPPPpvst99+3BHT/d6Z1Yo5arJ+EY/HUVVVhYsvvhg77bTTET8lzK4n8cQTT3AB7g61z+VykCSJ5z2YNGnSGd3lnvfff38yfPhwmKbJLRZMELW1tfENxjPPPNOr50b3pr+hoeHs/fbbj3z11VczdtllF+i6DkIISktL0dTUxMU386nRNA2zZs3CSy+9RLdIWBBCeDEk9nJ+//vf887FTGLMROL+2auvvoonnniCFmBDP2LbNndKdZtLmeNmS0sLPvvss1qxZBcGq1ev5l8zC5vjOJAkiTvnDhgwoCCfbd26dZcBwJlnnkkmTpzIBbBlWbAsC+FwmMf1ezweaJqGL774AnfeeedDveX9n3feeXwz4N4UuJ0O3bC03r/+9a8JAJimWdKbx88rr7zCxw1rM1bUjxV569+/f7dLNXDooYfmRa4wMeT3+5FOp6FpGr766issW7bsyd4+R9bW1k5jIqN///4XPPTQQ18cddRRSCaT/N2zUF0mzplYu/TSS/nnrFmz5vbNEhZsMGYyGYRCIVx44YXXH3nkkbwQEitEJssyYrEYt25QSnHdddfhzTff5OKiEJLKFBcX328YBk+Uw0QFIYSrcwCoqqoqgaAgqK+v5+fsLCKAWTDYhDNw4MCCfLaSkpK72dcXXHCBycRSNBqFx+NBa2srfD4fGhsbIcsy0uk0wuEw/vrXv+Kjjz7qFf4WBx988J/32GMPnvDKba3QNC2v/o/X6wUhBA899D/d1adPnyt769h5/fXXaWNjY57Fjx0fsfmwqakJ5557LrqbZefoo49GNpvltV/Y+2XZlVkBrueff/7U3j5Hdq1muuuuu4685pprmkaNGoXa2lpEIhFu8clkMrz6bzabRVtbG6655hq60bGyqagQdPGkdXuRAqDM6xvfe98qikJ1XaeyLFNd12lZWRmdO3duQXnf7r777tTv9/MoGBYRw9rC7/fTO+64Q3gUF8gViUR4BJOiKNQwDB4pEAwGqSRJ9KmnnuoR73P69Om870YiEQqA+v1+PpZDoRBvi+3hFb8jo0Lc1/ehhTzSy30P7kgRVVWp3+/fLvdUCFEhxxxzDPX5fFTTtLyoAUmS8iLmuut4KCsr4/3d/a69Xi9/3yNHjhRzuetqaGiYzL7+7LPP1g4YMIAC4PNJMBiksizTRCLBx1IikaBr1669cbOjQpjJw7btPHPxCy+88OeysjLU1NTA4/Hge5MhdyBjFSUbGhpw+umn89SihcC4ceO4lz3b5aqqytVaR0cHXnzxRWEKKACWLl36LLOosb7MjgZYfQ3HcdC3b9+Cfk7mhHX55ZeTk08+GbZt89Lh7DjT5/Ohvb0dwPpS0u+88w7mzJnTK6wWJ5xwAtl7770BgFstmLUinU6joqKCm/jfe++9KjFy1vPWW2/xtSCXy/HkWMwk7jgO9t133257/+effz6PaAgGg0in04jH43nRjt9884140S7cR1qjRo2qfPDBByHLMjo6OjBo0CDuu9XQ0MAz2jY0NOD3v//99V0/a5NRIYFAAF6vF47jYM2aNQDWn+tWVlZe+8UXX5zBXhYhBNFoFKZp8lLPbAKvq6vD2LFjzygUcTFq1CjuMc4WIhaiyM6qGxsbRQ8sAKqrq09i4VPseI9lYWR+CN8PpucK+TndTlg333zzbwYOHMgdrgOBACzLQmdnJ3Rd50mDTNPEww8/3Gv6wtSpU+H1etHe3s6PNg3DgGEYqKqqYkXGulUG1h3JkiVLXsxkMujs7OTput3VdC3LQmVlJcrKyrivT3eBHcuMGjUKgwcPRiaTQWtrKzRNQ2NjIw81Z3NAbzkW/Ckcdthh5OKLL4Zpmli+fDkikQgvt97R0QFgfWLJ//znP/jkk0863f9X2dSHZrNZ5HK5PAfNkpKSu2tra6eVlpbe+fLLLz8+adIkpNNptLW1oW/fvqiurkY2m+Ue1o2Njairq8Mpp5xyxieffHJmd2/I4cOHryOElLi9xZnzClO6NTU1oscVAGvWrOE7UyYsVFVFJpPh4rmiogKBQOCDnvLMpaWld9555513nHDCCRuk6WWhlbquI5vNYvbs2fjwww/p2LFje3wBnAMPPPCORCLxG7bjYlbJXC6HUCiExsZGPPzww9htt912FiMHWLRo0fHMZ4fVo1FVFT6fD83NzWyTiRdeeAEfffTRXZZl3ZXJZHjxr64RONuCrhWoWaVi0zRRWlp6RzKZRFtbW17GaFaUzOPxwO/3o7GxEZ988gnGjBkjXvomuPbaay9+8cUX71uzZg06Ojp4dCQL37UsC9XV1Xj66ae9e+655w9bLNgOnSXNYA5ObPICgAMOOIC8/vrrS5izY01NDY95DQQCqKurQ1FREbxeLz777DMcffTR3V4ZFhUVzfB4PLzSqTsGmi1K2Wy215iRCxkWBs1ykNi2DTb5MavF2LFj85wgCxlWq+f4448nkyZN4qZ+lgSKHetlMhl+HPTGG2/0ir7Qp0+fK++66y60tLQgm83ystEswdO+++6L448/XlQY/J7FixfnRYOwyDi22QLA06TX19ejpaUFra2taGlpQWNjI5LJ5Ha92tvb0d7ejo6ODnR2dmL58uVobW3lQQhu6wurFMycOkVuoh+muLj4/v32249XRmUpGFhRRNM04fV68fLLL+frh02pQabqY7EYP1txs3r16ukjRowY+uyzz8Lv93NTmSRJ6OzshKIoaG5u5vnl58yZg3POOadbL8gVFRU3sCgBd10UFgXDQmqfeOIJ0eO6OfX19QDW1wlgYWfsfbKz9nHjxvWY53Wfj15yySV5UQ/saM9tsXEcB88//3yv6Avr1q277IQTTiC77bYbUqkUioqK+K4LAH77298KIe7KkrxgwQIA+QUZTdPkYfg+nw+yLMPn8/HESSzyhvW7bXmxhE3uy229YGKICSPmZ8VymmSzWS6658+fLybLH2H8+PHIZrM85JithexYSVVVLFu2DK+99hr9QWHBFKqiKPB4PBuUEl+3bt1lrOLfuHHjyN/+9jfIssyPQZiJRNM01NfXQ1EUeL1ezJw5E7///e9pd66EetRRR/HnZ8/DzGysc7799tuit3VzPv74YxiGwQfDxsyzQ4cO7ZHPvt9++5Gjjz6aTwLMpC3LMlgSOAC9wnmtsbFxMrNKjRo1Ch6Ph/ucfN9WOO6443q9tYIQYrotFm4nZyYw2GYzk8nwYwe3ZYzlUdnWsPvZ2LrFjjyYlSKXy0FVVXi9Xqiqyn0rZFmGLMv4+OOPxWT5I+y9996PsDmUWe8ty8rLDWIYBh577LEftliwDzAMA9XV1YhEInl/X1JScrdb4U6YMIHMmDEDtm0jHA7npcdWFAWmaSKdTkNVVUyfPh0PPfTQ4901t8WECRPgOA4fREzxsmfJZrOor68vqGiX3sh3332HTCYDx3F4OmfbtqFpGrLZLOLxOPr16/dIT33+c845B36/n0eDsImXZZRlfPDBBz32WK+hoeFstyXnkEMO4ceZjuMgGo1i2rRpvX6sNDY2TmbttHr16um1tbV8E+XuN2wx1zQNuq5D0zS+YPt8Pr6ws0yw2+piDrjsa3ax3++O6GNzN0vqxYQ2W5/a29s3SO4kyGfAgAHnHnnkkTxvFVsb2TFzLpeDruuYM2cOP5L9wQRZzHGns7Nzg3/TtQ7I6aefThYsWLAuEAigra0N0WgUqVQKoVAIhmHAsiz4fD6k02ncfvvt+PWvf31fd8x8NmbMGDJ06FDu6MYUsuM48Pv9PEHYTTfddIboct2TefPm0dbWVp41lhXR83q9vP7NKaecggEDBpzbU9vg2GOPJfvssw9fRN3HemzHp2kaPv300x7bD7rOUWeccQYZPXo0T5J04YUX4phjjun11gq3+JoxY8blzB9BlmXuZ8b+ZIkR3UWqstlsnhVjO1hX8i63FYP1a03TNvAPYX2/a3mGG2+88Tdi1vxhLr744jwrFhOczc3N0HUdyWQSLS0t+OCDDx7/UWGRy+UQCAR4VMiPMXr06NJ7770Xfr8fDQ0NvOCL22NYURS0tbXh7bffxujRo09dtGjR192tES+66CIuIJilgn0dCoVACMHTTz8tels35ayzzkImk4HX6+VREOx8mBACwzBw/vnn9/hzgDPOOINbKHRd55M/w7ZtLFu2rFf1jXvvvReKouCAAw7AH//4R+Gw2YUXX3yRz//MMuGuaO31evM2W7ZtQ5ZlZDKZvGJf2/rq6m/BfEByuRwymQzS6TTPEAkgLzKECWy2xs2cORMrV658SLz9TTN+/HgycuRI7mfoPhpj71xRFLzwwgvYpLBwHIcnv8pkMnznvjkcc8wx5Je//CUP7TEMg99IU1MTSktLQQhBXV0d2tvbceihhw5fsmTJi92pEU877bRz2LPLssyjYphZ2TRNaJqGt99+W0SHdDPq6+unLFmyBPF4nHv/M7+CTCaDTCaDioqKXhFaeMQRR1zg9/v5oGcOi2zhYKbg3sQ+++xDJkyYgMsvv1wMli48++yzdPXq1dy5mfnksLkcWB8pp+s6dF2Hqqrcssusgm4nzm11qaqadw+sAjX7mv0d+/dMULgLzrFaIsD6XAzPPffcFNEDfnTs5PloMVcBls/KcZz/WUA3ldLbnV4WPyF167HHHsvTqCqKQgcNGsQ/t7i4mGqaxtNlV1RU0JUrV95LKUV9ff3Z3SG96a677srTPwOg4XCYlpSU8PaJRqP0+uuvFylhu8FVW1t7Gfv6sssuo+FwmL83Qgj1+Xw0EAjwPv3II4/0mvc2ZMgQnpYZ36fnlWWZqqpKCSF07NixtCen9N7YtXjx4hd3dLrs7pTSu6amZhqlFGPHjuXlC1jq6+LiYurz+aiqqtTr9dLnnnuuIMeOqqo8BbU71TcbF8OHDxdz+Y9cjz/+eN4YZl+zvitJEk+LL20rdfPyyy+TSCQCXddhWRZqa2sRj8dBCEF7ezvPLcCy3x1xxBEXf28tMbqDOrvqqqvynH0sy8K6det4TfqOjg4sX75cyNhuAPP6X7ly5UMzZszgx24AEAwG0dnZiVQqxdNbn3322b3GBD5w4ECeQXZjuzcWftqbGDJkyAli1PwPlpvou+++430ilUpB13XU1dXxwoyyLGPixImkUMeBoihIJpM88SM7xgGAZcuWiWqnP0K/fv24Ncvt3+I+GjNNE42NjZOlbXkj1dXVpE+fPjy3BeusqVSKn4GzP5csWYKbb76ZFhcX398dGnHy5MmEVXJj4oj9yTqkCFXqPjQ2Nk5+5plnpliWhZaWFgQCAe4RHg6H+TnsqFGjNvi/NTU1V/fUdhkxYgR3YmWJwb4X8AA27pgt6H385z//oW1tbQiFQlBVFewITdd1tLS0wHEcHHXUUQX7fJdeeimKiop4PgZ2vM9yveRyObz++uunip6wafr37389iwxijrBMVDAsy0JNTc010nbosHeUl5cjFApxhxoAMAyDe+yzQjHuONjuwBlnnMHPkTKZDGKxGM8zr+s6Vq1ahf/+97/Cz6IbUFtb+5s333yTZ9Zct24dAKCjowPpdBqhUAixWAzTpk1D11DnsrKyv/Rgaw7P5ZHL5dDZ2cn9LFjomEDwl7/8hecmsG2bF7BjlJeX46qrrmoq1OebOnUqYf3e5/NxnxHmg6UoCp57bn3ZoPr6euFvsRHKy8tvYu3mzsLqhlKKurq64dtcWPTp0+fKuXPnPu6Ob47FYjxkSdd1tLW1IZPJoK6uDhdccEG3WagvvPDCKpYC9vtdMRcarAjL3XffLXpcN+DLL78c8dZbb8FxHBQVFcHj8SASicDn8yGbzaKtrQ0dHR044YQTSHc5btsesMJjTByz7Ljs2h51HQTdn7feeos7a+q6jqKiImQyGViWxYX67rvvHi/kZwyFQjyagT2XLMvo7OwEIQT//e9/sXbt2luKiopmiB6xcVhqbwYL6XXT0dEBaXvczMCBA8+8//770bdvX14pD/if1zHztWhra8Pf//533HLLLbRr0pIdka1z1KhRlbvvvjuam5sRj8d52BWLg1ZVFS+99BJefvllYbXYgVRVVd14+eWX8wQ5TU1NfHfOTP3xeBz33XcfVq1adS87U+4NtLW1AQAfc+xPd1IhQe/miy++WOzxeKCqKlitJFZrg9WLOvPMMwv+OadMmQJN03gFa5YGgZnyTdPEG2+8cY3oEZumpKQEuq7zuYMJC/Y9Cz/dLrPKqlWr7p00aRL5xz/+gYqKCjQ3N6N///48KyebAFmc9N13343Zs2fnJS1xJ3HZnlx66aUghPBKeV6vl59Ts+QwDz30ELprJtHewCOPPHJ9Y2NjXjiZx+NBJpOBx+NBOBxGJpPBEUcc8cd+/fpdAvyvvHJvgbUNCwtjfhfu3Yegd3LPPfcMYQKCVS8NBAI8O6ksy7jkkktWFvpzHnPMMY/7fL688eCudUII6TX1c34qLBW6m67RI4ZhbB9hwSbz/fbbjzzzzDPwer1YuXIld6qTZRm6rvM8/vX19bjtttswe/bsHW4JmDBhAhk3bhxXualUiqc7ZzvA2bNn45VXXrlPdLvtz9KlS5+99dZb4ff7oSgKXzBTqRTPad/Z2YmpU6eioqLiBvb/eovVgqVaZhMoSyrEvLiFxULwyCOPIJvNIhAI8KMQlv6+vr4ehmFg5MiRAwr9OQcOHHjmzjvvzCsd+/1+7tTNNrhffPEFVq1ada/oFRunra2NCwh3sjImMID1uU62+6yyzz77kLvuuotbLoD1Z1/s5bJKotXV1TjjjDPw6aeftu3oxjz33HN55kIWfgqsT3nu9/shyzJuvfVWVFdXXye63vbl+uuvPymbzaKzsxOWZSEYDMI0Tfh8Pp4YqrKyEhdeeOGM3joRuHP7s4XDnSFR0DtpbGyc/PXXX89jIYTMmZ7VRMrlcigrK0M0GgXQM6Kn9thjDx4yyQQ2C5sMBoOora3FCy+8cLHoHRuns7OTh6gripKXlZUdjYRCoSXbRVi4C5atW7fusnPOOYf85je/gWmaPP8888xlaZgdx0FzczMmTZoUZOJiR1VFnTx5Mjn44IN5Z3QchxdVY3n1ly1bhttuu+2PouttP15++WX69NNPQ1EUnh21tbWV57Rn+UdOPvlk9O/f/4Le2Eb19fV5tX/cOw0AGxQYFPQe4vH4rNtvv32M1+vl1izm95ZOpzFw4EDU1NTgnnvuAdAzoqeOO+445HI5hMNhpFIp7kdiWRa3Wjz5pEhnsSlYYUeGOyiDrY+GYXy7zYVFfX39FFYMqKam5mqWzOiyyy4j119/PVRVRV1dHS+/yiIu4vE4DMPAihUrcOmllwaXLVv25I7ys6ipqbn6d7/7HR982WwWhBB4vV6u8mOxGB5++GHMmjWLH98IC8a2Zdq0aQgEAshms8hms1xQsJS+uVwOgwcPxllnnTWnt7ZRVVUVT/TmdlJjk0MsFhMdqRfz/PPPw7ZtHmaqaRpyuRx8Ph+qq6vh9/tx/PHH95iEcgcddBDp168fMplM3mLI/pQkCZ999pmoHbIRlixZ8qI7pbdlWXmFHh3HgaZpCAQC729zYeEO3emqeG+44Qbyi1/8AuFwmFsukskk32nKsgy/349PP/0UEydOPPWbb755b0c0aFlZ2V/Gjh1LJkyYAGC9yYyFyTLfkKamJvh8PvzpT39CVVXVjcD6uF/RHbc+jY2Nky+//HK6bNkytLe3IxaLIZPJIBgMchWdTCYhSRKmTp2KnXba6YjeKvKqq6v5kZCiKFBVlR83EkK4mVvQ+3j00UepZVk8dL7rQpvNZrHvvvsygXpjT3nu0047DZlMBoFAgEcyuJ2aNU3DzJkzRS6LLnz00f+3d93hURVr/z19+2ZbOpAQkCJdRBFBsICoFEFFKdIEuYgGQRRUpKh8ICDIBRSUJsWrlCuIIIgiSpUiCEhNISE9ENLZ+n5/6Mw9GwKk7G5Ccn7PMw8h2T1nzpx3Zn7z1oO9SKl04sAp114wDANhYWEQFhY2t8o9t1atWsV89tlnEBERQUtb8zwPOTk5UFBQQKvRnTp1Cvr27dtxwYIFVebQ+fXXXzM9evSAvLw8AABqiyT5OLKysiApKQmee+65906cOHFOEUXfIy4u7svZs2evXrhwITWf5eXlgcFggGvXrtGU1QaDAd58800YM2YMU1tJ3s6dOzE1NZVOemI/BwBaVjosLEwRqlqKjz/+GARBAI7jQKPR0NMn0frxPA8fffTReQDwcny+0zFo0KCdYWFhYLfbQRAEYFmWamqIaWTt2rWKgJTA999/T7U6pFos8Vch60nLli3/JqnVocP9+vVj/vzzTyYiIoKm+zabzdSHgTibJSYmwrhx46BPnz5VRi62bNnCNGnSBBwOh5cKTV7p7cyZM/DAAw/cVR1Lwt8pKM1RLDs7e+BTTz016KOPPqIaLp1OByzLQl5eHnAcByaTCQoLC+HBBx+EDz/8sFaXxV62bBnVqpFNgxALosaMiYlRhK0WYvv27Xj69GnIz8+neQnIAUkQBMjJyYEOHTpAy5YtG9W0Z2/cuHG3IUOGwPXr14HneRrhBwAgCAI4nU6Ij4+HxYsXK/mJ/sHly5en7d+/HzweD107SCCDPJ9Fhw4dqg+xIBg1ahQIggAWiwUKCgrAaDSCKIpgt9tpPgK32w3//e9/4Y033qiyl75q1aoi4mhKmD7xoCYJZjQaDdx///1NL126NE8Ry/IhIyNjdGmOYtOnT1998eJF6t/icDjg2rVrYLfbwWKx0NLNAAD33nuv13drmykkMTFx4Y8//khPEyTjJoHdbge32w3NmjVTBK4WYuPGjVSd7XK5qKe/vFDdwIEDa+zzDxgw4KCcYBPHTZZlQRAEAAD44osvFEH5HxF9LyMjg64hxNGXhK+TcevYsePfX/BX2fSyNnmZ9AsXLqyLiIhAlmVRkiTkeR7Dw8OR53kMDQ1FhmHQZrOhXq9Hnudx1qxZVVbqdunSpcgwDMbExKAoimgwGJDjOFqym5TpbdeunVKOtwItOTl5mvz/Y8eORZZlked5lCSJlq4ncmo0GumY16tXD8+cObODfDcjI2NkbRu/5cuXIwCgIAio0+kQAFAURdRoNLRsNMMwePny5cm1rWx6VbfqUDa9Tp06CABoMBionKhUKvp/s9lc499PeHi4l2xqNBpUqVS0lDrHccraXUJmBUFAjuOQ53nU6XS0fLrJZPKSmSrXWJCIkUuXLs1r0KBB//Xr14Ner4eYmBhwuVyQn58PMTExkJ6eDjabjUYAuFwumDdvHnz++edVorkYMWIEExUVBZmZmTREi2VZmgqXMLo//vgDhgwZoqjUygm5Tfff//43LliwgFbnVKvVwHEcXL16FXieB1EUoaCggL6HHj16QOPGjbuR79fG3P9Lly4Fnue9ykM7nU5wOBz0dBYeHq44GNdCfPXVV5iVlQUAAHl5eSCKIk0aRWzmrVq1qvHj0LNnT+rMTA7ZJGEWiQBctmxZrV+709LSxu/atYvKCfFtKygooLVDiouL4ZlnnqHfqVJiIc9vUa9evdcB/k6gtXPnTmdiYiJNnHXu3DmwWq209LrL5QKdTgcZGRnwxhtvwObNm6vk5Q8dOhTy8/PB4XBAbm4uDdcqLi4GURSph/Hq1athwoQJmJycPKOk3UpZ5m6Nn3/+Gd966y3gOI4WGCOl64mKX74wPvjggxAbG/sVmRC1ccx2796Nv//+O7hcLigqKoLi4mIaEiZ3bm3RooUiYLUQO3fupCSCZVkafsxxHE141LVr11pBLIjfkSRJtDCm2+2mG+jChUoSzj/++GMOMRkR8xGBwWAAt9sNLMvC4MGDqwexuBnatWsnbt++HRwOB1itVtBqtbQyo8FgAEEQaLhcXl4ejBkzBk6fPn0gkH28fPnytBdffHE+Kf/OcRyYzWYICgqizqaICMXFxeDxeGDRokXw1VdfTYqPj19W2qlcQelYvXo1LRbEcRxkZmbSfCfEHkxOHPXq1YN58+ZdadCgQX+A2pG2u2TSuKysrKGLFi2iTprEjq7T6QDgb0djvV4PeXl58OqrryoCVsuQnZ09cPfu3QAANAU+2TBEUYT8/HxQqVTw5JNPHq3pY9G9e3eGaGjk6ajJ/81mMxw/fhzS09Nja7PM7Nq1i0aBkEzTBMXFxQAA0KRJE7BYLN/TP1S1j8Wt2s6dO6nNj9jV5f3TaDTUZjxhwoQq6eOUKVOQ53kv2xz5V6fToVqtpvZtAMB3331XsduVsa1YsQLVajUaDAY6poIgoMVioTJhNBqRZVnU6/X4yy+/1PqxPX78+DmO41Cv11ObKJFFMm90Oh1aLBa/jpXiY1E9fSx+//33QpVKhaIoUtlgGAYZhkGj0YgAgDExMbXm3TRv3hwFQaDyGRQURP0G6tatiyqVCvft21erZLWkT9p9991H11+Q+eWQdUav1+OLL77oNUbVugLRY489xnz66acQHR0NdrsdzGYzTd1M7OnktLp27Vo4d+7c1kD38Zlnnjk6dOhQQESqXlSpVNTuX1xcDCaTiWYlmzVrFjz33HOlmm5qQi5+X+G9997DsWPHgsvlguLiYrh+/TpIkgRqtRpyc3NpieeCggJQq9XwxhtvwEMPPVSrw0szMzNHtmvX7i6GYSA/Px/0ej01FRHzIRmzd999VxGyWoasrKyhb7/9toaosomvDcnlQNbV6OjoWjMmd999t1ckCImWMplMkJSUBC6Xi4ZQ1hbIfdLOnj2748SJE2AymWhG48LCQroPkwrSo0d7F/eulsQiKSlpNvm5S5cub7zyyitgNBrh6tWr4PF4oG7dujREitjIcnNzoVu3bk/K/TZKwh+lzZs1a9Z2woQJG5o2bQpNmjQBl8sF165dA5fLBSqVCiwWC+Tk5IBKpQKn0wlqtRq+//57mDt37g3kIjw8fGZtDE89e/bsDvn/R44ciRs2bKDmr5LOVWRhLCoqAoPBAM8//zy89957tZpUAAB8/PHHS4hpLjw8HPLy8kCSJDCbzeBwOCA0NBSKi4vBYDDAwIEDBylbbe2CzWZbce7cORomCPC/bJuICEVFRcBxHNx11121ZkxCQkLAbrfTgyrx3bp+/TpwHEfX8aqqU1WVyMjIGP3ss892dTgckJWVBZIk0YNKfn4+NY80b94c7rvvPu/1tzqbQkhLSUmZOG7cOK/+aDQaqo6RJAkFQUC9Xo/Nmze/oa+nT5/+1d99/OOPP+Lr1q2LkiR5qX3lZhyVSoVarZaaRi5cuLBOfo309PTRtU0tnJqaOp78HB8fv+T5559Hk8lE1ZE6nQ5ZlqXhvDzPI8/z1Bzy3HPPKaYlRNizZw9KkkTHTa1WoyRJ1BzRoEEDOl+mTp3q9zFTTCHVzxSyZcsWVKvV1ExG5IXneWqyZRgGv/jii1rzbv5JgoVqtRoZhvEyaavVauQ4DgVBwDVr1tQ6eZ04cSJdT0jaB7L36vV6uqcdP378XGJi4jz5d6stsSi5yWZmZg6NjY2l/bFarajValEQBOq/QCZHw4YNsSo26mPHjiWrVCoMCgpCnU6HPM8jy7I0r4XJZEKGYSgZMplM+P3339faBVaew2Tnzp149913e9nxyLsltmCS34TY+B577DGFVPzTgoODkWEYjIqKogsjy7JosViQZVlUq9VoNBrRarUGZMwUYlH9iEXHjh1RkiQ0m81e6yXHcRgcHEzfz++//15YG95DVlbWwKNHj6apVCp6UBVFkcorz/M090ttW2t27dpF9y5yMA4LC0MAwMjISOQ4DhmGwYcffhgREUrmw7kjNBakXbp0afYrr7xCH4oIA3FSIxuQWq3Ghx56yKvP8fHxSwLRxzNnzuwAANTr9ajRaOgmKIoiJUBkXMPDw1EURRw+fHit3iDHjBmDJpMJQ0NDked5ypKDgoLoWJGNyWq1Is/z2LVr11pPKkgSsenTp1O5YlmWOjRLkkQ1ZKStWrVKIRa1lFjwPE8dNMlpk5ALi8VSrdb6QDYim4IgoFqtpuNgNBqpZodlWawt68mpU6cOEDkxmUxUS6FWq1Gj0aAkSdSp/tixY8mlXeuOIhaICAkJCQv79OlDVeFkAydCER4eToVi0aJFmJ6ePvrixYtfBrKPZ86c2SGKIgYFBdFTNtkoiXraarXSF2a1WtFms+GOHTtq1aROTEyc17lzZzQYDHSBI2SCRDGQd0lImSAI+Mgjj9TaTSkrK2tgyd9xHIcmk8lr0+B5np5MjUYjqtVqbNKkScDGTSEW1YtYbN++HY1GI90g5NFrAEC1v1FRUbXuvbRp08bLHETMrfJxkiQJN27cWOPH5j//+Q+2bNkSg4KC6KEkMjKSyihZlwVBwFGjRuHNLAx3HLEg7dlnn6VhnkFBQVQIdDodfXiO43D58uVYUu0eKAJUv3591Ol0aDAYaMppskHqdDove54gCGgwGGpFOOq5c+e+/frrr9FqtaJaraYCSwSZ4ziqjSJEA/5JM/z0008jeZe10SelZBsyZAi1dxIzIM/zdFMnac8NBgMeP378nEIsaiexePTRR1Gj0SDHcdRfiRx4yEYKAPj+++/XuveyePFiujZzHOdlfiWknWVZ7NWrF9bkw8rx48fPtWnTxot0ksNJvXr16PwNDQ3F1q1b33Is7lhikZSUNGPZsmXUNijPW05U5sRO1q9fP9y/fz9WhWpp5syZ2Lp1a6+xJSdI4m9BbFmEdFitVuzXrx+uWLECA61t8Ve7fPny5M2bN+Prr79OHQkNBgNKkkSJYMkNiKjeiD/F6tWrA/4Oz58/v746qiznzZuHMTExdPEj6mzysyAIVCvWpEkTPHjwYEDHTiEW1YdYJCUlzSB+NqIo0nVH7lhOVNxxcXHLauM7ueuuu6gGXJ53SKVS0fXJYDDUSP+TCxcurJsyZQpGR0cjz/NoMBjo4URuSiXrce/evfHs2bNbaySxINEiFy5cWGez2Wi/g4OD6aQp6cRWUihKUyv7iwSNHz+eehmTsZVrLIg/hlarpQlrGIbBoKAgfPrpp/Gnn37yegdpaWmxgep/Zdu6deswNDQURVFEo9FInaLIOMjJFhFknU5HTw4rV66sEvmbM2cO1qlTB1u0aIH79+/HqhjvklqZI0eOZJNThCAItECfKIqo1+tRkiSUJAnJnGjcuHGVjJ1CLKoPsRg1ahRdY1iWRY7jUKVSIcdxdK00GAz46quv1tp38vHHH1NyTsZDpVLdsA/2798fK7umVCefuvXr12NISAiNIiNzVK/XeyXXI5rj8ePH46FDhxy3u+4dTSzkHqyEVRJ/C0Iy5GxTpVJhVZ5Aly1bhmq1GtVqtVdIE+kfOZ2TKnvkZEHsfb1798adO3feMZP/8OHDuVOmTKEOQOQ0YDKZvExAWq2WyhkhVBqNBnmex9jYWCwtiiQQjsLh4eG0z8HBwfj6668H9MQiz4CXlZU18OWXX0aWZal8N2rUiBIIeRQNIWetWrXCH3/8EUs+l0IsahexYFnWy6So1WpppJDcJCKvCFwbG8uy1J+L7CNEbslBx2AwVPi97N27F/V6PXIch4MHD8ZbZbv05aH2ZuboXr160f2HVBMPCgqia7J8XbFYLNiiRQssaxBEjSAWiAgvv/yyF8NSq9X0REc2MJZlsWvXrpiSkjKxKvM2kLwbJDaYsGR5ulTyDuTvRBAE1Gg01WpRLm2zP3ny5BGbzeZVylyr1aJKpfLyByCbDDk12Ww2tFgsNMrnmWeeqbLnfOKJJ2hfifMSAGDr1q1x/vz5tF/+Vh3HxcUtW7hwIbIsi1arlZJOQtZINBQJGST+FEajEb/77rsqGz+FWFQPYnHs2LHkkt798nuSTcVkMtX6KKuWLVtSfy95PhjivEk24XXr1pV7rLKysgbWqVOHmliIZvGzzz4L+LjPmzcPg4ODqUzI1zitVkt9TUh6c6KxKM+h6o4mFnI2dunSpdnEb0EURRq2SPIeEG0Ay7J43333oT9ZYln63K5dOy8bJxE44nMhj6cmmwnxGSEn6Hbt2uFvv/2GJEyoKtvBgwdx5MiRaLPZkGEYjIiIoBtfUFCQl2zJn4M8s8VioerZyMhIXLZsWZXJ3L59+7wWXblmiTxTWFgYTp06FdPS0mL90YezZ89unTp1KjZr1oySZTJmxMGMLH4ksohohfR6Pa5fv97LaTnQZhyFWFQPYjF27FivsG0ix1arlZpl9Xo9Dhs2rNYTi3feeeeGsFNBEOh7IYfTJ598stxj1bZtWyr/9erVQ4Zh6LsIDg7Gjz/+2O+m1m+//ZYmRZOb44l/iTys32g0Uu0KAODu3bvL9cw1RmNBTA3EL4E4oJAQPJK9kcQkkyRaVdXi4+OXWK1Wr5AvksxIvqGR9yC3hRJPfyIYZrMZmzdvjm+++Sbu2bMnIM+Vnp4++ssvv8QuXbrQMSXmG8J+jUYjDa81mUxeDlHEf4LIF8uyGBkZiR06dMC//vrr56p8N8OGDUPyboh6lGzm5BlIxEVwcDA+/fTT+Msvv2BCQsLCyjq4zpkzB1u3bo0Gg4GSCUIyiRmNJKsh2WaJbDRt2hQZhsFdu3bhrSJyFGJRe4gFOZWSDJI8z3uZjYnKuzocTqq6nTx58gg5gJK5JicW8syc5bnu+PHjked5NJlMNEkiIXtkT+I4DkNDQ/Gll17CjRs34s1MGBVpmzdvxr59+9IcQMSxW6vV0rWjYcOGdA+Sr3c6nQ4HDRpUblmsUcQCEeHHH3/0stcT1R8xIxiNRhpu1alTpyp9rrS0tNg+ffpgSEgIXXiJYBsMBi8HIhKOSWzq5Hm0Wi21j4miiGq1GuvUqYP33nsvjhgxAr/88stKb9RZWVkDf/75Z5w6dSr27dsXGzZsSPup1+u9UnAT00dISAjyPE8JEtHCkE2SyBkhGA0bNsSZM2dWuZxdvHjxS6I50Wg0XlVBSay/yWSi7F6uyTCbzfjUU0/hJ598gjt37rytNuPs2bNbf/vtN5w2bRr269cPmzdvfsMcZFkWIyIi0GazeWm1CDnjOI6SZ47j8NSpUweqwzxUiEXVE4uNGzfekCBNnheGZVnUarUYHBxc67UVpLVu3ZrOa7J2kYMT0VhwHFfmKKudO3di/fr1adZKeaABMYmXTKBoMpmwefPm2L17d3z33XfxwIEDZbpXRkbGyLi4uGWnTp06MHfuXOzUqROGhoZSx3iixSdyptPpqGZZFEUaWkrWMpPJhGazGeVlF8qcjK2mFU559NFHmaVLl+Lw4cNBEARwu92gVquhqKiIFlAhNVL27dsHQ4YMwZUrV1ZJAavQ0NBPNm7c+MmWLVtw5cqVsG3bNigqKgJBECAvLw9EUQSPx0Mci6C4uBgKCwvBaDSCy+UCp9MJbrebFulimL8fIzk5GTIyMuD8+fOwdu1aKCoq6qLRaDA6Ohqio6Ohbt26IIoiiKIIHMcBAIDH4wGn00mvmZ+fDxkZGZCSkgLp6emQn58PbrcbGIYBhmGA4zgQBAHy8/OBZVlQqVTgdrvBbrcDy7KQmZkJDMPQqoHk+ogIkiTRYmJ6vR769esH//rXv442a9asbVUX3ZkwYcIgu90OPM9DUVERBAUFgSiK4HA4oLCwEACAvpvi4mJwu92g1WrB5XJBXl4ebN26FbZu3UoqJs5nWXa+vIAa+bzD4QC73Q4qlYoWPHK73XQsHQ4HHeOsrCxwOBwgCAKtKpifnw8AAJIkQVFREbRo0QJmz54Nd999d3ul3JYCAIBvv/2WznEiYxzHQW5uLpWtwsJC6NKlizJYsmqnJ06cAESk6ykBx3HgdDpBkiS4cOEC3Hfffbe93sCBAyEzMxMAAEwmE2RnZ4PBYIC8vDx6D41GA9evXwePxwMcx0FOTg7k5eXBqVOnYPv27fDBBx+ASqXC8PBwiIqKgtDQUEBEcDqdUFRUBEVFRZCfnw/Z2dlw7do1yM3NBQAAlUoFLMvSdZ1UcXU6nWCxWCA7OxscDgfYbDbIysqC69evg1qtBrvdDlevXoWWLVvCJ598AmFhYXPLPZA1TWNBzAzDhg3zyo9gNpupkxtRDxIP2F9++aXKn+/SpUuzFyxYgHLfC3kmRaJ5IfHmcg2FPEyIMGt5KKc8X4b89/LTJPk7eefyz5HIFPmpk9gh5aYarVaLBoOBMm95aml5fDT5W9++fW8Io63qtnDhQjQYDDTFuHwMiYc0y7LUsVOeO4WoGUuOX2mt5AlePufkmRCJDVxeL4WoY4nTb8uWLQNmAlM0FneOxoKcQOXrg1xjGB0djQBwQzHE2tyOHz9+juwT8kJ+xHePOEvPmjULb6eNRkRo0KCBl48f0ULLyzsQk6s88ICsueSzJddz+botiiKqVCq6tsrLIsjXJnniL7kTvTwihKztY8eOrZRpt0YSC9Ieeughr1BGMsFCQ0NREARqw+7Ro0e1eb7ExMR58+fPp5nOzGYzJRPy2iglK6gS72W5o5Fc2Erb0G7XiAmJeEWTDZNMNmIukPuJEIfZsLAwatclCxyZJN26davW1QJXrVrlFQZcr149miNC7mhLnomoG0uOM6nFUNJxVT7Rybsj0UF6vZ7eWxRFL9WpPJ0uuWZ4eDhu3bq12o2lQiyqlljEx8cvIdcj+Svkhykiy2azGavCib26JvEjZIDIKZlzJCCArHW9e/fGspqRR44cSZPZyf1b5FVC5fuT0WikGaRLkkJilrndwUVuMiVrNDkckmuaTCbqWE+yV5NSGJVNKFljiQXxhn/ooYe8QqrIKTAiIoK+VLVajZs2bcKq7mvJ9u9//9sruoIkkNLpdGg0GtFisdCwIbkAltROkCgMwmIJG5bb28jiL9dAlPSHII5fJHRU/jfC6klfydiSiWSz2bB3795VluyqvG3JkiX4yCOP3BAGHB0dTUkcicSQE4aSRKLk2BBCRt4FcTCWk0I5cZEvDsTpi9yrbdu2+Oeffx6vjuOnEIuqJRYbN25EeXEt8rPcmVOr1eILL7yg+FeUaKNHj/Y6sJH5L88rZLPZyjVumzdvxg4dOtCU6vJaSOT6VquVHmBKrq3yKqPyBIolDzNk3ZbLFQltJX4cDMNgcHAwyh1VBUHA+vXr+8xxvkYSi5Ib9QMPPECdmMhgljx9CoJwgzd9dclsuWvXLnzwwQcp4yRCRzQG8vdGPH3JZ8lkkC8uJTe7WzWSLIUkiCmp/icsmmyW8kyihOW3bdsWq2Nq7LJqL6xWq1fYKRlHi8XiVZuGPDcxiZDFoKRZSU4s5E6vBoMBbTYbSpKEKpWKemfzPE+dvwAAo6KicO3atdV6TirEomqJxbvvvks3KDL/GYahJmHy/9pQWKsiAQBkHpP1U+4EazQakWXZCoWar1u3jpKHyMhIqpWQa32JKaYkaZAf+sh8uhnJIKHFhDTITSfkcELWFpPJhIsXL8ab1RBRiMUtBqZNmzbUnEDU1uQFEuExGo3VujZHWlpa7JgxY2iyFnleA6JJID4WJK97aQJa0qdCbl6RC29JvwoS2UFUqWTikXTSchW+KIrYsGFDXLp0KVW1VjYcsyrTaX/99dfYqFEj6vsiLygXFBREF4vS7Ju3Mj+R68ivV9r3BEHARo0a3ZD0qrqqsRViUbXEon///l5ZWuXh6vLwe4VIlN5sNptX/g8yfiSBlkajwa+++qpC4/fHH3/El4wOIT5VZC0nRSrl/hNkn7qZz4V8fskPkkTTrNPpUBAEemCxWCy4aNEiv8gAdVghNuGSrId09E4VEJJlMy0tLbZTp040MQmZYCSMLzw8HNVqNep0OiyrqaIqs3eOGDGClhsvuSHJWSwROjlJKIu2Qq6yL+2zcvU9mXRGoxEfeeQR/OSTT/DXX3/F6jZuvpClAwcOYN++fdFoNHqljJdrNEjhIlL7hSzuJR00SxtrQvhIBjy9Xo/PPfdctXPOvF0juUzk5ILIKc/zOHTo0Fq7qfXq1esGx115qDYA4NSpUys1Pvfcc49XZkVCeuX+Od27d1eIxS1y2ZA9Qn7YItoLSZKwQ4cOlRq/7777Dp999lkvPwuyRsuJJgl1l9e+uhmpuNmhhJAWQRAwJCQEt2zZ4td3T2s6lOwQYUVkkasJwnLmzJkdjRs3pk51REjIAk4mXdOmTe+Y5z1//vz6+fPnY9euXTEiIoKeUrRaLRqNRq/oAjlhLI0wEE2GPLqEfJYIJclkShbByMhIfOWVV3DDhg148uTJI7Vl4bl06dLsrVu34sCBA+kJQG7WKG185SRMfrKQN0mSsFGjRrS67Z1qQoqKiqLriFyNTAjGiBEjau2m1r17d695VfIgp1KpcMqUKVgZzWbdunW9CjESciGPQPr6668VYnGLuh7ycZOXmCd7h1qt9sn4HT9+/NySJUuwe/fuVENB8hiRdVZOIEiendLIhNwvTh45BgA4ZMgQnybeulVjEBEAAKZNm4Y8z9PYXafTCQ6HAyRJAqfTCe+//z5TE+KU09LSxi9fvnyO2+0GnufpM5L8Cy6XCwRBgPr168OAAQPuuGdOTk6ekZWVNTQzMzM0KSkJ0tPTITc3F/Lz8+HKlStw7do1yM7OBo/HAx6PB9xuN82BwbIszVHB8zyoVCrQ6/VgtVohIiICIiMjwWQygdVqhbp16/7WtGnTTkrk+99ITU2dmJOT0+v8+fP3x8fH05wjhYWFYLfbaX4Qt9sNer2expSr1WqwWCxQt25diImJuRISErIoMjJyyp0+HvPnz8crV67QXCzyHCgAAK1atYLevXsztVFWvvnmGzx9+jSwLEtD/snYkPbggw9C586dKzQ+KSkpkz/66KPpLpeL5klhWRZ0Oh3k5+eDJEmg0WhqzJruL7z11lvocDjoumi322k+C5fLBR6PB6ZPnz7IarWu8eV9//rrr1/T0tI6xsfHw+XLlyE3NxcKCgrg2rVrkJeXB9euXQOPx0PzBKlUKlCr1aDT6ei/4eHhEB4eDiEhIRAdHb2zcePG3QI5dpRYKFCgQIECBQoUVBasMgQKFChQoECBAoVYKFCgQIECBQoUYqFAgQIFChQoUIiFAgUKFChQoECBQiwUKFCgQIECBQqxUKBAgQIFChQoxEKBAgUKFChQoBALBQoUKFCgQIEChVgoUKBAgQIFChRioUCBAgUKFChQiIUCBQoUKFCgQIFCLBQoUKBAgQIFCrFQoECBAgUKFCjEQoECBQoUKFCgEAsFChQoUKBAgQKFWChQoECBAgUKFGKhQIECBQoUKFCIhQIFChQoUKBAgUIsFChQoECBAgUKsVCgQIECBQoUKMRCgQIFChQoUKAQCwUKFChQoECBAoVYKFCgQIECBQoUYqFAgQIFChQoUIiFAgUKFChQoECBQiwUKFCgQIECBQqxUKBAgQIFChQoxEKBAgUKFChQoBCL2o7Lly9PU0ZBgRzZ2dkDlT4qUFC7kJSUNFtZ826PuLi4LytFLDIzM0f6otNZWVlDq+uARkZGTqnOL9xX76A6Iy0tbXzJ36Wnp8dW9roJCQlLKvI9q9W6JhDvoTILWWl9VBA4pKenx5ZVRjMyMkYrI1a9kZmZObJu3boTauNhISUlZXLJ9UR+4C659sXExLx46tSpI/QXiFjmlpKSMhERIT4+fknJv2VlZQ0sz7Uq2tLT00eX5XPy/pT1OzdraWlpsb7oe1xc3LJAjJG/WkZGxsg7uf83k4fU1NTxZfleaXLvi3Yz+UpPTx/9xx9/xG/duhW/+eYbXLx4Ma5duxZ//vlnjIuLW5aRkTEyMzNzKPl8YmLivKoaU1/JNnkXly9fnlzRa8jHJBBrTaDmUWXGxF/NF+u+r8b53Llz3/rjGcsqT5mZmUN9vUbK55Wv5Loi8vbNN9/grl27cOXKlfjdd9/h7eSg3Dd77bXX8N5770VfC+eMGTNQEATU6XSoUqmQ4zhkGAZFUUSVSoUAgCEhIRgTE4NhYWEYFBSEAEA/x3EcSpKELMsix3FoNptx7dq1FernhQsX1oWGhqLFYsGDBw9W+lkPHjyIwcHB2KRJE/SFcEyaNAklScILFy6sC9SicejQIYcgCAgAqFarked5ZFkWRVFESZKQ53nkeZ6+L5PJhACAJpMJly1bVqExtFqtKIoikvsCAEqShKIoIsuyqNfrUZIkDA8PR7PZjCqVClUqFWq1WtTpdCgIAqpUKuR5HnU6HTZp0qTC73LVqlVYp04dtNls6I8Nh1wzLi5u2YkTJ07369cPGYahzy2KIpV3+Vg88MADuH37dqyqjSUzM3NoWlpabEhICJpMJjx//vx6X1y3Y8eOyLIsrlu3rsLP9v7776NGo0GGYdBoNHrJpyRJKAgCCoKAoigiz/N0XN99912sDGE4f/78ekmSsFWrVugrMrBs2TI0m83Ys2dPrChhe/3119FisdDnZFmWzmMA8PpZFEUURZHKm9FoRI1GQ+eY0WhEhmHQbDbjiRMnTlekT0uXLkUAwHvuuafS8vvaa6/hPffcg++88w76gvQJgkDXEbLH6HQ6BAAUBAFbtWqFQ4cOpXuMv0jo/fffT9dck8lE9zkiszzPUxkma6Ver8c9e/b4ZE04f/78+pYtW6IoiqhWq5HjOBQEAdVqNYqiiEOGDMGzZ89uLfk9vry+B//5z38gMzMTpkyZgtOmTWN8oXaxWq1rLBbL6uDgYFCr1aDRaMDtdoPL5QKO40AQBHA6nSAIApw4cQIAANq2bQsOh4N+jmVZEAQBioqKICcnB4xGIxiNxgr1p0GDBv3T09NfAABQq9V/VVad5nA4IDMzE4KCgsBms62o7HjpdDoAAHC73QZ/qsPkqjCz2byBZdkXAAAaN24MxcXFcP369b/Z6T+aL/Ku7HY7SJIEHo8HjEYjaLXaCt1fr9eDSqUCSZLA4XCAVqsFtVoNHMdBXFwcGAwGSElJgaysLNBqtRAZGQmICMXFxcDzPHg8HuB5HpxOJzAMA2q1usJjkZubC8nJyRAUFAQhISGLfT3WISEhi0+fPn2gW7du91+5cgU8Hg+IogiCIEB0dDSwLAvFxcWg0WggLy8PUlNTQRAE2L9/P3Tv3h3q16+PU6ZMgRdffJEJpMqUyHOjRo3m7927F3bs2PFMw4YNK3XNbdu24fnz5yE6OhoeeuihSRW9jsVioTIaExMDubm5YLfbQaVSgcfjAUQEhmGAYRjweDzgcrnA5XJVeN0IDg5eCgCg0Wj+tNvtzyQkJMDjjz8+ffv27XxlzasejweuXr1a4e8LgpAhSRJoNBrQ6XSg0WjI78Hj8dD11eVyQVZWFly5cgWaNm0KTqcTrl69CgaDAXieB57nobCwkMqmwWAAvV6/tzLPplKpfKG6h6NHj8K9995bqeuwLFtExruwsBDq1KkDwcHBgIjAsizYbDZgWRZSUlLgxIkTsGbNGhg+fDgeOnToL7IupKamTgwPD5/pI5cBuhaKogghISHgdrvB4/GAx+MBAACGYbwsEIWFhaBSqZyVvfdPP/2Ezz77LDidTjCbzRAZGQkOhwOKioogPj4e9Ho9rFy5EjZt2vTk66+/jlOnTmXKZAopqSL+7LPPUKvVol6vR5vNhr5Qg5XnGgcOHMCoqChs3749VkS9Wp6m0WhQp9PhyZMnj1T2GXfu3IkAgK1bt/YJi/zggw+QZVk8cOBAwE6qFy9e/JJhGOzQoQNWJ1XsM888gwzD4FtvvYX+NIWsXr2anup8/Qzk/h06dKCnybFjx5bpPlu2bMF27dqhKIpYr169Kns3+/fvR5vNhnq9vtJ9ePjhh5FhGJw6dSoiIly6dGl2Ra4za9YsVKvV+PTTT1eoT8nJydMq+gzklMlxHH700UeVHpPFixejyWTCrl27+v0dx8bGYteuXdFfpj/SvvjiCzSbzT5ZU2JjY1GSJBw3bpxPxodhGAwLC7vttSRJQkmSEABKNRFUtoWFhaFer8evv/46oHP7r7/++tloNKIkSfjCCy/gzUwxkZGRCAA4fPhwr/7d0nkzLCxsrtzZberUqZTRFxQUwMqVK1f78lRchhPIhtTUVDhw4EC57hEWFja3vP0qKioCt9sNhYWF91T2GXmeB5VKBYIg+OSU6HA4IDw8HFwuV0AdeiRJgoSEhIDcqzTnNrlDJ3H+LSwsBI1GAzzPl/VkM7mkxqGs8qFSqcBkMtH+paSkTPbFs4aFhc2NiorCw4cPw5IlSwARmXnz5pVJ89CjRw/m0KFDzMmTJzd37NgxYI69qampE+X/b9iw4aCcnBwoKiqCzZs3Y2WuferUKRAEAR566CEAAKioA50oiuBwOCA1NTWgTtzJyckzwsLCoLi4GNRqNWzcuBGSk5NnVMbxVxRF0Ol0ZZbzygAR4eTJk6DVao/68z48zwMiwpUrVyp9LY7jwOl0gtNZ6YM6ZGZmjjSbzZCWlnbbz16/fp158803gWVZ6NGjR6Vlv+QayHEcsCzrpZXwN7KysoZ27969i9PpBJ7nYd26dcw/mhGnfB39R9aZrKysQY0aNbpRiMrSPvvsM9RoNNimTRvcsWMHSpKEFosFA+W0iYhw+vTpX4n9z9/3Ivc5cuRIdmWv9dNPP6Eoij7TWMyYMQP/fnWBY7BnzpzZAQA+OZH6srVr1w6tVivOmTPHr/368ssv0V+y17x5c5QkCV977bVqNbblbf/973+RZVns2bMnVvS0v2DBAmRZFrt06VLpsViwYAFyHIctW7YM+LgSv7AzZ87skCSpwn4bch8flmXx0UcfRX87y7/66quo0Wj8PmaffvopchyHLVq0qPS9Ro0ahQzD4BtvvIG+Wv8NBkOZr/Xoo4+iRqPBzp07+3TcWrVqhTzP43//+9+AyfCePXuoDyMJ2ChvK3O46YoVK6CoqAheffVVaNCgwXKz2Qy5ublw7Nix1YFiUoRBEx8Df8PhcIDH41FX9joejwccDgc4HA6f9QsA4NixY2mBGntEFDiOq7D92V8ICwuD7OxsvzN6lmWp1saXGDJkCJ48eRJCQ0Nh8uTJg+AOxr333vueVquF7du3V+iUBAAwefJk8Hg8MH78eJ+cvN1uN1it1oCOQ1pa2nji99W4ceNugwcPhg8++ADWrFlT4dOsy+Wifjfl1fSWF4EaM5ZlwePx+MTHgmVZQESw2+0+6RvDMFBUVFTmz0+cOBHcbjf8+uuvvtYegMvl8vm6cyt88803kJ+fD+Hh4VBRX5EyEYtdu3bhoUOHoGnTpvD444+PrV+//vApU/7WEk6aNKlG5lUgjogsyxb74lqSJAHHcXfseLAsW4SIATe/1GSsWrUKf/jhBxBFEaZNm3bH56GIiIh4v3fv3uB0OmHx4sXvlee7NpttxeHDhwsZhoEHHngA2rRp80Zl+0M24fJsEL4ybblcLurY3KdPH4iKioIxY8bAvn37KkQu5E7SNQmE/PkKvjpglGetS0xMXPjII48wgiCARqOBuLi4L321J2q1WhAEgcpyIOB0OsHtdkPjxo3p7y5evLjO58Ri2rS/82K89tprEBoa+gkAwMsvv8yo1Wo4duwYHDlyZAnUMLjdbjLAlY68cLlcYLfbfaaxqCKiladQAd9i3bp1kJGRAQMGDIDBgwczNeGZhg4dCiqVChYsWFCmz8t9aSZNmqS5du0aPP300xXyiyqJgoICkCSpUtFAFUFqaupEhmGoP0S3bt2YFi1aQEFBAfTq1QvOnj27o6o2zOoE8ky+JEu+GieyoZcFUVFRY8ieUVBQAJmZmYNIhFBlkZOT4zPfkbIiNzcXrFYrOJ1OmqCrQYMG/X1KLFJSUiYfOHAA1Go19O3b10tVO2XKFNBqtfDvf/+7Ri78LMv6TGNB1H53MNEyeDyeO1rrUp2wevVqPHjwINSrVw9ee+21hJryXF26dGGaN28ObrcbVq5cedsdQ+5Iu3v3bpAkCZ588sndvugLcd68fv16QMcgPDx8JsMwXifxzZs3M/fccw9IkgRPPfVU1wsXLqwv71pU0+YeCfUlZkZfaRp8gcLCwnJt5ikpKZNZlgWtVgsqleqyr55HkiQQBCGg77558+aQnZ0NqampXlrU8mTLvu0bfeWVV6a73W6YMGHCDTcZP348U1hYCDt27IBffvmlRunoSKy7y+WqtMaCxBwHyjfEH3A6naFkgVNQeWzYsAEKCgqgQ4cO0KpVq/o16dliY2PB6XTCpk2byvyduXPnIsuy0K9fP2jSpMnDvprDVSGvWVlZQzmOu+EgcejQIeafTKswYMCAZyqiLvel2aA6wNemHV9erzwROKtXr56OiBAdHQ0RERHv+6oPoiiC0+kMqAn6iSeeuGw2myEuLg7mzZtHB9Rms60oq8zedtZt3rwZAACefvrpBID/5QsniXFGjx4NiEg/V1NAzBZarfZEZa9FktEE+uTkY+1NEcdxNc7GW1U4dOgQMAwDTz75ZI17tgEDBjA2mw12795d5gPHnDlzwOPxwKuvvuozk5vH4wG32x2QEM0SJDzE4/GAwXDjmSQ1NZUpKiqCuLg4eOmll5YkJiYuLOuz+GMjrg6ojn5bKpWqzP06ffr0gYULF0JRURE8+OCD4CszCNHqyPeQQCAiIuL9Pn36gMVigUmTJsHBgwfx3LlzWwGgzM92S2Jxzz33oCiKsGnTJnqqKhnbvWjRIqZNmzYwf/58WLJkSY2Reo/HA2azGQoLC1tW9lqFhYUQFBR0R582BEHIEEUx4I5wNRFJSUmzMzIywOPxwH333be6Jj7jzJkzobi4GCZOnHjbz86aNQvT09Nh+PDh0LZtW5+FHRFtRaD9E8LDw2e63W7Iz88v9e+ZmZnD+vTpA99//z3861//eqWsuQ9I5suaAp7nibnZZxuwrzRUtyMVx48fj//8889x0qRJ+Pjjj99vMpng008/hU8//dSnwlZYWAiCIEBhYWHA3ktwcPDSzz//nBk3bhy0b98eunfvDlOnTn1y6tSpuGrVKiytQGSpqqOb1bcQBAG7deuGZckcCACo0+nQXznTSZElAECz2RyQPBbwT458klmN/AuyXPvkX1LXgeM4mk+f53k0Go20zkPjxo190u+pU6ciAODRo0fTAlVo6Pz58+u1Wi2t5yIfC4ZhkOd5mlOf/A7+yavvq/oRpbVevXohAODcuXP9KhP/hAr6JI/H7t27URCEgOQKqMr24IMPIgDgkiVLkGRvLfmZX3/9lc4XX99/1qxZaDKZUJIk1Ov1VB45jqOyyjAMsiyLgiCgJEmoVqvx8OHDuZW5b0pKykQyP26V/XX79u30vuvXr7/l8y9fvhy1Wi326tXL7zIzevRorFu3rt/vs2bNGlSr1diuXbtK3+uVV15BhmHKnLH2do3U3lCr1ShJEjIMg1qtlq5t5OcGDRr4JeMmaREREQgAaLFYaD0bIr83a0FBQT7tz7Zt27Bt27Z0rgAAdunSBTds2HDT+9yU/m7btg2cTidMnnzz5IIpKSmTIyIi3g8LC5vbs2fPOVu2bIHExMRFbrfb4Ktc6SXBcVxATiCCIIDFYoGePXtCixYtaPYzURRLEhDaH1J/gJzsERHUajVcunQJ3n//fZ85bwb6BGa1Wtfk5OT0cjqdEBUVBa+88gqtFSAfBzJGdrsd1Go1FBcXg8PhgIYNGz4bCA2TP+FLFTTRXNVET385Xn31VTh+/DgsX74cRo4cCTExMS+W/Mz69evB4XDA4MGDfX5/hmFAkiSIiIiAwYMHg16vB0EQ6PgTPwi3200dPTMzMyutNRFF8bLdbr9lVEFISMjili1bqt955505n332GQwbNgzCw8PxgQceKFUoiouL6XzyN4hTpb/hdrvh+vXrPpm7xMzsq3WA1D6aOXMmGI1GyMvLAxLpc/78edi6dStcunQJQkND4amnnmIyMjJGE0fktLS08b6IagL423nTaDRC3759oVWrVuB2u6kzJ8ndQXz4iCOsXq/36Xvq3r0706pVq/GXL1+evmrVKs3atWth3759sHv3bujYsSPOmzfvyj333GMtk8aiV69e2LRp0zIznx9++AElScKXXnrJb+wtISFhIamo5282LUkShoaG4rZt2yp9r507d6LRaPRZBsBp06YFVGOBiHD27NmtPM9jVFRUuZ7BnxosRITevXsjAPg986YvNRYnT548Av/UHamOpbB92Ro1aoQqlQp3795d6rg1a9YMAQD//PPP476+98yZM1GtVmP37t0DqhnKysoaSLQjZfn8gAEDUBAErFOnDiYnJ08rrSbDF198gQCATz31VI3RWMyZMwcZhsG2bdtW+l79+/dHjUaDo0aN8lnmzeDg4Jte69ixY8lhYWEoiiI++eSTeKtKqZVpwcHBaDabK1Xl19dt7969OGrUKOQ4Do1GI0ZFReFff/31c5k0Fjt37oTevXvDN998gxzHgd1uB8LCJUkCnufp79xuN9jtdtDr9cBxHGRmZo70pQOLjEk7A+W8ZLfbIT093WeRHLm5uQG1k/nhdGGoSGY7f1QC9bdGwd9o1qxZW47j0OVyQVJS0nRfepFXN7z88sswbtw4mDdvHnTu3Nnrb0uWLMGzZ89CixYtoHnz5q18fW9JkqC4uDjgfkGIWK6iQGvWrGGuXr2Ku3btgocffvi98+fPM6X5I5CKwTVFY1GvXj2QJAlycnJ8orEoKioCm83ms/7l5ube9G+tW7euk5qaClFRUfjjjz/CO++8gx9++CFT0lfBF8+Vl5cXUOfN26FDhw5Mhw4doHPnzvjaa69BYmIiDBo0qMuRI0f+J6+lfXHFihXIcRxs2LABvvrqK9BqtVBcXEzV3aIowvXr12kparvdDhqNBkRRhC1btsBnn3221E8C7wqU+jgoKAjy8vJ8Ej9MUtZWJ+GoyGJZMja/OsHfC66vk/mEhIRARkYGJCQkQPv27WusOaRnz56rx40bN2jPnj03/G3lypXgcrngrbfe8su9tVotVEUkU3mJBQDAtm3bmOjoaMzMzIRevXrh5s2bmZIbjFqt9lkhw9uR9ECMmU6no4SgskhKSgIAALPZ7JO+GY1GuufdCj/88MPOli1bdv3yyy/h+eefP+5rgmy1WsHhcFTLHCb9+vVjcnNz8eWXX4b4+HjYtGkT9unThwGQRYXIk1+sWbMGunbtCg6Hg0FEpqCggHG73Yzb7WacTidTWFjIuN1uxuVyMfn5+YzD4WCuXbvGZGZmMg6HA7Zu3YokY5ePBZ4P1CJBqmb6gsgQT+U7PR22PJtgdezbnaQZadGiBWg0Gvj666/p78rkbX2HISYm5sX+/ftDbm4uzJ8/nw7exYsX1506dQosFgv079+f8dccJpqLABOLCk2Sw4cPDyKHs9GjR2NJklRQUHDTSJM7kViQjKi+yIyakJAAQUFBPtNYlDVMuXHjxt3GjBkDly9fhv79+7eU9ccn2ahJJJAv6qn4CnKuMHLkSCY0NBRycnLg2LFj/9vzyA8kL8XevXvx559/hnvvvbdCN33ggQdg3Lhxfql74PF4AnbkdzqdPguFIhncakLmvEDmrK8IebtTNBaDBg2C/Px8+P777+HIkSO5AAC+cviqbhg2bBgA/B2CShAfH/9CQUEBDBgwwK9zmJhpAyyLxRUxJ1it1jW7du36KywsDL766ivYtWsXyuXP5XIFJD15oEwhDRs2nOQrU0hBQQFcu3YNmjdv/pcv+lZQUFBmTcrcuXOZNm3awKlTp2D48OGYnp4eGx0d/bIv+pGbmwsFBQUBl+FbgXAFgvvvvx8YhoHMzMwbiQXBokWLQKVSQYsWLQAAID09Pba8xOLChQvlLlpSRoF3BvLE/E91U5+w3zsdiCh4PJ6An/7KOrZ3WoRF//79GTLH5s2bZyCJ52oiWrZsOahOnTqQkZFB14Xjx4+DXq+HsWPHLvXXfUVRrJJaITabbQXx2C8vWrRocfdHH30E165dg1WrVtHfX7t2rUq0L/5EeHj4zIYNG0JOTg6cOHHiXHm+K9eIHz58uNDhcED9+vXBarX6JC8My7Ll0s5+8cUXl3meh23btkF8fPx8X5I8lUpVrQ+lOTk5wPM8ZGRk3EgssrOzB545c+bnb7/9FjQaDTzxxBMMANCiY7cDISDt27cHhmGgd+/eL/j6ATiOyyMhjv6GIAg0fLSyIIlg7mSCgYh8dawVQsbU3zLhD+Iyc+ZMYBgGtmzZAnv37n0PaiisVuuauXPnQlhYGDz++OMvAADs2LEDGjVqBL462ZW28RQWFoLH46kS811lNGgDBw5kli9fDhs2bKDVUIkqPBAO4IEsevXSSy+BRqOBtWvX3lVemSI/7969WwMA8M4770BxcXFTX/SLBCiU1aTfunXrOrGxsZCeng5vv/12qZ9JTU2dWN5+kDW3vBoLf7giJCcnzwAAr2rmaWlp4/Pz80GSJC/Sy8pf1MSJE7uwLAs9evQo901DQ0M/yc7OHti0adNhoih6sZfy4mZakuLi4qZ2u52q4/0xeCVfqiAIlfYscrvdIEmSz3wsPB4PaDQanxRIux2IPU2r1R5lWRYuX74M1QmiKALLsn5XFaakpIBerwer1eqza8bExGwePXo0FBQUwOuvv16hhedOQatWrTZcuXIFLl26BMnJyTPOnDkDEyZM8CuZMRqNgIhVki22svUd2rVrd7BTp07QvXt3SEhIWKJSqcBqtQZEJa7VagPm8PrYY4/9xnEc7N79d925m2nuyJ5Q2t9/+OEHsFgsUL9+/VJzpVQU169fL5dJf9y4cZM6deoEv/32G8TGxiLA31l25Rqa8u5ZgiCA0+kEi8VSbvn3BcmQr0l16tR5GwDAbrdHkd+FhYXNTUhIgIKCAnj22f+lK2LlDmP79++H4uJiiI2NvVzRyWyz2VYMHz4csrOzSY4BSElJmVxeknKzU7O8nK0//DgITCYTaDQacDqdlfbrIKddX6kxtVotFBUVQUFBQbS/Jz7DME75c/g6+YqvtEv+VnerVCooKiq6ZQhaeXHXXXf1Hjly5MF27dpBeno6jB49+v9uRe5uRwCPHTuWVl2JRcOGDZ8dMWIEICKMHTt2EsMw8PDDDw/ytzbL5XKVe5OsSHGwkrBYLJUioXfffXf7fv36QVFREbRv336ky+WC/Px8aNCgAQRgzoPRaAyIXDRt2rTTp59+CqdOnYK5c+ciKRlR0vmR7AmRkZFT5PNh+/btuG/fPnj33Xehc+fOPlMrarXacq914eHhM0ePHg0qlQo2bNgAf/31169169adcLMNvyxo1KgRaLVaSEpKqrBzd3nvuW/fPpw+fTqSZyr5d0IwsrKyhnbq1AlzcnKgQ4cO0L59++nyzRoQEUaMGIEsy2Lfvn0rnYhjz549SNI/+zIB0LFjx5JVKhVqtdqApfSubHpfRIQdO3YgAGB0dLRP+j1p0iQURRETExPnlfe7pSXfuV3LyMgYeejQIQfP8xgZGVmt0lB37doVWZbF2bNn+7VfK1asQJZl0WAw+OU+jzzyCAIATpo0Cffv349JSUkzyvrdX3/9Ffv27YsWi8Wv6dN9kWQN/kkM1rp1azqOaWlpsf6434IFCxAA8NFHHw2ozJ4+ffpXURRRkiRMSUmZWJlr3XfffchxHJrNZjQYDNilSxe/P8uIESPQarUGdMxat26NoijiW2+9hbdKLCf//4wZM5BlWWzSpInP+8qyLGo0GqxIkqtRo0YhwzC0HMbp06d/rWg/6tatiwCAP/zwQ8Dex7Jly1CSJLRarfj555+Xet8jR45kP/HEEwgAaDKZcN68eV6foz+EhYWhJEm4b98+nzxAu3bt0Gaz4ZgxYyp0vdIyNl64cGGdIAg0I1pFNsmyNoPBgBaLBS9cuLCustf6/fffC4OCgjAmJsYnYztlyhSMiIjAn376KWDCFhcXt0ytVmPz5s2xvFkI/dmvF198Ec1mMy5cuNCvY7Fx40aUJAktFovf7tO3b18EAIyIiMARI0bgd999h2fPnt1aci7ExcUtS0hIWPjDDz/gsGHDUKPRoCAI2Lp16wqRzUC2Zs2aoclkwokTJ6K/ZeXDDz9EQRCwZ8+eASfDWq3WJzUbLl++PNlkMtFaRc8884zfn2Xy5MkYGhqKgZi/pM2fPx85jkNRFNFms+HMmTMxOTl5Wknyefjw4dwVK1bgXXfdhRzHIc/zfpn7oihWuH5NcnLytPr16yPHcfj2228jeY8VuZZer0eLxYI7duwoV18qs2+dO3fu22bNmqFarUZRFLFZs2a4Zs0aPHDgAO7atQuff/551Gg0yPM86vV6XLRo0Q19A0SEN998EwEAe/To4bMXlJCQsDAsLOyG1NMVEVRCIE6fPv2rRqNBjuMCprE4ePBgpe/13XffIcdxPkuTO23aNBRFkU5EUkQJZEXBOI6j/w8JCUGr1Vrh03ZCQsLCo0ePplksFq8ibKSIEylOQwqPkYJkpGDZhx9+6Lf3RVJ6T58+3a8y8fnnn9Nn82fK+rvvvpsW5ZIkCXmep4WqBEFAhmFQpVJ5vYOIiAj89NNPq31Bs6ysrIHLly9Hnudx1apVfu/vunXrsE6dOggAGB4e7iW78vGDfwo7kfENDw/32tQq8pykyJkvniM+Pn4JIReB0L7079+/SjSTH3zwAep0OgQAVKvVyLIsWq1W1Gq1dCOLjIykBcDq1q2L48eP90s/RVEsc0r20tqmTZsQACpdXI/IrcVioWu6KIrI8zyVXSLHLMvSImH9+/dHeZHQitz7vffew5iYGDSZTKhWq70KbvI8j23btsWVK1eW+nwMydlut9uhd+/eB++++26fpQH88MMP8R9bKtx///2Vtn9dvHhx3apVq14wmUwwbtw4v8YX/sOgoVevXnNK2snKi6SkpNmbN29+Q6/Xw5AhQyrd7927d+OJEyfg6tWroFKpwOPx0JwbGo0GioqKqEMjwzDgcDhAp9MBIsJbb71V4fvPmDEDiQ2WFByTF2IjBXFcLhewLAscx0Fubi48/PDD8Nhjj/nlfW3ZsgX/+OMPePjhh6Fjx45+k4mzZ8/u2LRpU1ez2QyjRo3ye2zr1q1b8ejRo2C324Hnebh+/Tq4XC5QqVTAsiwNo2zXrh106tSJ9kdeDKm6YtasWVgZOSwrDhw4gHv37oWioiIwGAyQm5tLvdfdbjeVWafTSeWYOFxOmTKlUv37v//7P1Sr1TB27FifPGdmZubI5cuXL4mKioLnn3/er2O3Z88eTExMhMGDB1dJDPdvv/2Ge/fuBbvdDg6HAxARXC4X6PV6yM7OhvDwcOjcubNP9pSbYfbs2ejxeCq1Xq5YsQLj4uLAYrHA66+/zgCUv0DZ7NmzkfgKsSxLCz+SiEX5WkyKkQmCAPXq1YNnn33WJ+Nz/vz5b7///vteHo8HiouLoUmTJtCmTZult4ro+n/Dgp3ryNvzugAAAABJRU5ErkJggg=="
-  };
-  document.querySelectorAll("[data-logo]").forEach(function(img) {
-    img.src = assets[img.getAttribute("data-logo")];
+// Inject logo base64
+const LOGO_SRC = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABVUAAAI1CAYAAADWyRprAACqdklEQVR4nOzddXxVdQPH8e/ZJiXd+YDk2AjFwqAFpbs7RJBQujukS0RUpLsVkJZSASVUGCHd3SEx9nv+AOZGX9h2zr338369nke23W3fe++J3/nunPOzjDECAAAAAAAAADwbH7sDAAAAAAAAAIA7oVQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFlKoAAAAAAAAA4AJKVQAAAAAAAABwAaUqAAAAAAAAALiAUhUAAAAAAAAAXECpCgAAAAAAAAAuoFQFAAAAAAAAABdQqgIAAAAAAACACyhVAQAAAAAAAMAFfnYHAAAAAAAAAML6c+tWs2H9BgVt366dO3fq8uXLkjGKGSumMmXKrMBs2ZTr9deVL38+y+6s8E6WMcbuDAAAAAAAAIBmTJ9upkyapB1BO57p8SlTpVLVatVUvUYNxY0Xl4IVUYZSFQAAB7h06ZKZN2eOgp5x8IjIN3DwoAgflLdp1ZqBl43KlS+vd959J9IOtnh/n6x8hQrK/U5utznY3RG0w5w8eUL3j5eMMWH+fff/Qj+WeehxocdZ5oHvfcRjFebnhvvaA4/VAxke9XP/+733P1b43xXmZ+uhzHrg4/uLtHn4+x/MevdFeeT3P5hVj3huDz72oWwP/Wz997Me8dzCfhz75diqUaum0mfI4DbLH6QVy5ebn1es1O3gYLujQNIHH3ygD4t+FKnr0K6dO02bVq20c8fO5/r+pEmTqm+/fspfsADrOqIEpaqHC8iSxdy6ecvuGE/VpFkztWjVkg3fEwwZNNgsW7IkdEApSWHX37CrcvjPP7COP+Zrj/23nv47nuVnfvJpY9WqXdtR73G1ylXM7xs32h3D6+09eMBRy4UdVv+8yrRv11Znz5y1OwrCGDhksMqWKxdhy+fqn1eZBvXqRdSPw3OqWKmSvhjQP8K3O+fPnzdv5Xo9on+sx6lZq5a69ezhFtv9A/v3m+pVqur06dN2R0EEsCxLn7dsqSbNmrrF8ufNjh87Zlq3bCXG6c5S6IMP9M2Y7yJt/Zk2ZYrp0a27gh8o0RMmTKhcr7+uwGyBSposmXwsH128dFE7g3boz61bdfjw4Yd+ljvta+DeuKcq4Abq1qpt1q1da3eM59a0eXMKVeAxunbubKZOnmJ3DMBrzJo5U//e+NcMGzHCUfslbzFp4kQZY0z3Xj0d//q/kj69NWX6NFOtchWdOXPG7jh4QcYYDR08WDuCgsxXo792/PLnrebPm2e6d+2mq1eu2B0FUWjalCmmS6fO4T4XEBigho0aqUTJkk9cXzes32DGjhmjn1euDP3cpIkTdevWLdOn3xes64hUPnYHAPBklcpXcOtCtUWrVvq8ZQtH7cwoVOEEf//1l/mgQEEKVcAGC39coEYfN+RyLZtMnjRJ3bt0dYvX/16xqsRJEtsdBRFk6ZIlKlrkQ3Po0CG3WAa9xaVLl0zzJk1N6xYtKVS9zE+LFoUrVH19ffVZi8/146JF1tMKVUnK/U5u69vvx1jDRoxQ3LhxQz8/Y/p09f+iH+s5IhWlKuBQ586eNSWLFTNbNm+2O8pza9ehveMusaJQhRN8OXy4qViuvA4eOGB3FMBrrVi+XHVq1uJgyybuVKymz5DBmjJtOsWqB9nzzz8qW7KU1q1d6xbLoKf79ZdfTLEiH+qnRYvsjoIodu7sWdM1TKFqWZYGDRmiZp995vIxZIlSJa0p06cpTtw4oZ8b8+232rxpE+s5Ig2X/wMOdPz4cVOreg23Llw6d+2iOvXqOapQrVqpsvnj99/tjgEvdvDgQdO6RQv9ufVPu6MAkPTLunWqUrGSmT5rpqP2V95i8qRJMjKmR69ejn/9M2TMYE2eOs1Ur1pV585y/2tPcPnyZdWvU1et27YxDRs1cvwy6Kl69ehpJowbZ3cM2KRHt+66ePFi6MedunRWydKlLElasnixOXXq1EPfY1mWYsSIoYCAAGXLnj3cups1IMAaM26cqVqxkkJCQmSMUbs2bbVi1c+R/EzgrShVAYc5sH+/qVWjpk4cP253lOfWvWdP1ahV01GDUwpV2G36tGmmT89e+vfff+2OAiCMTX/8obKlSpvxkyYqXrx4jtp3eYMpkyZLklsUqxkzZbSmTJtmqlWpovPnztkdBxEgJCREA/r1V9D2IDN85JeOXwY9SdD2INPq88+1d+9eu6PAJvv37TNhz07OlStXuJNyxn43Rlu2bHniz4gXL55p/vlnql23buj3vf7661atOrXN+LF3y/qDBw5ozqzZpnzFCqzjiHBc/g84yM4dO0zlipXctlC1LEt9+n1BoQqEce7sWdOwfgPTuUNHClXAobb9/beqVa6ic2fPcomgDaZMmqxuXbq4xWufMVNGa8r0aUqYKJHdURCBFi1cqBJFi5mjR466xXLo7kaP+tpUKFuWQtXLTZ82LdzHXbp3c/lnXLp0Sb169FTnjp3Crbudu3a1wt4GYOoU5jBA5KBUBRxi8+bNbn3mg2VZ6j9wgCpXqeKoQrVKxUoUqrDNyhUrTNEPPwo3GykAZ9q9a5eqVKqsEydOUKrYYMqkyeraubNbvPaZMmWyJk+bqoQJE9odBRFo186dKlOypNb/9ptbLIfu6OiRo6ZKxUpm0IABun37tt1xYLO5s+eE/ts/a1Zlz5HjiceR1WvWUJ16dVWxUiWlSJky3NdmTJumfXv3hVt3i5coGfrvv/78U//s3s26jQhHqQo4wC/r1pk6NWrqymX3nOnSx8dHg4cOVbkKzrqkokrFSmbTH3/YHQNeqlP7DuaTBh+77R9KAG90YP9+ValYUYcPH+bAywZTJ09xm2I1c+bMFKse6OLFi6pdo6bGjvneLZZDdzJ39mxTomhRMTaHJP3zzz8m7L1US5cp/dTv6dGrl9W5a1friwH9rXW//WrlypUr9GvGGM2fNzfc48uULRPu482bNr1QZuBRKFUBmy1dvMR8XK++214W7Ovrq2FfjlCpMqUpVAFJW7dsNYXy5Tczpk+3OwqA53Ds6DFVqVBRe/fspVSxgVsVq1myWJOmTlGCBAnsjoIIFBISor69e6vV5y3cYjl0ugsXLpgmjRqbtq3b6OrVq3bHgUPsCAoK93GOnDld/hnlKpQP93HYklaS3njzTcuy/jtEDQra4fLvAJ6GUhWw0ZxZs02zJk3c9vKXl156SV+OGqVixYtTqAKShg0ZaipXqKBDhw7ZHQXACzh9+rSqVa6snTt2UKrYYOrkKerSqZNbvPZZ/P0pVj3UD/Pnq0yJkub48eNusSw60ZrVa0yxIh9q6ZIldkeBw+zasTPcx5mzZHH5Z5w4cTLcx8mSJXvoMf/73/9C/71zB6UqIh6lKmCTCePGmXZt2igkJMTuKM8lWrRoGvXNaBX5sIijCtXKFSpSqCLKHdi/35QrXcaMHDHCbddpAOGdP39e1atU1Z9bt1Ko2GDalKluU6z6Z81qTZo6RfHjx7c7CiLY9u3bVaZkKf2+caNbLItO0r1LV1O/Th2dOXPG7ihwoAsXL4T+O1r0aEqQIIFLx5QrV6wwE8aPD/3YsiwV+fDDhx6XPEXy0H9fvHDhoa8DL4pSFbDBiGHDTK8ePe2O8dyiR4+ub8Z8pwIFCzquUOVeOYhqUydPMSWLFdfff/1ldxQAEezy5cuqVb2GNm7YQKFig2lTpj40o7NTUax6rvPnzqlmteqaNHGiWyyLdtu+bZspUqiQmTxpkt1R4GB3gu+E/tvP1++Zviff+++b/O/nMa/lyGE+afCxrl75bz6ST5s2VeYsWR46NvUN87OD7wS/SGTgkShVgSjWu2dPM2LYcLtjPLcYMWJozLixypM3L4UqvNrZM2dM/bp1TdfOnXXjxg274wCIJNevX1e92nW0ZvUaChUbTJ/qPsVq1oAAa+KUKYoXL57dURDB7ty5ox5du6ldmzZusSza5asvR5oKZctp/779dkeBw7300kuh/75169Yzfc+xo8d09OjRcJM7+/n5qd+AAWrRquUjj03D/uyXXor2vHGBx6JUBaJQuzZtzPix4+yO8dxixYqlsRPG651336VQhVdbtnSZKVrkQ61ZtdruKACiwM2bN9Xo44+1dPGSxxYqCRMmdNS+0ZNMnzpVnTt0dIsyKyCQYtWTzZk1W+VKlzEnT550i+Uxqhw+fNhUKlfeDB08WMHBnA2Ip0ueIkXov4ODg3X82LGnrlNJkiRR0qRJw21fg4ODlSRp0sd+z6GDB//7ncmTP/ZxwPOiVAWiSJNGjc2cWbPtjvHcYseOrXGTJuqtt9921EFjpfIVKFQRpdq3bWs+/eQTXeC+TIBXuX37tpo1aaL58+Y98sDv/PnzlCyRaPq0aW5TrAZmC7QmTJmsuHHj2h0FkeDvv/5SmZIltXnTJrdYHiPbrBkzTcmixbRlyxa7o8CNBAQGhPt49+7dT/2e9X/8bv32+0Zr2coVihkzZujn+3/xxSMff/HiRRP2nr6B2QKfMy3weJSqQBSoU7OWcedZL+PEjaMJkyfp9ddfd1yhumXzZrtjwEts3rzZFMiT18yeOcvuKABsEhISojYtW2n61KmUKTaYPm2aOrXv4BavfbZs2ayJFKse6+yZs6pepaqmTZniFstjZDh//rxp3LCh6dCuna5du2Z3HLiZwMDwBefGDRuf+XsTJU5s1ahVK/Tjf3bv1uyZsx5aF39/4GcGBmZzNSbwVJSqQCSrVL6C+WXdOrtjPLf48eNr0tSpyvnqqxSq8FpDBg0yVStW0pEjR+yOAsBmxhh17thJY8d877Vlip1mTJ/uPsVq9uzWxCmTFSduHLujIBIEBwerS6fObnPP34i0+udVptiHH2r5suV2R4GbSpkqlZU+Q/rQj3+cP9+l72/Y6BO9/PLLoR8PHTz4ocfMmf3fVaK+vr565913XQ8KPAWlKhBJzp09a0oWK+bWxV/ChAk1edpUZcuWjUIVXmnf3n2mTImSZtTIrxQSEmJ3HAAO0rd3b40cMcLryhQncLtidfJkxY5Dseqppk+dqkrlypszp8+4xTL5orp27mwa1Kuns2fO2h0Fbq5K1Wqh/z59+rQWLVz4zOtQggQJrFp1aod+fOrUKY0a+VXo9x86dMisWb069OsfFC6sJEmTOOqYFp6BUhWIBMePHzeVK1bSzh077Y7y3BInSawpM6bLP2tWR+18KpUrT6GKKDFxwgRTqnhxbd++3e4oABxq2JCh6v9FP68oUpzGnYrV7DlyWBMnT6JY9WBbtmxR6RIl9OfWrW6xTD6Pv//6y3xQoKCZOnmK3VHgIcpVKK9o0aOFfty3V+9wX0+WPLnSpEkT+r8HNWjYUBkzZgz9+pLFP4V+rVvnLuEmTates0YkPANA8rM7AOBpDuzfb2rVqKkTx4/bHeW5JU2aVJOnTVX6DBmcV6hyE3xEstOnT5t2rdto3dq1dkcB4Aa+++Yb/Xv9umn2WXO7o3idGdOnyxhj+vbv56jxyqPkyJnTmjBpoqldo6auXr1qdxxEgtOnT6ta5Srq0auXqVi5kuOXSVd8OXy4GTniS925c8fuKPAg8ePHt5o0bWbuX7p/6tQpfda0mRk+8ktLkr4c9dUT16N48eJZS1Y8fAuK778bE+72ewULFdK7773nUesknIMzVYEItHPHDlO5YiW3LlRTpEihqTNnUKjCKy1ZvNgUK/IhhSoAl0yeNEmdOnS0O4ZXmjljhjq2a+8WZwfmfPVVa/ykiYodO7bdURBJbt26pQ7t2ql7l65usUw+zcGDB02FsmXN8KHDKFQRKZo0a2qFnbRq0cKF6tC23XOvP1MnTzFf9OkT+nHcuHHV+4u+LxYSeAJKVSCCbN682VSrUkXnz52zO8pzS5U6labNnKl06dJRqMLrtGnV2jRt/KkuXrxodxQAbmjFciZsscvMGTNe6CA8Kr362mvWuIkUq55u8qRJqlqpsjl39qxbLJePMn3aNFOyaDH9ufVPu6PAww0ZPlwJEyYM/XjWzJkqX6asObB//zOvP5cuXTItPvvMdO3cOfRzvr6+6j9ooJImTeqoY1t4FkpVIAKsW7vW1K5eQ1cuX7E7ynP73//+p2kzZih1mtSO2ulULFeOQhWRatMff5h8779v5s2ZY3cUAMBzmjVzptsUq6/les0aO2FCuJmr4Xn++P13lSlZStu3bXOL5fK+c2fPmob1G5jOHTrq33//tTsOvECGjBmsiVMmK378+KGf++vPP1W0yIf6rGkzs2H9hseuQ7t27jS9evQ0+fPk0YIffgz9vK+vr0aMHKnCRYo46tgWnod7qgIvaMnixaZF8890+/Ztu6M8t3SvvKLJ06YqefLkjtrpVCxXzmzdstXuGPBgA/v3N9+O/kbGuNXxDgDgEWbNnCkjY/oNGOCo8cyj5Ho9lzV24gRTr1ZtXbt2ze44iCQnTpxQpQoV1OeLL0zZcuUcv1yuXLHCdGjX3q2vvIN78s+a1Zo6c4Zp0fwz7d61S5IUHBysRQsXatHChfLz8zMZMmZUsmRJZfn46NLFi9q9a/cji//ESRKr/8BBypc/n+PXObg/zlQFXsDsmbNM8yZN3bpQzZgxo6bNmEGhCq+yZ88eU7JYMfPN16MpVAHAg8yeOUvt27Z1iw3766+/bo2dMF6xYsWyOwoi0a2bt9SmZSv17tnT0ctlp/YdzCcNPqZQhW0yZ85sLVqy2Pq0aVO99NJL4b4WHBys3bt2ae2atVqzarX+3PrnIwvV0mXKaOmKFRSqiDKUqsBzGj92rGnftq1CQkLsjvLcsvj7a8qM6UqSNImjdjoUqohM48eONaVLlNDOHTvtjgIAiARuVay+8QbFqpcYP3acalStZi5cuOCoZXPrlq2mUL78Zsb06XZHASRJLVu3sn5Z/5tatm6tlKlSPfXxcePGVd369bT855UaPGyoFS9ePEcd28Kzcfk/8BxGDBtmRgwbbneMFxIQGKAJkycrQYIEjtrpVChb1nBDfESGkydPmratWuu3X3+1OwoAIJLNnjlLktziVgBvvPmm9f34caZ+nbq6fv263XEQiTasX68yJUvq62++NQGBAbYvm8OGDDWjRo5065NE4JkSJU5sfdq0iT5t2kRHjhwxQdu3a9fOXbp8+bJMSIhivRxLGTNlUrbs2ZUpUybb1yV4L0pVwEW9e/Y048eOszvGC8meI4fGT5oop/0Vj0IVkWXRwoWmS8dOunz5st1RAABRZPbMWTLGmP4DBzpqvPMob771ljVm3FhTv05dJgfycMeOHlOl8uXVb8AAU6JUSVuWzQP795tWLVrq77/+suPXAy5JkyaNlSZNGn1UtKjdUYCHcPk/4IJ2bdq4faH6Wq7XNO/HHxx3WQSFKiJLq89bmM+aNqNQBQAvNGfWbLVr08ZRl1s/zltvv22NGTdWMWPGtDsKItmNGzf0efPm6tf3iyhfNqdOnmJKFitOoQoAEYBSFXhGTRo1NnNmzbY7xgt54803NWvuXEeVqZJUvgyFKiLehvUbTJ533zM/zJ9vdxQAgI3mzJqttq1bu0Wx+nbu3NaYcWMVI0YMu6MgCoz59lvVqVnLXLp0KdKXz7Nnzpj6deuarp0768aNG5H96wDAK3D5P/AM6tSsZX5Zt87uGC8k9zu5NXnaNEcWqn/9+afdMeBh+vX9wnz/3Xcyxi2OoQEAkWzu7DmSZAYMGuS4sdCD3s6d21q1dq1p17aNbt64IcuyJN2NbVlW6P/Cfywp7Of0qMfc//ju/91/3ON+riyF/5we9Zi7v9t6yu9WmN9tPfC7T585rWVLlkbWy+l4v6xbp7IlS2n0d9+azFmyRMryuXzZMtOxXXtduHAhMn48AHgtSlXgKSqVr2C2bN5sd4wX8t7772vC5EmOO4igUEVk2L9vnxnz7bd2xwAAOMzc2XNkjMzAwc4vVpMkTWKNHT/e7hhRZuGCBaZT+w66du2a3VFscfjwYVUoW04DBg8yHxUtGuHLZ+OGn0T0jwQAiMv/gcc6d/asKVmsmNsXqvkK5KdQhVfZuXOn3REAAA41b84ctWnlHrcC8CYlSpa0fli4QFkDstodxTbXr19X08af2h0DAOACSlXgEY4fO2YqV6yknTvcu5z5oHBhfT9unOMK1XKly1CoItJwyT8A4EkoVp0p3SuvWAt++smqWr2a3VFsNW/uXJZNAHATlKrAAw7s328qV6ykgwcO2B3lhXxUtKhGf/etIwtVZhtFpOJQBADwFPPmzFGblq3YYzhQrz59rGEjRujll1+2OwoAAE9EqQqEsSNoh6lcsZJOHD9ud5QXUqJUSY38ehSFKrxSSEiI3REAAG5g3ty5FKsOVaLU3dsB+Gf13tsBAACcj1IVuGfz5s2metUqOn/unN1RXkjZcuU0bMQIClV4LcOpqgCAZ0Sx6lzpXnnFWrj4J6tKNe++HQAAwLkoVQFJ69auNbWr19CVy1fsjvJCKlaqpIFDBjuuUC1bqjSFKqIM91QFALhi3ty5at2iJTsPh+rdt481dPhwxYoVy+4oAACEQ6kKr7dk8WLTsH4D3bhxw+4oL6Rq9Wr6YkB/RxWqly9dNmVLlTbb/v7b7ijwIpSqAABXzZ83j2LVwUqWLmX9sHCBsvj72x0FAIBQlKrwarNnzjLNmzTV7du37Y7yQmrVqaNeffo4rlCtXbOmKFQR1ShVAQDPY/68eWr1eQt2Ig71Svr01qIli60qVavaHQUAAEmUqvBi48eONe3btnX7SW0afPyxunbv5qhCVZIoVGEXE8LxMADg+fwwf77OnjnDjsTBen/R1xoybBi3AwAA2M7P7gCAHUYMG2ZGDBtud4wX1rjJp2rVpo3jClVJXlWoFi9RQu/nyWN3jFA3b95U965d7Y5hG287U/WNN99UmbJl5OvrHrv0sd9/rz3//GN3DDxFqtSp1LRZc7tjhDIymjBuvHbv2mV3lCiROElitWrdxu4Yofbt3asx331nd4woE7Q9SPkK5Lc7Bp6gVJnSVrbs2UzTT5von9277Y4DB0mYMKGaftZcMWPEtDvKM/n99981b84cu2MAeE7ucQQGRKBePXqaCePG2R3jhTX//DM1//xzRxaqZ057zxkeZcuX18DBgxz3PnTv2tVr3oMHeUupmjJVKvX5oq/y5M3ruOXvSRb/tMhQqjpfwoSJVLFyJUctW4WLFDE1qlbzimI1bty4jnv9EydJYvr17Wt3DCBU+gwZrJ+WLlGn9h3MjOnT7Y4DB8iWPbtGfTNaKVOmdNT280mMjKFUBdwXl//Dq7Rt3dojCtWWrVs7tlD1JuUqOLNQ9XZGnl+q5siZU3Pnz3O7QhV4EQkSJLAmT5sq/6xZ7Y7ilRo0/Njq0KmT3TGAh/Tp94U1eNhQbgfg5cqWL6/5C3603KlQBeD+KFXhNT5t1MjMne3+fwVs17GDPm3ahMGCzcpVKK8BgyhUncjTz1T9qGhRzf1hvpU4SRKWP3idBAkSWJOmTqFYtUn9jxtQrMKRSpcpY81f8KMyZ8lidxTHuXzpskcPjPz8/NStZw9OdABgC0pVeIU6NWuZZUuW2h3jhXXp1lUfN2zIgMFm5StWoFB1MOPmk889ScNGjTTy61Ese/Bq94vVrAEUq3ao/3EDq2PnznbHAB5y73YAVqXKle2O4iiefAVPosSJNWnqFNWsVYuxEQBbUKrCo12+dNlUKlfe/LJund1RXliPXr1Uu25dBgw2K1+xgvoPHMj74GCeeKaqr6+v+vT7Qm3bt2PZA3S3WJ04hWLVLvUa1KdYhWP17d/PGjhksGLGdI+JiiKbJ46LpLu3Qvph4QK9+dZbjI0A2IZSFR7r3NmzplqVKtqyZYvdUV6IZVnq27+fqteswYDBZhUqVaRQdQOeduwQM2ZMfTf2e1WuUoVlDwjj7hmrUylWbVKvQX2rU5cudscAHqlsuXLW/AULlClzZruj2M4TS9UKlSpq7g/zreTJkzM2AmArSlV4pOPHjpnKFStp186ddkd5IT4+Puo/aKAqVa7MgMFmFSpVVL8BA3gf3IAnHTzEixdPE6dMUd58+Vj2gEeIHz8+xaqN6tavR7EKx8qQMYO1eNlSq0SpknZHsVWIB90Wyc/PTz1792ZMDsAxKFXhcQ7s328qV6ykgwcO2B3lhfj6+mrw0KEqV748gwabUai6F08pVZMmTapps2bqtVyvsewBT3C/WA0IDLA7ileiWIXTlS5Txu4I9vKQcVHiJIk1Zfo0VatRnXERAMegVIVH2RG0w1SuWEknjh+3O8oL8fPz07AvR6hk6VIMGmxGoep+QoxnnJGRJEkS3bxxw+4YgFuIHz++NXHKFIpVm1CsAs7lKX9sNkbav2+/3TEAIBw/uwMAEWXz5s2mQd26unL5it1RXshLL72kEV+NVOEiRSjybFaxUiV9MaA/74Ob8ZSDh6CgIJUrXUYVKlY0rdu2UaLEiT1iWRw7YYJHPA84z71i1dSuXkNBQUF2x/E6devXsyxLpnfPXnZHAcLxlHHB8/KUp3/u7Fl1aNdOUyZPNl27d1eu13N5xHiiUuXKVqXKle2OAeA5caYqPMLaNWtM7eo13L5QjRYtmr7+5hsKVQegUHVjnnL0oLsHgrNmzlSh/AU05tvvPOeJAZEkfvz41sSpUxQYGGh3FK9Up149q3NXzlgFnMRTruC5b/u2bapUvrxafd7CnDp1irERAFtRqsLtLf7pJ/NJg491w80vk40ePbq+GfOd8hcsQJFns0qVK1OoujFPPCPl6tWr6te3rwoXLGTWrFrteU8QiEDx4sWjWLVRnXr1rC7dutodA8A9njgukqQf5s/XB/kLaNTIrzzzCQJwC5SqcGuzZ84ynzVtptu3b9sd5YXEjBlTY8aNU568eSnybFapcmX17d+P98GNeeixgyTpwP79ql+3rhrUrWcOHjjgwc8UeDEUq/aqXbcuxSrgEJ5aqkrSv//+qyGDBqlAnrxm2dJlnvtEATgWpSrc1rjvx5r2bdsqJMS9L2mJFSuWxk4Yr3fefYciz2YUqp7B3bcJz2L1qlUqWuRD9ev7BQcQwGNQrNqrdt26Vpfu3eyOAXh0qfgsvOH5HzlyRJ9+8olqVa9h9uzZ4/lPGIBjUKrCLQ0fOsz06eX+EyHEjhNH4ydN0ptvvUWRZ7PKVapQqHoIbzh4kKTbt29rzLff6u033jSzZ87yjicNuOh+sZotWza7o3il2nXqUKwCdvOScZEk/fbrryrxUVH17N7DXL502XueOADbUKrC7fTq0dN8OXy43TFeWNy4cTVx8iSPmbnSnVWuUkV9+n3B++AhjLxrDH3u7Fm1b9tWZUuVNlu3bPWuJw88g3jx4lkTpkymWLVJ7Tp1rK49utsdA/BaISHeNTS4c+eOJo4fr0L582vq5Cne9eQBRDlKVbiVtq1bmwnjxtkd44XFjx9fk6ZOVY6cOSnybGZZFoWqp/GiMzLC2vb336pYrpxat2hpTp8+7Z0vAvAY8eLFszp07mR3DK9Vq3Ztq12H9nbHgJfylitYHsfb/th834ULF9S1c2eVKFrM/L5xo3e+CAAiHaUq3ManjRqZubPn2B3jhSVMmFBTpk9TYLZAijwHsCzeBk/j7QdP8+fN0wf5C2j0qK+9+4UAHuDjw7DXTu++977dEQCv5O3jol07d6pa5Spq3qSpOX7smHe/GAAiHKNLuIU6NWuZZUuW2h3jhSVOklhTZkxXFn9/mjwgknjbZW6Pcv36dQ0aMEAF8+Yzy5cxGy4AAN7K20vV+35atEiFCxbSiGHDeEEARBhKVTja5UuXTaVy5c0v69bZHeWFJUuWTNNmzFCmTJkoVIFIxMHDfw4fPqzGDT9RnZq1zN49e3lhAABex9vHBSYkxO4IjnHz5k2NGDZced59zyxauNC7FwwAEYJSFY5WrUoVbdmyxe4YLyxFypSaOnOGXkmfnkIViGTefvD0KL+sW6fiH32kXj16MhsuAABehHHRw04cP67PmjZTtcpVzM4dO3iBADw3SlU40vFjx8wHBQqaXTt32h3lhaVKnUrTZsxQ2rRpKVSBKMDBw6PduXNHE8aN0wcFCmj61Km8SAAAeAHGRY/3+8aNKl2ipLp06mQuXLjACwXAZZSqcJz9+/aZyhUq6uCBA3ZHeWFp06bVtJkzlTpNagpVIMowJn6S8+fPq3PHTipVvLjZuGEDLxYAwGNt2bzFzJ87z+4YtqJTfbKQkBBNmzJVhfLl1/ixY3m1ALiEUhWOsiNoh6lSqbJOnDhhd5QX9kr69Jo6c4ZSpkxJoQpEoRDuHfZMdgTtUPUqVfVpo0bm0KFDHEQAADzC3j17zZBBg0z+9/OYSuXLa+mSJXZHshVnqj6by5cvq3fPXipcsJD5eeVKXjQAz4RSFY6xedMmU61KFZ0/d87uKC8sU6ZMmjZjupIlS0ahCkQxDh5cs2zJUn30QWH169OXFw4A4JZOnjxpxnz7nSlVvLj5qHBhjRr5lY4ePWp3LEcIMfyx2RUH9u9Xw/oNVKt6DbN71y7GRgCeiFIVjvDH77+rdo2aunrlit1RXlgWf39Nnj5NiZMkoVAFbECn6rrbt29rzHff6a1cr5spkybzCgIAHO/ypctm5owZpkbVqibPO++qX9++2hG0w+5YzsPA6Ln89uuvKlmsuDp36GjOnT3LiwjgkShV4Qi/b9yoGzdu2B3jhQUGBmrK9GlKlCgRhSpgE85UfX7nz59Xty5dVLRwEbNu7VpeSACA4yxZvNg0/uQTk/vNN9WxXXttWL+Bff8T8No8v5CQEE2fNk2F8hfQt6NH80ICeAilKhBBcuTMqUlTpyp+/PgUqoCNOHh4cXv27FHdWrVVv25ds2/vPl5QAICtfvv1V9O+bVvzavYcpmnjT7V86TLdunXL7lhuwdfXz+4Ibu/q1asa0K+/8r+fxyz+6SfGRQBCUaoCESBXrlya+8N8K268uBSqgM1atGpppUiZ0u4YHmHNqtUq9uGH6tG1m7lw4QIHEQCAKLN9+3bTt3dv8+5bb5ta1Wto9sxZHnGrsKiWMVNG6/08eeyO4RGOHj2qZp82UZWKlcz2bdsYFwGgVAVe1BtvvqmZc+dQpgIOsu63X61mn32maNGj2R3F7d25c0eTJk5UoXz5NXbM9xxAAAAizeHDh83IESNMkUKFTJkSJTV2zPc6ffq03bHc3vhJE62vv/1GqVOntjuKR9j0xx8qU7KU2rRqbU6dOsXYCPBilKrAC8j9zjuaPmsmhSrgQJ+1+NxatmKlinz0od1RPMLly5fVt3dvFcpfwKxYvpwDCABAhDh39qyZOGGCqVC2rCmYN5+GDRmq/fv22x3L4xQuUsRa/cs6q0WrlooRI4bdcTzCvDlz9EH+Avpy+HDGRYCXolQFnlOevHk1edpUClXAwVKnSW2NGj3amjB5kjJmzGh3HI9w6OBBNfq4oWpUrWZ27tjBQQQA4LnMnzfP1Ktd27z7dm717NZdf2790+5IXqFJs2bWsp9XqniJEnZH8Qj//vuvhg8dpvdzv2Pmz5vHuAjwMpSqwHPIX6CAxk2cQKEKuIn33n/fWrJiudWpSxfFjhPH7jgeYcP69SpVvIQ6tmtvzp45w0EEAOCpfl650nzWrJnJ5p/VtG7RUmvXrNWdO3fsjuV1UqZMaQ0f+aU1edo0Zc6Sxe44HuHkyZNq3aKlypUuYzZv3sy4CPASlKqAiwoXKawx48ZSqAJuqG79etbKVT+rQqWKdkfxCMYYzZwxQ4XyF9DXX43iAAIA8JBNf/xhunTqZN549TXTsH4DLVqwUDdu3LA7FiTlfie39dPSJVa3nj0UN25cu+N4hL//+kuVy1fQZ02bmWNHjzI2AjwcpSrggqLFiunrb7+lUAXcWKLEia1+AwZYc3+Yr5yvvmp3HI9w7do1DR44UPnef98sWriQAwgA8HL//POPGTRggMn73vumSsVKmjZlqi5evGh3LDxGzVq1rBWrV6lq9WqyLA51IsKihQtVuFAhDRowgHER4MEoVYFnVLJ0KX056itGGYCHyJEzpzVn/jxrwKCBSpQ4sd1xPMKxo8f0WdNmqlS+gvn7r784iAAAL3L8+HHz7ejRpvhHRU2xIh9q9KivdfzYMbtj4RklTJjQ6tWnjzV/wQLlev11u+N4hFs3b2n0qK/19htvmhnTpzMuAjwQpSrwDMqWK6ehw4dTqAIeqFyFCtbGTX9Y9T9uID8/P7vjeIQtmzerXOkyavV5C3PixAkOIgDAQ126dMlMnzrVVKtcxeR99z0N6Ndfu3ftsjsWXkBgtkBr5pzZ1pBhw5Q0aVK743iEc2fPqlP7DipRtJhZ/9tvjIsAD0KpCjxFpcqVNXDIYApVwMN16NTJWrRkid7Pk8fuKB7jh/nzVbhAQQ0bMpQDCADwID8tWmQafdzQ5H7jTXXu2Em/b9xodyREsFJlSlu//b7R+qRxI7300kt2x/EIu3buVM1q1dXo44bm4IEDjI0AD0CpCjxB9Zo11Ld/PwpVwEtkyJjBGj9povX1t98oderUdsfxCDdu3NDIESP07ltvm7mzZ3MAAQBu6pd160ybVq1NzsBspnmTplqxfLlu375tdyxEsjbt2lmLly9T/gIF7I7iMVYsX66PChdRn169zOVLlxkbAW6MUhV4jDr16qpHr14UqoAXKlykiLX6l3VWi1atFCNGDLvjeITTp0+rbes2KlOylNn0xx8cQACAG/j7r79M7549Te433zR1atbSvDlzdO3aNbtjIYqlS5fOGjNurDVm7FilTZfO7jgeITg4WOO+H6uC+fJp4oQJjIsAN0WpCjxCg4YN1blrVwpVwMs1adbUWvbzShUvUcLuKB5j+7ZtqlKxkpo2/tQcOXKEgwgAcJiDBw+aEcOGmQ8KFDTlSpfR+LHjdPbMWbtjwQHyFyxgrVy9ymrbvp1ixYpldxyPcPHiRfXs1l0ffvCBWf3zKsZFgJuhVAUe8GnTJmrfsQOFKgBJUsqUKa3hI7+0pkyfpiz+/nbH8RhLFi/Wh4U+0KABAziAAACbnT1zxowfO9aULVXafJC/gEYMG66DBw7YHQsO1bBRI2v5qp9VukwZu6N4jH1796lBvXqqV7u22bd3H2MjwE1QqgJhfNbic7Vs3ZpCFcBD3s6d21q0ZLHVrWcPxY0b1+44HuHWrVsaPeprvfvW22be3LkcQABAFJs7e7apU7OWefft3Ords5e2/f233ZHgJpIlS2YNHjbUmjF7lgICA+yO4zHWrlmr4h99pD69ejEuAtwApSpwT6s2bdTss88oVAE8Uc1atayVa1aravVqsiw2GRHh9OnTatOylSqULWv+/usvDiIAIBKtWL7cNG/S1ARm8TdtW7fRL+vWKSQkxO5YcFOvv/GG9eOiRVbvvn2UIEECu+N4hPv3W33r9TfMjOnTGRcBDkapCkhq37GjGjf5lHYEwDNJkCCB1atPH+uHhQv1+htv2B3HY/y59U+VK11GbVu3NmdOn+EgAgAiyO8bN5rOHTqa13O+ahp93FA/LVqkmzdv2h0LHqRKtWrWitWrVKt2bfn4UDNEhPPnzqlT+w4qXbwEk3wCDsXWDl6vS/duatDwYwpVAC4LCAywZsyeZQ0ZNkxJkya1O47HmDt7jj4oUEDfffMNBxAA8Jx27dxpBvTrb/K8+56pVrmKpk+bpkuXLtkdCx4sXrx4Vtce3a0FPy3S27nftjuOxwgKClKVipX0efPm5sSJE4yNAAehVIVX69Wnt2rXqUOhCuCFlCpT2vrt941Wo08b66WXXrI7jke4du2a+n/RT4XyFzA/r1zJAQQAPINjR4+a0aO+NkWLfGhKFC2mb0eP1onjx+2OBS+Txd/fmjJ9ujXiq5FKkSKF3XE8xsIfF6hwgYIaOWIE4yLAIShV4ZUsy1K/AQNUtXp1ClUAEaZ127bW4uXLVKBgQbujeIxDBw+qYf0GzIYLAI9x4cIFM3XyFFO5QkWT7/08GjRggPb884/dsQAVK17cWrf+N6tJs2aKFj2a3XE8wo0bNzRsyFDle/99s2TxYsZFgM0oVeF1fHx8NHDIYFWoVJFCFUCES5cunfXd2O+tMWPHKm26dHbH8RjMhgsA4S38cYH5uF59886bb6lr587avGmT3ZGAR2rRqqW1dMUKFf6wiN1RPMaxo8fUtPGnqlG1qtm9axdjI8AmlKrwKr6+vhoybJjKlC1LoQogUuUvWMBauXqV1bZ9O8WKFcvuOB6B2XABeLs1q9eY1i1amhwBgebz5s216uefFRwcbHcs4KnSpEljff3NN9b4SROVPkN6u+N4jA3rN6hkseLq2rmzuXDhAmMjIIpRqsJr+Pn5afjIL1WiVEkKVQBRpmGjRtaK1atUpmxZu6N4DGbDBeBN/ty61fTs1t289fobpn6dOpo/b56uX79udyzgubyfJ4+1bOVKq2PnzoodO7bdcTxCSEiIpk6eokL58mvihAmMi4AoRKkKr1GrTm19VLQohSqAKJc0aVJr0NAh1ow5sxUYGGh3HI/BbLgAPNX+ffvM0MFDTMG8+UyFsuU0ccIEnT93zu5YQISp16C+tWLVzypfsYLdUTzG5cuX1bNbdxUt8qH57ddfGRcBUYBSFV5j7Jjv1bTxp+bkyZPsYADY4vXXX7d+WLTQ6v1FXyVIkMDuOB6D2XABeILTp0+bsWO+N2VKlDRFCn2gr778UocPH7Y7FhBpEidJYvUfONCaM3+ecuTMaXccj7Hnn39Uq3oNNf7kE3PkyBHGRkAkolSFV1myeLE+LPSBxo8dy84FgG2qVK1qrVy9WrXq1JGPD7viiMBsuADc1eyZs0zNatXNe2/nVt/evbV9+3a7IwFRKuerr1pzf5hv9R84UIkSJ7Y7jsdYvnSZPiz0gQYPHMi4CIgkHMnB61y7dk29e/ZSqeLFzV9//skOBoAt4saLa3Xt3s1auPgn5X4nt91xPMb92XDr1KxlDuzfzzYegCMtW7LUNG38qQnIksW0b9tW63/7TcawyYJ3K1+xgrVx0x9WvQb15efnZ3ccj3Dr1i19/dUo5XnnXbN08RI2MkAEo1SF19oRtEMVypZTty5d2LkAsE3mLFmsydOmWV+O+kopUqa0O47H+GXdOhX78CMNGTSIbTwAR9iwfoPp2K69eS1HDvNpo0Zasnixbt28ZXcswHE6du5sLVy8WO+9/77dUTzGiRMn1KRxY9WtVdscPHiQsREQQShV4dWMMZoyabJyv/mmWfDDj+xcANimaLFi1rrffrWaNm+uaNGj2R3HI9y+fVujRn6lvO+9b5YvW8Y2HoBtmn3axNSoWlUzZ8zQlctX7I4DOF7GTBmtCZMnWaO++UapU6e2O47HWLd2rYoV+VBDBw9hXAREAEpVQNLZM2fV4rPPVKt6DXPwwAF2MABs83nLFtayFStV+MMidkfxGMePHVPjhp+oQd165vDhw2zjAUS5U6dO2R0BcEtFPixirf5lndWiVUvFiBHD7jge4datW/rqyy+V//08ZuWKFYyLgBdAqQqE8duvv6rYhx9pxLBh7FwA2CZ1mtTW1998Y42fNFEZMmawO47HWL1qlT4qXJhtPIAox6SEwItp0qyZtWzlChUrXtzuKB7j6NGj+qTBx2pYv4E5cuQIYyPgObB3Bx5w69YtjRg2XIXyFzC//vILOxcAtnk/Tx5r6YoVVsfOnRU7dmy743iEWzfvbuML5s1n1qxazTYeQJSgVAVeXMpUqawRX420Jk+bpsxZstgdx2P8vHKlPvqgsEaOGMG4CHARe3fgMQ4dPKjaNWqqxWefmbNnzrCDAWCbeg3qWytW/awKlSraHcVjHD58WPXr1lXjhg3NoUOH2MYDiFQ+PpbdEbxOwkSJVKt2bc2aO1d58ua1Ow4iUO53cls/LV1ide3RXXHjxrU7jke4efOmhg0ZqkL58pufV65kXAQ8I0pV4CkW/PCjChcqpCmTJrNzAWCbxEmSWP0GDLDmzJ+nnK++anccj7F82XIVLVxEgwYMYBsPINJYFoddUeHll19W2fLlNW7iBP2+eZPVtUd367Vcr1kWnbZHqlW7trVi9SpVqVZNvMkR49ChQ2pYv4Hq1qptDuzfz9gIeAr27sAzuHL5irp16aJypcuYoO1B7FwA2Cbnq69ac+bPs/oPHKhEiRPbHccj3Lp1S6NHfa08775nli5ewjYeQITj8v/IEy1aNBX56EN9Oeor/RW03Ro4eJCVJ29eGjYvkTBhQqt33z7WvAU/KleuXHbH8Rjr1q5VsQ8/0uCBAxkXAU/A3h1wwd9//aWypUqpd8+e7FwA2Kp8xQrWxk1/WPU/biA/Pz+743iEE8ePq0njxqpbq7Y5fuwY23kAEcbXl8OuiGRZlt597z31GzBAO/7ZbY0aPdoqWqwYRaoXy5YtmzVz7hxr8LChSpo0qd1xPMLt27f19VejlOfd98zqn1cxLgIegb074KKQkBCNHztO772d2yxZvJidCwBbdejUyVq0ZInez5PH7igeY93atSpZjNmFAUQcizNVI0SOnDnVuWsX/bpxgyZOmWxVqFSRIhXhlC5Txvrt943WJ40b6aWXXrI7jkc4cfy4GtSrp40bNnDsCzyAvTvwnE6dOqWmjT9V/bp1zZEjR9jBALBNhowZrPGTJlpff/uNUqdObXccj3Dp0iX98fvvbNsBRAgf7qn63NJnSK8WrVpq5ZrVmvvDfKtOvXpW0qRJKVPxRG3atbMWL1uqfAXy2x3FYyxdvMTuCIDjsHcHXtCaVav10QeF9fVXozj4BmCrwkWKWKt/WWe1aNVSMWLEsDuO22PSCwARhXuquiZ58uRq0LChfly0SMtWrrSaNGtmpU2blo3yczpz+oxXHqeke+UV6/tx46wxY8cqbbp0dsdxf4yLgIewdwciwM2bNzV44EB99EFh8/vGjV45aAHgHE2aNbOW/bxSxUuUsDuKW6NUBRBRfHzYnjxN/PjxVbV6NU2bOUO/bFhvte/YwQoIDOCFe0Grf15lChcsqAnjxnntMUr+ggWslatXWW3atVWsWLHsjuO2GBcBD6NUBSLQ3r17Va1yFbVt3dqcP3/eawcuAOyXMmVKa/jIL63J06Ypc5YsdsdxSxaX6wKIINxT9dFixoypkqVL6bux32vTn1utXn36WG++9RbNTQS7evWqevXoqZLFipmtW7Z67THKJ40bW8tX/axSpUvbHcUt8cch4GHs3YFIMHf2HBUuUFAzZ8zw2kELAGfI/U5u66elS6xuPXsobty4dsdxK5yRASCicE/V//j5+algoUIaNmKEtu3cYQ0dPtwqULAgG9wosHPHTlUsV04d2rYzFy5c8MrjlGTJkllDhg+zZsyepYDAALvjuBXGRcDD2LsDkeTSpUvq2K69KleoaP7ZvdsrBy0AnKNmrVrWitWrVLV6NQbFz4iXCUBE8fX1tTuC7d56+2317ttHGzb9oW+/H2OVKFWSraxNZs2cqcIFCmr6tGlee4zy+htvWD8uWmT16tNb8ePHtzuOW2D8CDyMUhWIZJs3bVKp4iU0oF9/rx20AHCGhAkTWr369LHmL1igXK+/bnccx+PgAUBEsbz0stnAwEC179hR69b/pqkzpltVqlWz4seP750vhsNcvHhRnTt0VIWyZU3Q9iCvPU6pWr26tXLNatWsVYsJ5Z7CEqsu8CC2GkAUCA4O1rejRyvve++blStWeO2gBYAzBGYLtGbOmW0NGTZMSZMmtTuOY1GqAogo3nT5f9q0adW0eXMtXbFCPyxaaDVo+LGVIkUKNqgO9efWP1W2VCn16NrNa49R4sWLZ3Xr2cNa8NMivZ37bbvjOBfjIuAh3rN3Bxzg+LFj+qTBx2rcsKE5fvy41w5cADhDqTKlrd9+32h90riRXnrpJbvjOA6lKoCI4ulnwCVJkkR16tXV3B/ma+Wa1dbnLVtYGTJmYCPqJkJCQjRp4kS9/cab5of58732GCWLv781Zfp0a/jIL5UiRQq74zgO4yLgYZ69dwccavmy5frog8L6/rsxXjtoAeAcbdq1sxYvX6b8BQrYHcVROHgAEFEsDyxV48SNo4qVKmnS1Cla/8fvVueuXa0cOXOy4XRj586eVavPW6h6lSpmz549XnucUrxECWvd+t+sJs2aKVr0aHbHcQzGRcDDPG/vDriJ69ev64s+fVSiaDGzdctWrx20AHCGdOnSWWPGjbXGjB2rtOnS2R3HGTh4ABBBfDzknqrRokdT0WLFNOqbb7T177+tLwb0t955913PeHIItXHDRpUsWkz9+n7h1ccoLVq1tJauWKHCRQrbHcURGBYBD6NUBWy2a+dOVSxXTp07djKXLl3y6oELAPvlL1jAWrl6ldW2fTvFihXL7ji28qZ7IAKIXO68PfHx8VHefHk1cMhg7di92/py1FdWkQ+LUK94uODgYI359lvleedds3TxEq89RkmTJo319bffWuMmTlD6DOntjmMrT7+NCfA8WCsAh5g+daoKFyyk+fPmee2gBRFjyqTJLEN4YQ0bNbKWr/pZpcuUsTuKbTgjA0BE8fX1tTuCy1597VV169lD63/fqLETJlhly5Vjq+iFTpw4oSaNG6te7drm4MGDXjvGzJM3r7Vs5UqrQ6dOih07tt1xbMHl/8DDKFUBBzl/7pxat2ipGlWrmv379nntoAXPb+rkKaZbly52x4CHSJYsmTV42FBrxuxZCggMsDtOlOPgAUBEsdzw8v9MmTKrZq1aVqLEid0vPCLc2jVrVazIhxo+dJhXH6PU/7iBtWLVzypfsYLdUWzApgB4EKUq4EAb1m9Q8Y+KaujgIV49aIFrpkyabLp27mx3DHig1994w/px0SKrd98+SpAggd1xogylKoCI4o6Xzc6aOVNdOnViLIpQt27d0pfDh6tAnrxmzarVXrtsJE6SxOo/cKA1e95cZc+Rw+44UYZxEfAw99u7A17i9u3b+urLL1Uwbz6zbu1arx204NlMmTSZM1QR6apUq2atWL1KtWrXdsuCwFUcPACIKO56T9VpU6aqZ7fujEMRzpEjR1S/bl01/uQTc/zYMa9dPl597TVr3o8/WP0GDFDCRInsjhPpGBcBD3PPvTvgRQ4fPqy6tWrrs6bNzOnTp7120ILHo1BFVIoXL57VtUd3a8FPi/R27rftjhO5OHgAEEEsN/5D1MQJE9S3d2/GoHjI8qXLVKTQB/rm66+9evmoUKmi9fvmTVbd+vXc8v7Jz4pSFXiY++7d4VEKFyms1994w+4YjrZo4UIVKVhIEydM8OpBC8KbPHEShSpskcXf35oyfbo14quRSpEihd1xIgUHDwAiio8b3lM1rLFjvtfA/v0Zg+IhN27c0MD+A/ThBx+Y9b+t9+plpFOXLtaiJUv07nvv2R0lUjAsAh5GqQpHyJzFXzNmz7JGffONXkmf3u44jnX16lX17NZdZUqWMtu3bfPqQQvuFqrdu3a1Owa8XLHixa1163+zqtesYXeUCGcxIQOACOIJt0z55uvRGjZkKONPPNK+vftUs1o1tfjsM3Pm9BmvXU4yZspoTZwy2Rr1zTdKnTq13XEiFH9sBh7m/nt3eJQiHxaxlv+80urRq5dX3JfmeW3ftk1lS5XmHldejEIVTtOjVy+rZ+/eHnXZm7ufWQbAOXx8PGPbOHLECH315ZeMP/FYC374UYULFtSEceO8ejkp8mERa/Uv66xPmza1O0qE8YQ/DgERjbUCjlS9Zg3r982brCbNmilGjBh2x3EkY4wmTpigd958yyxauNCrBy3ehkIVTlWtRnUrevTodseIMJyRASCieFIZMXTwEK+/hyae7OrVq+rVo6dKFitmtmze4tXLyu5du+yOEIEYFwEP8py9OzxSi1YtrZ/XrlGlypU9ajAakc6cOaPPmjZT3Vq1zaFDh7x60OINKFThZFMmTTbXr1+3O0aEoVQFEFE87cz3gf0HaOyY7xl34ol27tipSuXLq0PbdubChQtet7zUq1PHrFyxwu4YEYZxEfAwWio4XtKkSa2+/ftZC5csVv4CBeyO41jr1q5V0SJFuCTLg02aOJFCFY514cIFM+bbb+2OEbE4eAAQQTzx5IC+vXszgSqeyayZM1W4QEFNnzbNa5aXmtWqm7Wr19gdI0JRqgIP87y9OzxW5syZrTHjxlqTpk5VtmzZ7I7jSLdu3tLQwUNUpFAhr59909NMmjjR9Ojaze4YwCOdO3fO1K5RQ0eOHLE7SoTi4AFARLEszzzs6tmtu6ZNmcKYE0918eJFde7QUeXLlDVB24M8epmpWqmyWf/bb3bHiHCMi4CHeebeHR7tnXffseYvXGANGTZMqVKnsjuOI+3ft181q1VT6xYtzbmzZz160OINJk6YQKEKx9q+fbupWLacdgTtsDtKhOPgAUBE8cQzVe/r0qmzZs2YyXgTz+SvP/9U2VKl1KNrN49cZiqWK2f++P13u2NECoZFwMM8d+8Oj1eqTGlrzS+/WO07dlTcuHHtjuNI8+fNU+GChTR96lSPHLR4g4kTJpie3brbHQN4pPFjx5qKZcvp8OHDdkeJFJSqACKKp91T9UEd27fXvLlzGW/imYSEhGjSxIl6+403zfx58zxiuTl58qQpVby42bplq91RIg3jIuBhlKpwew0afmytWrdW9T9uoGjRotkdx3EuX76szh07qWK5cmbXzp0eMWjxFhSqcKoLFy6YhvUbmN49e+n27dt2x4k0FrPcAoggPj6+dkeIVMYYtWvdRgt++JGxJp7ZubNn1bpFS1WrXMXs2bPHbZedHUE7TPnSZTzyqp2wKFWBh1GqwiPEixfP6tCpk7Vs5UqVLF3K7jiOtHXLVpUuUVJf9OnjtgMWbzJh/HgKVTjS7xs3mpJFi+nnlSvtjhLpPP3MMgBRx5Mv/78vJCRErVu21OKffmKsCZf8vnGjShYtpn59v3C7ZWfVzz+bKhUr6tSpU3ZHiXSeem9o4EX42R0AiEip06S2hg4frnr165t+fftq44aNdkdylDt37uj778bop4WLTJfu3VXkwyI0Bg40Yfx406t7D7tjQNI/u3dH6uA+c5YsoevgiRMnHH0gceXKFX379Wj9MH++jHF01IjDGRkAIkicOHHsjhAl7ty5oxbNP9Od4Dvm9TffsDtOqBs3btodAU8RHBysMd9+q0ULFphPGjdW/PjxJevuHyQsy5KPdfe/lo919+Mwn5dlyeeBz1uWj6ww32/5+MjSf4+7/1iF/uwnPPb+7wrzeVmWli9dqj69eiskJMTuly9KcKYq8DBKVXik7DlyWFOmT9eqn382/ft+ob1799odyVFOnDihTz/5RAULFTLde/ZQylSpvHYPGRISoqGDhzimITp37pymT51qd4wokzhJYrsjPNLcOXNM21ato+JXOWbZw8M4eAAQUWrUqmkNGjDAXL161e4okS44OFifN29udwy4qRMnTqh71652x8AjMC4CHkapCo9WoGBBq0DBgpoxfboZNniIzpw5Y3ckR/l55Uqt/+03bdvp2ff/eZqvvvzS7gheKXGSxJoybbrdMR7y88qVpkPbdnbHgANw8AAgIo2dMEH1ateWNxSrADwP4yLgYdwUA16hcpUq1vo/frc+b9lCsWLFsjuOo/z777/q3bMnZ8shSt0vVDNkzOCo0dnmTZtMs0+b6M6dO3ZHgQNw8AAgIuV6PZc1dsIExY4d2+4oAOAyhkXAwyhV4VWaNm9u/bxmtarVqC5fX8+ehRVwqsRJEmvqdOcVqrt37TIN6tXTzZvcdw13UaoCiGi5Xs9ljZs4kWIVgNthXAQ8jFIVXidxkiRWz969rZ+WLlXhIoXtjgN4lSRJkmjq9OlKn8FZherRI0dN3Vq1deXyFbujwEEsOWoxBeAhXsv1GsUqAPdDqQo8hFIVXitDxgzW199+a02bOUM5X33V7jiAx0uSJImmTJ/muEL13NmzpnbNmjp9+rTdUeAwHDsAiCwUqwDcDWeqAg+jVIXXe/Ott6w58+dZI74aqf/97392xwE8klMLVUmqV7uODh08aHcMOJDlwzAJQOShWAXgTnwsxkXAg1grgHuKFS9u/bx2jdWlW1fFjx/f7jiAx3ByoVqjajUTFBRkdww4FGdkAIhsFKsA3AXjIuBhlKrAA2rXrWtt+nOr9UnjRooWPZrdcQC3liRJEk2d4bx7qEpSk0aNzYb16+2OAQfj4AFAVHgt12vW+EkUqwCcjXER8DBKVeAx2rRrZ61YtUply5dnBwI8h/uF6ivp0ztuBercoaNZumSJ3THgcAkSJHDcsgvAM736GsUqAGeLFo0TjoAHUaoCT5AyZUpr4OBB1g8LF+q999+3Ow7gNpImTerYQnXIoMFm+rRpdseAw5UtV87uCAC8DMUqAKfKlCmTKlSq6LhxPWA3SlXgGQQEBlgTJk+yxk2coCz+/nbHARwtadKkmjJ9miML1QnjxplRI0faHQMOFi9ePH056isNHDLYccsvAM8XWqzGiWN3FACQJNWpV1eLly9jXBTJ1q5ZY6ZPm2Z2BO0wdmfBs/OzOwDgTvLkzWvlyZtXc2fPNkMGDdbJkyftjgQ4ipML1R/n/2B69ehpdww42Pt58qj/oIFKliyZ45ZfAN7j1ddes8ZPnGDq1Kqtq1eu2B0HgJdKliyZBgwepPfef59xURTImy+fVTBvPnP48GFFix7NBAYGKnuOnMqeI7ty5MipDBmdN0cFKFWB51KuQgWrXIUKGj3qazN61ChdvXrV7kiA7e5f8p/ulVcct8Nfs3qNadu6td0x4FDRo0dX2w7tVbtOHcctuwC8E8UqADsVL1FCPfv0Vrx48RgbRaHhI79UxXLldevmLW3dslVbt2wN/Vrs2LFNtuzZlD1HTuXImUPZs+dQ6jSpeX9sRqkKvIBGnza2KlWpbEaO+FJTJ09WcHCw3ZEAWzi5UN26Zatp0qgR6yceKSAwQEOGDVfGTBkdt+wC8G4UqwCiWuw4cdSjV0+VLlOGcZENsufIYbVt39707d37oa9dvXpVG9Zv0Ib1G0I/lzBhQpPt3pms94vWJEmT8N5FIUpV4AUlTJjQ6tq9m2rVqW0G9R+gJYsX2x0JiFLJkiXTlOnTHFmo7tmzxzSoW1c3btywOwocxrIsNfq0sVq1aeO45RYA7nv1tdesCZMmmto1a1GsAohUud/JrQGDBytlypSMjWxUr0F967dffzWrV6166mPPnz+vtavXaO3qNaGfS548ucmeM0e4ojVuvLi8p5GEUhWIIOnSpbNGfj1KW7dsNV/06aMtmzfbHQmIdE4uVI8fP27q1qylS5cu2R0FDpM6dWoNHjZUr7/xhuOWWwB4UM5XX6VYBRBpokWLppatW6tBw48ZFzlE/0EDVbJoMZ0+fdrl7z158qROnjyp5UuXhX4ubdq04YrWN958k/c6glCqAhHstVyvWTPnzFbHdu3NzBkz7I4DRJpkyZJpyozpSpcuneN2yufPnzd1atZkMjk8pHzFCuo/cKDjllkAeBKKVQCRIXOWLBo6fJiy+PszNnKQRIkSWUOGDzc1qlaNkJ936NAhHTp0SAt/XCBJsizLZMqcOXQSrBw5cyh7jhwsA8/Bx+4AgKdKlDiR3RGASOPkQlWS6tepq/379tsdAw6SIEECffX11xSqANzWvWJVsePEsTsKAA9Q/+MG+mnpEotC1Zlyv5Pbatq8eaT8bGOM/tm9W3NmzVa3Ll1UtlRpZc2U2VQqV94cPXLURMov9VCUqgAAlzi9UK1do6bZ9vffdseAg+TNn08/LV2qD4t+5MhlFgCeFcUqgBeVIkUKTZo6VR06dWJc5HCft2xhvfHmm1Hyu27fvq0tW7aoetUqOn7sGMXqM6JUBQA8s+TJkzu6UP2sWTPz6y+/2B0DDhEjRgx179lTY8ePt5gJFYCnyPnqq9bEyZMoVgG4rFTp0lq0ZIneefcdxkVuYsjwYYoXL16U/b5jR4+pepWqOn78OMXqM6BUBQA8k+TJk2vy9GmOLVS7d+lqFi1YaHcMOES27Nn146KFqlGrpiOXVwB4ETly5qRYBfDM4saNq2FfjtCQ4cMsZoJ3LylTprT6DxoYpb/zyJEjqlm1mk6ePEmx+hSUqgCAp3L6GapfDh9uJk+aZHcMOICPj4+aNGum+Qt+tNJnyODI5RUAIgLFKoBn8c6772rR0iUqUbKk48ZFO3fsMMU/Kmoqla9gunbubKZNmWK2btlKkfeADwoXtmrVqROlv/PQoUOqUbWaTp8+zfvxBH52BwAAONv9QjVt2rSOG4hJ0pRJk83wocPsjgEH+N///qdBQ4cq1+u5HLmsAkBEu1esmto1a+rK5St2xwHgINGiR1Obtu1Ut349R46L5s+bZzq176CbN29KkrZs3hz2yyZt2rTKktVfWbNmVRb/rMoakFVp0qRx5HOJCl27d7M2/fG72RG0I8p+58EDB1SjalVNmTbdcCutR6NUBQA8ltML1Z8WLTLdu3a1OwYcoFLlyurbv58jl1MAiEw5cua0JkyiWAXwH/+sWTVk+DBlzpzZkWOjHl27mUkTJz7xMYcOHdKhQ4e0bMnS0M+9/PLLJou/v7IGZJW/v7/8swbotVyvOfI5RobhX36pUsVL6N9//42y37l/337VrFZNU6ZPM4kSJ/aa1/pZUaoCAB4pRYoUmjx9mmML1V9/+cW0+ryFjOGKFG+WMGFC9en3hQoXKeLI5RQAogLFKgBJsixLDRo2VLsO7R05Ljp16pRp1vhTbdmy5bm+/9q1a9qyefMjz2r1z5pV/ln97/3XM89qfSV9eqtnn96mTctWUfp79+7dqxrVqmvytKkmUaJEHve6vghKVQDAQ5xeqG77+2/TuOEnun37tt1RYKMCBQvqi/79lDgJlyMBAMUq4N1SpkqlQUMG662333bkuOj3jRtNsyZNde7s2Qj/2ffPal26ZEno52LHjm2y+PvLP8wtBDzhrNay5cpZv/3yq5k3d26U/t49//yjWtVraPK0qSZBggRu/zpGFEpVAEA4Ti9U9+/bZ+rVrqPr16/bHQU2iRkzpjp16awq1ao5chkFALvcvcfqZFOrRg2KVcCLlC1XTgOHDHbsuGjc92PNF336KCQkJMp+59WrV7V50yZt3rQp7KdDz2rNGpBVWfz9lTVrgFKnSe3Y1+5RBg4ZbG3ZssUcOngwSn/v7l27VKt6dU2aOtXEjx/frV6zyEKpCgAIlSJFCk2ZMV3/+9//HLmTPHnypKlTq7YuXLhgdxTYJEfOnBoybKjSvfKKI5dRALBb9hw5KFYBLxEvXjz1/qKvihYr5thx0WfNmplFCxbaHSPUk85qzRrmFgKvvubss1pHjBypCmXLRvmVezt37FTt6jU0ceoUEy9ePEe/RlGBUhUAIMn5herFixdN3Zq1dPzYMbujwAa+vr5q0qypmn/+uSOXTwBwEopVwPO9nyeP+g8aqGTJkjlybHTwwAHT+JNG2vPPP3ZHearHntWaLl24otXfP6tjzmoNzBZote/U0fTq3iPKf3dQUJDq1KylCZMmmbjx4jri9bALpSoAQClSptSU6dMcW6hK0sf16mnPnj12x4AN0qZLpyHDhirnq686dvkEAKehWAU8U/To0dW2Q3vVrlPHseOiFcuXm9YtWurq1at2R3khhw4e1KGDB7Vk8eLQz4U7qzUgq/z9/W07q7V2nTrWb7/8alauWBHlv3vb33+rbu3amjN/XpT/biehVAUAL+cOhWq9OnXM1i1b7Y4BG1SpVk29+/Zx7LIJAE5GsQp4lsDAQA0eNkwZM2V07NhoyKBBZtTIr+yOEWme9azWrFmzKlXqyD+rtd/AASpZtJhOnjwZ2b/qIX/9+acqlStvZs6d49jlMbJRqgKAF3OHQrXV5y3M2tVr7I6BKJYocWJ90b+fChYq5NhlEwDcQfYcOaxJU6aYmtWrU6wCbsqyLDX6tLFatWnj2HHRhQsXTIvmn+mXdevsjmKLR57VGieO8ff3l7+/v/wD7hatEX3lVYIECayhI4abapWryBgTkT/6mWzZskWVK1Q0M2bPcuyyGZkoVQHAS6VImVJTZ0xXmjRpHLsD7N2zp/lh/ny7YyCKFfrgA/Xt30+JEiVy7LIJAO4kW/bsFKuAm0qdOrUGDxuq1994w7Hjou3btplPGzVm7oMHXL1yRZv++EOb/vgj7KdNuldekb+/v7IGZNX9Wwm8yFmtb771lvVZi8/NsCFDXzz0c9i8aZOqVqpsps2c4dhlNLL42B0AABD13KFQ/fqrUWb82HF2x0AUihUrlvr276dvxnxnUagCQMS6V6wqTtw4dkcB8IzKV6yg1b+ss5xcqM6aMdNUKl+BQtUFBw8c0JLFizV08BA1+rih8r2fR69mz2GqV6liTpw48VynmzZt3tx6O/fbER31mf3x+++qUbVq1J8qazNKVQDwMilTpXJ8oTpj+nQzeOBAu2MgCr2W6zUtWPyTKlWu7NjlEgDc3f1iNW7cuHZHAfAECRIk0KjRo9V/4EBHj4s6d+hoOrRrp1u3btkdxe1dvXJFGzdsVJNGjZ/7ZwwZPlwJEiSIwFSu2bB+g2pVr+FVxSqlKgB4kZSpUmnK9GmOLlSXLVlqunTsZHcMRBFfX1+1aNVSs+bOtdKmTevY5RIAPEW27NmtiVMmU6wCDpU3fz79tHSpinz0oWPHRcePHzflSpcx06dNszuKx/n7r7/UsV375yomkyVLZg0YPCiiI7nkt19/VZ2atbymWKVUBQAv4Q6F6ob1G8znzZsrJCTE7iiIAq+kT6/Z8+aqSbNmjl0mAcATUawCzhMjRgx179lTY8ePt5IkTeLYsdH6334zZUqU1N9//WV3FI81c8YMTZ869bmKyQIFC1r1GtSP6Egu+WXdOg0bMtQrilVKVQDwAilTpdLU6c6+5D9oe5Bp9PHHXD7kJarXrKHlP6+0sufI4dhlEgA8GcUq4BzZsmfXj4sWqkatmo4eF333zTemVvUaOn/+vN1RPF73rt20ZfOW5yomO3bubGXLli2iIz2TlKlSadiXI/R5yxaOXpYjCqUqAHi4+4Vq6jTPP6NkZDt48KCpW7u2rl69ancURLLESRLr+3Hj1KNXL8cujwDgLbJlz25NnMo9VgG7+Pj4qEmzZpq/4EcrfYYMjh4bNWnU2PT/op+M8YoTEG0XHByspo0b68zpM8/1gg8b+aVefvnliI71WLFixVKrNm209tdfrBIlSzp6WY5IlKoA4MHcoVA9ffq0qVOjps6fO2d3FESywh8W0U9LlypfgfyOXR4BwNtky5aNYhWwwf/+9z9NnzVLLVq1dPS4aO+evaZIoUJm6ZIldkfxOqdPn1bTTz99ru9Nly6d1btv3whO9GgVK1XSytWr1bjJp45eliMDpSoAeKhUqZ1fqF6+dNnUrVVbR48etTsKItHLL7+s/gMH6utvvrESJkzo2OURALwVxSoQtSpVrqyf166xcr2ey9HjoiWLF5typUtr/779dkfxWps3bVL3Ll2f62zVkqVLWRUqVYzoSKFyv5NbPy5apC8G9Hf0fYAjk5/dARC5kiVNpps3b9od46mSJUtmd4QIlzRZMiVNmtTuGM8kol//JEmTWEmTJuW6EBulTp1ao8d8J6cXWJ07dtSF8+fdZl2B617LlUvtO3V09P18o4o37xecwJ1e/6RJPe/1T5Ysqfu8/sncI2dEy5YtmzX3xx9M448b6tKlS3bH8VoRvf11p22fN0iYKJHatG3rFlft9Ov7hRnz7bd2xwiVMGFCvfPuu1r/229ed0/XyZMmKXuOHKZ8xQouLzf9BgywtmzebCKyGE+bNq3ad+qowkWKOH45jmwW98MAAAAAAADAubNnzWfNmmnD+g225rAsS6+99pryFcivvPny6f7kphcvXjSDBgzU9KlTbc0X1aJFi6YZs2fpeSZ53bVzpylXuswLTwgcO04cNWveXPU/buD1Zep9lKoAAAAAAABe7q8//zRNGjXWyZMnbfn9iZMkVt58+ZQvf3699/77ih8//mPLuz+3bjVdO3fWjqAdURnRVilSpND8hQuUKFEil0vNKZMmm25dujzX7/Xx8VG16tXVvMXnjr8SMqpRqgIAAAAAAHix6VOnmh7duuv27dtR9jt9fHyU6/XXlS9/fuXLn18BgQEuF3YTxo0zQwYN1rVr1yIjouPkfie3Jk+b9lzF5qeNGpllS5a69D158+VVh86dlSlTJsrUR6BUBQAAAAAA8FLt2rQxc2bNjpLflSxZMuXLn1958+fTR0WLRkhRd/r0adOnVy8tWrAwIn6c49VrUF8dO3d2+bW7dOmSKVG0mE4cP/7Ux2bMmFEdOndWvvz5KFOfgFIVAAAAAADAyxw9ctQ0adRIQUFBkfY7/Pz89Mabb9wtUvPlUxZ//0gr6X5Zt85069JVhw4ejKxf4RhDhw9XydKlXH4tN2/ebKpWrKSQkJBHfj1+/Pj6vGVL1ahVkzL1GVCqAgAAAAAAeJF1a9eaz5s116VLlyL8Z6dImfLeJf35bJkhfuSIEWbUyK9eeGImJ4sePbpmz5urrAGu3zLh669GmcEDB4b7nJ+fn2rVqa2mzZorbry4FKrPiFIVAAAAAADAS3z15UgzdPDgCPt5L730kt58663Qe6NmzJTR9lLu0KFDpkfXrlq7Zq3dUSJN6tSpNX/hgidO6PU4tarXML/9+qskqXCRwmrXoYPSvfKK7e+bu6FUBQAAAAAA8AKfNPjYrFyx4oV/TurUqZWvwN0StWChQo4t4xb/9JPp3aOnTp06ZXeUSJEnb16NmzjB5df/zOkzpnXLlmr06ad65913HPv+OR2lKgAAAAAAgAf7Z/du07jhJzp06NBzfX+06NGUO3fu0HujvpI+vVsVcX179zbjx4577L1E3VmjTxurddu2bvV+eApKVQAAAAAAAA+18McFpn3btrpx44ZL35c2XbrQS/o9YRb4aVOmmC6dOtsdI1KM/HqUPipa1O3fI3dDqQoAAAAAAOCBevfsacaPHfdMj40RI4beefdd5c2fT3nz5VPatGk9oqS7ePGiGdR/gKZPm2Z3lEgTK1YszflhvjJlyuQR75m7oFQFAAAAAADwIGdOnzHNmjTRpj/+eOLjMmTMEHpJ//t58nhcITd3zhzTr09fnT9/3u4okS5tunRauXqVx72HTkapCgAAAAAA4CE2b95smjZqrDNnzjz0tVixYund995Tvvz5lCdvPqVOk9ojS7i9e/aabl06a+OGjXZHiVIFCxXSt9+P8cj31IkoVQEAAAAAADzAxAkTTJ+evXTnzp3Qz2XKnDn03qjeMNP7kEGDzLejv1FwcLDdUWzR/PPP1Pzzzz3+fXYCSlUAAAAAAAA31+rzFuaH+fMVO3Zsvff++6H3Rk2RIoVXFGyrf15lunftqqNHj9odxXbffj9GBQsV8or33U6UqgAAAAAAAG7q8OHDZuSIEUqaNKny5sunt95+26vKtBMnTpjePXpq6ZIldkdxjNixY2vejz/olfTpvWpZiGqUqgAAAAAAAHA7474fa4YOHqzr16/bHcVxMmbMqCUrllOqRiJKVQAAAAAAALiNP7duNV06ddLOHTvtjuJoH370kb4a/TXFaiTxsTsAAAAAAAAA8DSXLl0yXTp1MhXKlqNQfQZLlyzR6FFfczZlJOFMVQAAAAAAADja/HnzTN/efXT+3Dm7o7idsRPGK2++fJyxGsEoVQEAAAAAAOBI+/buM926dNaG9RvsjuK24saNq/kLF+h///sfxWoEolQFAAAAAACA4wwZNNh8O3q0goODbc0RLVo0+fj4yLKscP+TZcmyJEvWY772fF9XuMfq7n/1qK89/euSZFlSQGCgevbubVup+su6dWbm9BnKkzevCn9YRPHjx3f7gpdSFQAAAAAAAI6xZvUa071LFx05csTuKJKkWLFiKTBbNmXPkV05cuRU9pw5lDZtWrcvBaPC4cOHTd9evbVi+fLQz/n6+uq9999TseIlVPjDIooXL55bvpaUqgAAAAAAALDdyZMnTe8ePbVk8WK7ozxV3LhxlT1HDmXPkV3Zs+dQtuzZlCp1arcsByPL4IEDzZhvv9Pt27cf+xhfX1+9l+d9FS9eQh8UKexWBSulKgAAAAAAAGw1fuxYM2TQYF2/ft3uKM8tfvz4ypY9u7LnyK5s2bJ7bdH6w/z5pn/fL3T69GmXvs/Pz+9ewVpcHxQuorjx4jr6taNUBQAAAAAAgC3++vNP06VTJ+0I2mF3lEjhTUXr9u3bTc9u3bVl8+YX/ll+fn56P08eFStezLEFK6UqAAAAAAAAotTlS5fNoIEDNHXyFLujRLkECRIoW/a7BasnFK3nzp0zQwYO0ozp0yPl5/v5+SlP3rwqWryYypUv75jXiVIVAAAAAAAAUeaH+fNNn169df7cObujOIa7Fq3jvh9rhg8bpqtXrkTJ73vppZdCC9ay5crZ+vpQqgIAEEmunT1sjhw+rosmnlKnT6/UCaI7flAEAEBkMTfPmkN7D+vExVt6Ocn/lCNzSvaLUeDs4V3m8LELUvw0Sv9KSsWP4eN2r/vtq6fNkYOHdOqyFCdJSmXLlMrtngPu2r9vn+nauYs2rF9vdxS34OSidc3qNaZPr57av2+/bRleeukl5c2XT0WLF1OZsmWj/HWhVPUil9b3MfXaLNLpO3c/tl7KqZbTRqlMKssRK2RYp+d/ZqoM+EO3XV48fZSi2Bea2SWPo56TufmL6VOunZaeN5J8lLHyVxr3ec7HZrz2+xemZssFOnNHkm9yVRs2U43f8HPUc7rv6q+9TLW2i3UhRJJvGtUcOUUNX3Vm1scJ//48nU+M99V5/gAVjifHPM+Qi/NMqzIDtemm69/rl7CYvpjbWbmjO+f5SNLaPh+Zzgsvy0iKlqaKRkxursBozsr4KNeO/GrmT5umeT/8rL+O/avQpconjjLlraAGn3+m8q+6z4yWjhFyykxrWk6jtt59RWNkqqtvxn6s9H6PXyZCrq0xfSp31LJzRpKlmJnravT3DZ74PVEt3Db0qSzFe6+jFg4q7pj8YYVdZ60YudV+5mAVS/LoMYb5d4XpWrqrVl+RZMXSh90WqPOHMR31vDxxu3p2YUtTue8G3TKS5ZddzaZ8rYr/e3y5srzLB6bniruThcR+vaUWj6zgqOdz32PXI8tHvtGiK1acJEqTPqtee/8jlSzxtlLFdNb78ihh16ensmKoQIcf1LNkHMc+r0v/LDRjvxqjOSu36+TVO6Gf94ubXrk/Kq86jeopf/oYjs3vjg7+NtnMmD5XC1Zs1ckwc/74xs2gfOU+1mefV1JgfOcdB4Zlgk+bzfMnaerMuVqx6biuh1nHoyXIqLc/rKYmn9fQG8lfcvTzwH+GDh5ivh09+okzwePp7C5aD+zfb/r06q3Vq1ZF1a98JgkTJtSXo77S27lzR9lr4RdVvwj2Mnf2mOnDJumvo/8dGVi+MXXw5B0plfMWg52bN+jI8dPPNpAMx0+Zk6ePhEQv5vbRrdq865hO3LEkxdQbqZ6c8dSfGxV09ITuSPKJkUUp0vpGSc7ncezPDdp97F7WWIFKmdZ5y9PThH9/ni5mpsRKETOSQ7noetAf2nz4hE48UzETXpzUyZXGYW+bubPP/PXHLh0/cfc9SRyQUqmj2RzqaULOmo3je6jr0IXa96grX0KuaM/qcerwx3rtGPi96VKMs3Nc4pPMeunOKXPixN2D8eh+x3Xhjp44kjk0Z7Rmbz+ua5JkJVKZtmUcVahK4behT+erpInTRHKi5/PgOist05Kfz6tY5USPfPzNfVu0af8JnQiWLL9sSpY2etSFfUaetl2VpF2bNujI8RMKkfRS0rxKmdTnsY81wdvNn5v26cQJSfJR1sRpoyqmy56+Hu3XP9s2auUP4zVqWH41HzzENMidwFHbgrAeXp+ezPLNqCSpHTYwCWPX7M9N824/aP+1h78WfHm/fpk5UL8tXqDKXUaYXpUyOfZ9cRfB5/4wE3p00IgF+3TtEQdTdy7v08/jO2jzhr/U/7ve5oM0zjxr9eq+BWZIu+6asun8I9ftWxf2at30nlq/dKk+H/2NafQ2f7B2srVr1pjuXbrq8OHDdkfxCBcuXNC6tWu1bu3a0M8lSJDABGbLpqwBAQoICJB/QFZlyhTx29R+ffqa8ePGKTg4OKJ/9HNLmCiR6tarp+o1akT5ZFYOHO4hMpxZ9qXG/3G3UPXz81NwcLDMnTM6feo5jhQimQk5Ynbtep5CVZJPMmUOTBrRkV7YtaDtOnCvsLP80itrtpef+PgdQXt1/52JniZAmR08RggK2hs60ImZLlCZ49ga57mEfX+eRbyMWZXNYWdMntmxU6efa3X2UXL/bErl66znY278rZ377n/kp3SB2RVPzsoYlgk+bOa3raGOc48o7N/dX4qdRKnSJNfLt45r3/5zumGkkGu7NLl9K6V9ZaKplZUzK1yRMGF8WTonI+nO1cu6+oQdhbnxu5k8fqPuH8PHCaypBsUTR0VMl4Tdhj5dLGXImikS0zy/8OusJF3TH0tX6GzFyiaxz8Pr7uWgIB25Nxb3i59VWdI9vtyzi8dtV0OOmp07T4SOL17OGKhMT/hjlbm6XTsP3D3LW4qhTNn8oyDl8wm3HkWLo4Rx7j2xkFu6fuWqbgT/t7G4fmy1BjVqqQTzvzfl0zmzTHp4fXoyn5czK0smZx7WnV3V0TTt+IMO3rr/mWhKmC6zUscN1vkj+3Xswi0ZSSFXdmlax7oKjj7TfFGaPzo+r5tH5pv2NdtowcGwZYef4iRJrVTJY+vGyb06dOaGjIwu7ZquLm3SKe2EhiaTw86qv/T3aPNp3QHaeC7Mjt4vjpKnTaskMa7r+L4DOnfj7teCL2zU0IbNlXDeOFMpvTPXaW926tQp06dnL/20aJHdUTzehQsX9Mu6dfpl3brQz0WLHs1kzpwltGQNCAjQG2+++VzryawZM83AAQMcdQ/cVKlT6eOGn6hGrZq2rfvO3PsiQplbf5rxXy7SmRDJJ8YbqlDqimbN3K07uqGzJ89LSm53xHAsnzRWzTFbTaWQ8EfLN7b0V5WGM3TsjiSfZKo+aqE+f/uBMzgtXyWI77ySYk/QLt2/6sYvXlb5P+Hg0QRvNzt2XwstleNnCVCAwwq8+8ytzWbn7vujZEsJswQqs8POAnsWYd+fl5JW1NfLeyh/PGddhvo0r3w8z9pQ4UK4G7qY21s0sNzHmnX07m0nXqkwSlM7vfXAht9SggTxHfdcb+zeoT3X78Wy4ipzYDpb8zxRyEnzU6da6hSmUI2R4n3V+fxz1SrzupLeO1A5sfEr0+mzIVp70k9p3y6g7EnYBbsqYeL48tE53ZEU8u9lXb0lKcajH3t80WjNP3BvjfBJpuJNasnfYdvSB7eh6Sp8qxWDPnBUxmcVbp2959zGpfrlbCWVSfrwU9q5bZfuXzsTK1OAsjjwTHRP266am9sU9M/9ktRXqQOzKekjCu/7ru/Ypn23nv0PwnZ5cD1KW2aYVg4oGO55Hdo0x0wfPlDj1p1SsKTgi+s0eeo2le+YM+oDP4Pw+8Akqv7NSvUo4txL+x/HBG813/ebEVqo+iV8R58NHaLG+ZJbd79+1mxb9J36fzFWG0/eUfwshVTkDWcdl7iT4FNLTNc6bcMUqi/pf+/VVbMW9VT2jWT3XvNT5rfv2qrN4LU645tabxbIpcQv2Rj6EW7um2xaNQhTqPrE1+uVWqtNs4p6I1U0S5JuX/zLTO/+ufrNP6ibku5cWqcRfecq/7cVzJO2a4haE8aNM0MGDda1a484TR1R4tbNW9q+bZu2b9sW9tMmTZo0oSWrf9a7/33c7QM2b95senXrru3bt0dN6GeQKXNmNfq0sUqXKWP7+s4RnRc4NHeopu8MkWQp9Yd1VDXLOM2WJIXozMlTclqpKkmx4sW3Yj3wuSNH9pr794P1eSmzcuRKpAQJnH0fIElSyGmzM+hw6JkhsbIEKssTrnI0V7dp18H7Bz1+ypgtWxSEfD53Lm3XziP/Zc0Q6Nysj/XA+/NyxmwKiOPcS+ieJH6C8Jcy3j510Bw4dXfdl/yUKecbSpLAuZc7hnVxxzYdDb3/cyb5Bzqwcbnn0Pwu6jnrkO4eM1pK9GpDDf2mrd5NFv5siRRvN7GGfhXNfLv5VTVo8KYSMOh3WaJE8UNfNBNyRZevGOkRV/iY4O1m2tjVunTveCz+a3VVr3CCqAv6jMJvQ19SxuzOLHiexX/rrK+S/S+Fzh8+qtvXNmrlinMqUy38GcLmzmGzY9cpmfvlXtZsSubQ9cGTtqu39m/XP1fuR42pjIGZn/j4M0G7dP+CJr/4T/6DsJ0eHItkDAh86DFp3yhvtf0mpblevJqmHJCkOzq8/U9Jzlznwu4DfaJlVGCO2PYGek7X//xBS/feH2HF1get/itUJcnyS2zlKN1B4958zQwZtksF23ymtx5zH2Y8RcgxM7dbB83dd+/Pu1YcvfXxSA1vl1dJwpw1b/kls95rPEHDovUxu7I1Vq23Ezrq9TZ39phJXb7QmtP3duC+KVSqx3gNqZE5XM6X4ue0agz6zlw7WVKDNtyQZHRq7WQt3FdO9TI5c1vlTf7+6y/TpWMnBQUF2R0Fj3HkyBEdOXJEy5cuC/1cnLhxTNasAfL391fyFMmVIEFC/fbbr1rww482Jg0v1+uvq3GTT1WgYEHHbLsoVT1cyLV15rtRa3XZSJZfRpWtU0Qp983W3V3NHZ07dUJOHVA+aEfQXt3/u2v01AHK5LyTQB7J3N6uoH/uf+Sr1FmzP/Hg8XrQNu29d2aIfJIoc7aUkR/yOd3Yvk37gu9nTa4s2Zx3ae3TPPj+pMoa+MQzd9zJze1BOnDv/bF808g/MJ7NiZ5d0LZ/Qtf3aMmyyj+JM9+S26fmmv5frNC5e8eMMdKUVe9R7fRuskcfFMZ7/WOrzetRmdCzxE2YSNGlu8tGyBVduWSkR0z+e275t5q98/4ZLqlVpml1x91LVQq/DbV8UylzgPOK32f13zrrq8AyZXV+1Aj9GXxdfyxdrjNVqpokYbar5tY27dxz/6Poyhjo3MvKH+TO29XL27fr8L0Nq+X3igICn/wHxKCgf0IvqY+VOVCZHfq3rXBjEd9Uyhz46Pv4WrHesd7MEdNMPXB3AsE7168/8nFOEHYfGD1lgDI7q/d6Zv/uP6CT9/9A6vc/ZXv10bfoipbyI6v9gI+iMJnnOfpDTw1ZdvHelW5+ylSmn4a2z6skjxnTvlW/k/VWlCZ8Ngem99So9dfvPY/oylV/2EOF6n2WX0arSoOPzITf5+tMiGRu7dBva06qXibnHjt5usuXLpvBgwZqyqTJdkfBc7hy+Yp+37hRv2/caHeUh+QvUECNPm383LcuiEz8GcfD7Zo8RD/euxd04ndqqUKOl+QXJ45i3VsUr505pVMhz3f70qhk7uw2O3ddCg0aL3OAcjjsMs7HuXVku/aE3g/o6fckOx303z3cfKJlUYC/c//2cTRop87fzxrDXwH+Drt+6BmEf3+iK5MbHdw/zaGgnbp4v1eKlVlZMjp3WQrL3Nljdu4+H7q+x8mSTbkcdq+v+7aO+1Irz9z7wCe5ynTopMIpOcsmsvgmSqi490YuJuSqLl9++G6k5s4eM/P7xTp7b9uUOHd91c7rzLO8wm5DrRiZ5Z/ZPdbRB4VbZ60ESp29oN7McHc1OP/HUq07HX6YcWvvNv1z7b/Lyv0DH7w2xbncdbsqhb/lgl/CrMqS5sm3Itq5++q97bCzzyYOPxbJoqyPXY8umavXbobuW6IleHT5areH9oGZA/Wqm4x5H2L+O8gwwYe1dSMT1EQGc2uzmThqeeh+L1rykmrdqahj19nHMTc3mknf/aLL9xaaGK9UUevmT65+4+bOq5wv31/KgrX7778jNyQea8EPP5rChQpRqCLC+Pj4qFTp0lq4+CeNGTfWcmKhKlGqerTgcz+a0WP+1L+S5JNaJeqXUwpfWT5x4yr2vXf+1plTOuOcSdsey/wbdG+yBOnupDXuc5l5+EmqMigg25MPHncE7Qk9MyTG/wKV2cFn5O4I2vffJFWvBCqTM3uLJ3pwErEsAe556f+j7Ao6EO79yezM2+E9xPy7PdwkVa84dH0PubbczJx3MPQ1jperrj7+MKGtmTydX8KEin9/5GKu6srlhx9z+bfvNWPL3R2b5fuKKjSrojQOmzDovrDb0FivBLjNOvqgsOus5ZtEKdJkUe43k8iSFHL9d61ccTbc4y+FnaQqnr+ypHWf4ajbbldDb7lw17NMUnX3VkSS0yepetb1KOTCav3y5/1H+ilTzteiIp7LHtwHpsv68O0M3EXsrAH6X2jHfVU/D2qsHvP2Of5kDndzad0ULQx9WaPp7brNVSix+/2B99K66VoS2rvHVJ66DfVW7Cfvv60YryhditCBga6fPaMzbnDCkCc5sH+/qVmtumnx2Wc6d/bs078BSp48udKkSWN3DMeKFi2aqtesoRWrV2nI8GGWf9asjt6euc+f1+GyLd8P17J7Z1DFe62GquW5W+b5xo2nl+8tlrfPnAy9bNXJ/t21XXv/vX/D/gTKHOA+G6GwkyDJN0R7l3+n71Y9ZmdvLmrj5vuXvFiKlyVAWR14yap096/iO/65f86LpYSZA9x+kir5RdO5v3/Q/J2PeH+shMpeMJ8yxHWP52hubTI79vz3/iT2D9ArDi2WHnRj93a3mKTq6obF+vX+Wap6We+WK6O0bvIauyu/JEkVV/funWiu6sqVYEn/nSFvQo6Y+d/9oGMhkmQpab5PVPPtx8xkZbPw21DJN/pl/blgnrbr4e2PX/xAlSjw6MsfnSDsOmtFT6XUKWMqx7tvKt6Un3TR/KtNS5fpVLXq5v5ZU7u279b9aYViZX7yfcadxJ23q+bm39oRessFX6UOePIkVf/u3Ka9N5/9D8J2eWgskiVAGR8xFjG3Dpn53Qdo+dm7X/KJ+bqKlc4QlVGfWbh9oPzkc3mb5s8LesS40UeJAwrq/SzOncAqemAFlXt9ogZuvCFJMtd3aVLL0vp9WRPTsWN9vZcmmmOzu5Pfl6zWmftna8d+V6VKp7U30HP6Y/na0LNtfePlVYmiKZ7+TVYcxX75/n2upTvXr+iakZJEXkyEMWzIUPPN11/r9u3bT3+wl/Pz81PBDwqpfIUKKvTB3UlJFy5YYL75+mvt3LHT7niOEDt2bNWoVVN16tZV4iQOvffbI1CqeqjbRyearybtv3s/Jp+kKtagSujA3zdePL1876A05Pppnb5kpBjOXmYv7gjS8TA37PcPcJNFN+S02bnjSOgkSObmds0c8Kyz5vkqU7bskZXshQVf3K5dnjBJVdj358YWjWm75ZEP9Y3zkUYUzCdnHoI9LPjidu06GmYCHDd6fy7sCNKxsJNUBTjzRn47N2wK/aOUFS273svHED6y+cROoAQxJV2RJKOrly5J+u/s8utbJmjyb3cP3i2/zKrStJxjL38Mvw2VLm3+Xu03P/qxyT4arhIFnjypkJ3CrrPRU6bX/2JI8d77QG/E+UkrLksXNi/TLyerqXxK694Zk6dDJ6lK5e/cy8of5M7b1Vt7tofeckGKoYyBWZ74+NNBO/+bpCphVvmnceZb9NBY5IFJqs4e+tP8veFnzZs4QUuDLt/b38fUGw3aq/orPo58UmHXJ+mGNoxtrQ2PfGRslR2+Xu8/+a20leWbyaozoLvZWqWjVpy4t0CZa9q9eIDqrpur4o06m9YN8ilVDPfYBjiRubXZbNxy4b/bRWTPp3eSut/LaYK3m61/hbntReA7eiPRMzwPc0P/3vzvcdZL0eR+NyNzP+vWrjXdu3TVoUOH7I7ieFkDsqpCxYoqWbq0EiYMf4PsEiVLWiVKltTaNWvMt6NHa8P6R2/tPV2ixIlVv0F9NWzUyP02XqJU9VjrRo3S+it3/x0nWw3VKvzfRAq+8f+7/N/cOaPTJ+9IyZy9KOwI2hPmhv2ByuImN+wPPwmSi3ySKnO25BGaJyLdDPo7zCRVKeTv9pNUPVnMV7K5zWWeknQzaLv2h5kAJ0ug+0yAsyPsJFXJA5TFkX+oPGt27/6vkI+ROocCHJnTs1g+SZQgvhWmVL0s6d52MuS0+em7mToYLEmWUhX+VNVede6hVbht6BP56ZVszi7vwq6zsf6XXoHRZClaAVP4vZhaufhfhVz/XStWnlT5mimk4L06cPj+847u6MvKH+TO29ULO7bpaOgkVemV9SmTVIW9FdHLmbI98VYBdgq/Ht3W6j55lKWvjGQUcucR1wBbLytH1UEa8vmrURvUBWHXpyex/NIrIND5A5PoaStbQybHMP1adtW0vy6HvichV/dqwaB6+nVxFXUf3s0Uy8hZq8/DXAnSntA/LPgqTfZXldxN/lAVlrm5W3sP//c8UgfmeLY/uN05q/MX/vswZqKkSuUmVxC4o9OnT5s+PXtp0cKFdkdxtPjx46t02bIqX6GCAgIDnro85s2Xz8qbL5/+3LrVfDN6tJYvXRYVMW2XJk0aNWz0iapWr+7W66yzmzQ8lxu7vzRfzT2pEFmST1IVb1RLmcJcCmX5xVWcmJJuSSbkrE6fcvZtZ8ydPWbX7vP3zmqR4mQOUE43uWH/rcP3J0GyJEXTK+8UU87kj4tudPGflVoTdEVGdyepyprFuavokaBd4SeGcMdJqsK9P37KWKCK3nnkxB2WYmcr5DaXeUrS0R1hJu6ImVlZMjl3WQrrvwk67q/vzpykygQf04lT/30cLVkKp/9tyjP4JlKi+JKOSJLRtatXQr90Y/cUTVp1WUaWrGjZVK1ZMSVy8IFl2G2o5ZdeBaq8r1SP3PzE0KsF0kVlNJeEX2d9lTJDxntfiW/l/SiPibNkmS6bG9q8ZIVOVa9pEl46pKMX7m533W2SKnfdrkrSP0F7Q2+54JfAX1n+9+RJqnaEmaQqTWD2x84gbrew65EkmZA7enj6OknyUfwMBVW9eVu1KJ3Jkc9FengfGOOVAiqXJ418H/FYnxjZ9V46xz6VcGJlKG31mPWGKTy+v/p9tUi7L91/00J0Pmiq2tb9V34zBpsiTPToslvHTuh0yP2XzUdJkzv3hIwnCT53SudC74hjKWHSpM/0fbdPBWnP6f/G8qkypI+khJg4YYIZMnCQrl69ancUx7EsSzly5lSevHmVJ19evf7668+1LXv1tdesr7/5Rvv27jPfffuN5s+dp+BgN5gAx0X+WbOqUePGKlGqpEds891nNIhnE3La/DTie/194/49o5Lo+p+jNXDbf3+sNyHHtf/+ztdc0elTVyQ5d3IVc+OBSWsCnH3GTljXdmzXwdBJkDKqQpfB+iTg8ZebLWgeaNYE3f13zLQBjp6kaucDk1RldsdJqsK9PxlUumUPNc7uzMsBXbUjaG+Y9ydAWZx/MoukexN07L//kZ/SBzp0go6Q67p6/b8PfV+O6zaXMLszyzexEoaeHBiif8MM7NeNn6qdtyxJPkpXoqkqO/w2MWG3obEyFFPL7q3k74b3pQ6/zsZUxsCMoV9LlL+ocsddpmWXpItbftZvZ2uoyMEDOnFvDOJuk1S563ZVOmMOHjodOhCM+Yq/Mjxpkqor2+5NDmpJiqUs2TNFQcbnE3Y98ombVgHpE8hXkrl1Snt3ntB1I8knicr2m6mBlZzfQD64D8xavJV6tg50fO5nYUVLZeVpOEJvl6lixvbsrK8XHdC1ewvljSM/aOjIsirSN4+9Id3QnetXdCP0KM9S7LjxnvRwxwq5/q9uhXbqlmLFerY/uJ1b/7v23Plv3o1srzl3e+Wutv39t+nSsZO2b3/WW9h5h+TJk4eWqO++957ix4+4A/cMGTNY/QYM0GctWpjxY8dq6uQp+vfffyPqx9vmzbfeUqNPP1W+/Pk8Yr92n7OPOOCya1u+0+ill/67tOZakH78NugJ32F09tQJOblUvfFPUJhJa+IrU0A6W/O4Ys/2naGTIPnG9Zf/K086M2Sb2bE77CRVgY6epCpo938TQyTKEhjubGh3Ee79iROgrBnc5+D+ScytLWbn7vvnJN2duCODm7w/N3Zv0z+h63s8ZXLoJFVSNMUIU0qE3Lih8yEyCSlWI1lCK2HCmMbSvzIyun79miTp9rEJZtKiMzKy5BMzl2p9Wljx5Nz34sFtaIKs2d2yUJXCr7OWX4ZwlyP7xCugD96PpeWLrivkxmZtWH9N+e4c1Zl7LZh7TVLlvttVE3xKp0MnZLYUJ2UqpXjCturi+l/+++N89EC9muvJtwqwy4PrUdqiPTS//90DNXNjrelUqJZmHrOkkHPaFXRaUjrbsj6r8PvAOPLP5i53cn920ZK+azUaOc+8meNTNe73270zjUN0eM1y/XEzj3nTgVenOJkVLWbY6Rp148a/CnuvcXfh+/LLinl/IkoZ/Xv9X0lPucVKyDGzZMFvunbvw5cS51G+t9xkp+ImunfpaiZPmmR3DEdInjy5ArNlU+533lGevHmVMVPGSN9WpUiRwurQqZMaN2lipkyapPFjx+nChQtP/0aHKfTBB2rYuNFzn8HrdJSqHsTcOWxmDp+sAy6dIX5H506elOTQs8EkXQo3aU1G+Qe6yWIbctrs2HE09J6LL2cKVOYn7OfNlb+18+B/9xLKGOjkSaq2hZmsw08ZnHo24ZM8+P5kyS5/Z04S7rI7l7drd5iJOzK60dndF4L+m5TOeimTsgY69EZ+vomUIN5/kwzdPH5QR4OlhA6N60kSJUooS8dkJN26dvfPIn9NnqCNV++epZqxbDPVzOjsS0gf3IZmyu7c7f3ThF1n/RJmlX/qsC99PCvvR3lM3J+W6pK5pq2//a6jaU7p7hzB7jVJlTtvVxVyNdyZ9dGiP7l02LxmvS7d++t8zPRv6tVkznyLwq9HLyljtv/GIlaMvFbJomnM7DFHFaIQ7V08Q6tbvmXyx3P28hZ+H5hFAdk9tSCKZ+Vq0M98sqqgvlh/98Dl9tmTOnNbkqc+5Ujilyi+4oaWkSE6fuiQnHyyzOP4xkuoeH7S3RsKh+j4oYOSUj7xe65sHqNpG+7POu+rLKWrK39cZ6/j7mLhjwtM7149dfbM2ac/2AOlz5BeAYGBCggIuPvfwMCHJpmKSvHjx7eaNGumJs2aaeKECWbMt9/p+LFjdsV5Jj4+PipVurQaNm6kzJkze/R66SbtFJ7F+dUjNPbXG3fPdLQSqWSPMfrkzUeNTG5oaY9y+nKDJBldPnVaF0JkEjj0wGZX0B7d311GTxGgLIkdGfMh5vY27dhz/yMfpcya/YlnhlzfsU17b9+f+CmZMmdLFvkhn9PN7dtCJ+uQTwplyeZ+s56Hf3/u3hDfHW/s/yg3dm7/b+IO35TKHOg+k4jt2B5mUroUTp2kSrJ801n+WRIZa8vdmWpvHP5NG/aFKEdWzzjb2ckSJownS3cHknduXNXxcwvMxFn7dUeWfGK/o9qN3rc54dOF24b6plLWHO63Db0v7DobO/PDExolzFtUueMt0dKLITrxxzr96nvu3h+z3GuSKnfersontmKHnkBsdPX8+cc+NPjCIrNo1f2ZxP3k/8FHjj2LOux6ZPmmVpaA+OG+/lqZkso4/mv9EyzdPrNcPyw9p/yVEtmQ9NmF2wemDFRWh+4Dn8XlI0fMnVRp9LjjC8snjfW/NHGMtf7u8mbFiKWYj7p5LJ7opeSBypjY0l+nJOmODq5fqz3Brxl3u4LMipVN/uktrdohSSE6vmm9dgW/ax63/TE3tpnv+07T/nsrjE+sN1Wx2qtRltfTrVm92m0K1Vy5cqlE6VK6cP6CDh48oHNnz+nOnWDdvh2sO3fuKPj2bQXfuaPg4NsKDr4jX18fJUmSREmTJVPSpEmVJElSJU2a9N7HSZQ+QwZHrzu1ate2atWurR/mzzejR32tPf8876zYkSN69OiqXKWK6n/cQKlSp3b0axlRKFU9hAneYSaNmK8T9067e9m/mj6u8qr8HzOh096kMYyluwXs7bMndTpESuDALsDcOWh27jobZtKaQL3mRpNU/XP+/l+OoyvjUw4eT27fqTP3J8CIntnREz8dCQo7WYe/oyfUepzw709MZcruPgf3T3MiaJfOhi5Lzp7wLCxzZ4/ZsetC6O1LnL6+53jvLcWbvkQXjWSCd2rW14tVblhxk/gxB5DHj541KVO7yV+FHCxR4oTykXRH0p1rVxQ0a4F+Pnv37MGslZqr8v+cf1/ksNtQ31j+CsjsHuvog8Kvs75KHRCoB5d/n3j5Vfj92Fq28JpuHF6jH6xzdwsUN5ukyl23q5Jk+aVWmlTRpB13b19w8a9ftOpSOVPgEWdtbhjZX4tP3/u+6DlVvHTWKM3qinBjkViZ5f/AxGHRs5bRR9m+0T9/hkjmitbN+UFHy9czqR066eSD+8B4/tn1qoP3gY93yfw1ubNaf7FWqT+ZqHHNcz7yUebWdvPn9gth7vWbRa9wtYfLrOiv6Z23YmvugruTy13dMV1jF1fXFyUf/Ycfc+2oOfFvKqVM7KwrOiy/AOud3KnMNzuOKUTStX/maNqKeurx0cO3ADB3TpifujbVN1vv3/4jpt5u1FnV0zt0/3/ngtm7eZMO3H5Fb72TUfHc4CSOgUMGW3v++ce4w31Ut2zZov379+uzli30WYvPHf/aRpTSZcpYpcuU0eqfV5nRX3+tTX/8YWueOHHjqGat2qpdt44SJUrkNe+DJDmwRsPzOLFgqCb/ff96oQQq/HEtBTxhIBY3XtzQf986e1JnHTqpnLm5TTv23n8afkoX4D6XmV8L2q6D98+g8EuvrIFPntFix/Z/Qi9Fj/m/QGVx8H3mdwTt/2+ClVcC3HOSqnDvT0YFZnOfg/un2RG0579l6ZUAZXKT98f8u007998/vHL+pHSJPqil4mnvfxSiAws6qEn3Rdp/7b+JASXpxvG1ZuQn+Uyxkm0091CIefgnwRXREyZU7Hu7hVvnftP3k7fqhiS/+AVUv8GbtmZ7VmG3oTEz5JC/m6yjDwq/zsZSpjCTVP0nnpWnaB7FsyQTfEB7990dcLjfJFXuuV29K7711jvZdP8ON7dPL9TgHj/o0L9htlUhZ8yvX9Uy7SYeubds+ihjmSaq5eBbaYRbj9IFKPMDu3HLN7NVvORroVeTX9o8R4t2h8ipHtwHZsiew9Y8z2vLiBqq1WWhDly7rHVDa6hMq0lmy8lb4fZ95tYRs/SLtpq88/5nYuqN4h8pnUMLb2eLZ31QvYzS3D/LN+Sk5naqry8W7HtovHHkl5GmUYkiqtxmuo7ekePGI7kqVVDW6PdihZzQzC6f6fvfz4XLee3wKvNlw/JqPfPwvSsZLSV5+zN1aujMY8SQq5vNyJqFVbxSQzWuXkL1+/1ud6RnNuqb0UqY0D1uJXHx4kX16NpNH31Q2Kxds8Zxy3Zkyl+wgDV91kxrxpzZKvTBB1H++5MkSfL/9u4zQMryXvjwf+hKlaaAxMJSlBIRUAFhZyHsjklOmieJqSbnmGjUHKMxrwmiiNJRQBEQpCia2FvsNZZYYmwRCwIqdkCRolER8Hk/oASU9uAuM7t7Xd9kp/x35tlx9zf3PHecMvhP8eTTT2dOOvn3meoWVCOsVK0Skg//kcw4/+5Y8enLx65FP4wjv7H1j6U1btIwasTS9St9Vi2Nd/4dEQV4PsmPFzwbCz47D1imUaXapGr+M/Pisz36ajXuFB333tomVU8lz72w+j+bVHXqXLAft0s+fix5bv7qDf/9/oKL4pf9rohMbP6Xs5pNcjHqutOjd73C+n42fn6StfNiyk/7xqzMln/BbHDgiTFn0vejRYG/u5ysfSqZt9Gx1LTD/tGhQI+lz/tw3txY8OF/Nqnq0GWvrV8hzzL1emd+c+r3kvt/c228tjYikvfi8TnHxzeuPzu6HtgxadVgbbw1f27Me3FpfLAuIuK1mDDsijj4wh8lbfzhuMNqNm0WjWtELF8X8fHrj8RjERFRK7r95Lj4VuvCDUCf+fxr6L/nXRg/PfSSLb6GRtSOPideHWN+UHifA974ZzZTq90W3zzcrd/X45Amt8Zty//zLVSqTaoq8evqZ/b+3lExaNqxceOSiIg1Me/a38U3/z49undvl+yWWRYvPzs3XnjtvQ2Rst5XDo+TT8rmb+Bt2PTnKBPNOnWOfTfznHzlm9+OHuMfi4f+nYlk7Qtx85WPx9FnFOabL5v8PzDWxpMzfhz9Ls1s8feSTO0D4+SrJsW3di+s170uh/8qBlx9Utz46rqI5P145prT4wc3ToqOB341KWrTODKr3oiFTz8ZLyxZ/Z9VuV3+N/7vJ/vkde7KrMFBJ8QfDr8nfnflm5/+bfd0zPxtLq4+u1tywH6to/6axfHCM8/Fy0s+WP/m0KJxMfaKfnHej/fM8+Sbqtfpd5n/9/ObkqMufDHWRMSatx+IUUeUxGUH9Er227NefLB4fsx9amG8+9megZGJpt2OiXOn/Do6FdjfGZ958bKRMeWhZZ++tq6OF+66K2LwQXmeavu0btMmM3X6tORnP/lJfLz6421foQAsXLgw/ufIX0RxSTYZfOqQaFdU2B/lL089evTITJtxYcyfPz+58IJp8dcbboh169Zt+4o7aK+9945fH3N0/PCII6rNY7wlomoVsPCK8XHNZ29GZhrGgKOOjK7b2DmzceP/nMU7Wbc0liz5JKJZ4a0YWf783Hj901W0mVpF0bFz4X4kfhOfLNlkE6Rd23fZ6h+Pycpn4vlXPon/bFJVuCv01q6YG89v2BgiIlaviMVvrdji5Ru23iP2LLSn7XPPT8RHsXzxW1u5Qo3o2Gyvgg+qERHJymfjuY2OpXaVaHX35zep6lSom1RtZI9B52QmnrYiOX74PfHWpyd/XrNqUTxx76IvXLZOsx7x3SP6h6D65dRq0TyaxEavQRFRu8VhcdQvKseqrs+/hiYfLY+tv/zsGc3aNtkZo6W28c9s7WadolPbzR/aNRr1j0H9Gsbtf31/w6kC2nTav9JsUlWZX1c/U6PJYZnB436ZLDxudjz/3vp/+3Dpc/HQ7c994bJ1Ww2IwecPi4EFFus2tunPUa0o2sKGmbVbHBbfPHRkPHz7R5HEulhwy5Vx30m9kuIC3Mxm45+niIgPly/e8Obv5tRt2zzaNCm4byPqtPlWZsTMtUm9k4bFNXNXrf9d6+O344VH7ooXvnDpTDTt8rMYdcGJ0W3XwntOKo0azTO5odOSP674VYy5Y/Gn5+VdGytfeSLue+WJz124Vuze4/vx3X6FuXdDn5MviKGLfxHDbnxj/UrUT96LRU/cE4s+/21k6sd+/3VyDB96ZHy1WeG+Vr3+8qsb9gaJiKi3e6u8zbIjevTsmZl47nnJsccck+9RUrnvb/fG3+9/IH75v/+b/HHwnwr2+KgIHTp0yIwbf06c+PuTkpkzZsYVl10WH330UbndfufOnePoY38TX//GN6rV47o1hVfRSOWTlbcn06c9Gv/+9L932ecHceS39tjm9Ro1abjhyU/WvRNLl1TcuxhfxvxnFsRn74vV2WO/6NSichyyn98Eqc1+Xba6CdIHzz29ySZVHQt5k6q5G22wsk01Yo/9ukTbAotImz4/26PybKjywby58dKGY2mP6FCJNhH7wiZVleT0o189cmbmqsvPjB/13SsafOGtykzs0rJrHParcXHVHVfESaVtKsc3VcBqNW0WTTbZzKROHPizY6O0ReH+UbWxdK+hETXqdYr9C/Qc2xv/zNZv3yXab3HMxplDy9afAmC9ulHUZf8Kn6+8VObX1Y216H965tIrz45fDmwXjTazrCJTd/fodfjgmHX19Phxt10K+udpk5+jmm2iw/5b2ICqRvPMwG8PiM/a45q3b4+/3rFs5wyZ0sY/T9ujYYcuUVSgq713bf+9zMhrboqpf/rv6F3UKL64/1SNaNC6Z3z/99PjqquGxcA9C/RcmJVIpn6XzC+m3BAXj/hJHLJPgy8+5pm60apLaRwz9tq46Yo/RUnb2gX5mGfqFmWOmHhdXDLqp3HwXpv5Pmo0jH17/zBOmXpD3HjeLzKFHFQjIjr37xu7f/p6W2u3XvHrk4/I70A7oDRXljl92Bn5HiO1devWxYzp06Nf7z7JHbfdXq1OCRCxfqXxaUNPz9z/0IPx2xNOiMaNv9y5BQ/pfUhcdMmcuOHmmzKC6qYySVLtji8AqBCrl81P/vWvl2Lxsvfik12bxR5t28ch3bawfA8gT9asXJQ889S8eP2dVfHhJ/WiScu9okuPbtG6QWEHCiqnJQseSxYueiuWvLs6ajdsGq2KukXPDpXkndNK6u0F/0ieWbgk3n1vbezavFV8pahLdP5Kw0r3mC994ZHkmZcWx/L3M9G4VdvYu6hTFO2xa6X6PhY/fXvy6Cv1osPBvaNTyzoFMfuKFSuSJk3SLXUfO3pMMv2CCypqpAqXLSmJoWcOi7Ztq+/v5RfNmpXMvHBGvPXW1j4italBZaVx9DHHxAHdu1fbx21bRFUAAACAKuz6665Lzhk7LurUqRMXXXpJ6sD4+9+dmNxw/fUVNF3Fq1u3bhz329/GsccfV60D4bVXX51Mv2BaLFy4cLNfr1mzZnz7u9+JXx99TBS1L6rWj9X2EFUBAAAAqqB/PPJIMmr4iHjmmWc2/FvzFs1j1kUXx/6d908VzX7+k58mDz34YLnPuDPt227fGHbW8Ojdp3e1DoZ33XlnMm3q1HjyiScjIqJevXpxxI9/FP9z1FHRunXrav3YpCGqAgAAAFQhL7/0UjJm1Oi46847N/v1+vXrxwUXXpg6Lv74h0ckj/7jH+UyYz59+zvfiT+dOjiat2hRrQPiPx99NHni8cfj+z/8YTRt2rRaPxY7QlQFAAAAqALefffd5Pxzz4s/X3pprFu39Q2pa9euHedMnJB6N/eqElYbNGwYJ//hD/HTn/9MTGSHiKoAAAAAldyF06Ylk8+fHO+/916q650+7Iz4+ZFHVsuwGhHRtVu3OGvE8OjStau4SiqiKgAAAEAlddNfb0zGjR0Tb7z+xg7fxm+OOzZ+/4c/VNuwmslk4qc/+1kMPXOYsMp2E1UBAAAAKpnHH3ssGTl8RPzrqafK5fb++wffj9Fjx1bbsBoR0ax58zh1yJD41ne+La6yTaIqAAAAQCXxyiuvJGNHjY7bb7ut3G+7ZMCAuHDWzFRB8eijfpXcfddd5T5LPvXu0yeGnXVm7NuunbjKFomqAAAAAAVuxYoVyeRJk+KSi+fE2rVrK+x+uh/YPabPnBm77bbbdgfFIYNPTS7/y18qbKZ8qF27dvzq6KPjpJN/L6yyWaIqAAAAQAGbPXNWMuncc2PVqlU75f7aFbWL2XPmROvWrbc7KE6eNCmZcM74ihwrL9q2bRtnnHlmFJdkxVU2IaoCAAAAFKDbbr01GTtqdLz66qs7/b533333mH3JnOjQocN2x8Srr7wqGfzHP8Ynn3xSkaPlRVkuF0OGnh6tWrUSV4kIURUAAACgoDz15JPJyOEj4onHH8/rHA0bNYwLZ86Mnr16bXdIvO/e+5ITjj8+3n///YocLS922WWXOOHEE+OoX/9KWEVUBQAAACgEr7/2ejJu7Ji4+cab8j3KBnXq1olzJ02KQaWl2x0SX37ppeTYo4+JBQsWVORoedOhY8c4a8Tw6NGzp7hajYmqAAAAAHm0auWqZMrkyXHx7NmxZs2afI/zBZlMJs4aOSKO+NGPUkXEE47/bXLzTYUTiMvb93/wg/jDH0+Jpk2biqvVkKgKAAAAkCdzLr44OW/CxFixYkW+R9mm3510Yhz/f/+XKiDOnjkrGTViRJU8z2pExG677RZDhw2Lb37rv4TVakZUBQAAANjJ7rrzzmTMqNHx8ksv5XuUVH7805/EmcOHpwqI/3z00eT4Y4+LZe+8U1Fj5d2g0kExbPjwaNmypbhaTYiqAAAAADvJM3PnJqNGjIh/PPKPfI+yw0pzZTHlggtSxcMlS5Ykvz32uLxvvlWRGjVqFEOGnh7fO/xwYbUaEFUBAAAAKtibb76ZjB93dlx/3XX5HqVcHHTwwXHB9OnRqHGjVAFx5PDhyawZMytqrIJQXJKN4SNHRqtWrcTVKkxUBQAAAKhA54wbl8ycMSM+Xv1xvkcpVx06dozZcy6O3XffPVU8fOLxJ5LBp5wSCxcurKjR8q5Bgwbxx1MHp97ci8pDVAUAAACoAH+59M/JxAkT4t1ly/I9SoVp3aZNXDTn4ti3XbvU8fC8iROTKedPjrVr11bEaAWhd58+MXLM6Gjbtq24WsWIqgAAAADl6N57/paMHjmySq/E3FiTJk1ixuxZcUD37qnD4fz585PBp5wSTz35VAVMVhh22WWX+MMfT4mfH3mksFqFiKoAAAAA5eD5555LRo0YGQ89+GC+R9np6tWrF5OnTo3ikuwOhcOLL7ooOXvM2Pjwww/Le7SC0bNXrxg3/hyrVqsIURUAAADgS1iyZEky/uyz45qrrs73KHlVo0aNGD1ubHzv8MN3KBq++cYbyZBTT437772vvEcrGPXr149hw8+K73z3u8JqJVcj3wMAAAAAVFbnTpiYDCzOVvugGhGx9z57xwvz5u3w9Vu3aZOZddFFmfETJ0bTZs3KcbLC8e9//ztOPvGkOPGEE5JVK1dZ6ViJWakKAAAAkNKVV1yRTDj7nHj77bfzPUre1K1bN/r07RvF2WwUl2TL/WPtU86fnEyfNi3ef++98rzZgtG6TZsYP3FC9OzVy6rVSkhUBQAAANhOf3/ggWTUiJFfakVmZbbX3ntHtqQksiXZ6Ne/f4XHwJUrVyYzpk+P2TNnxUcffVTRd7fTZTKZ+M1xx8VJJ/9eWK1kRFUAAACAbZg/f34yesSIuP+++/M9yk5Vp26dOKR37/WrUbPZ2HvvvfMS/955++1k6pSp8ZdLL401a9bkY4QK9dUDDojx506MvfbaS1ytJERVAAAAgC145+23k4njJ8QVl18e1aWhtG3bNrIlJVGczUZ2QElBRb4333gjOf+8SXH1VVfFJ598ku9xytWuu+4aQ4cNi8O//98F9ZizeaIqAAAAwGZMnjQpmTb1gvjggw/yPUqFql27dhx8yCHrI2pJNvbZd9+Cj3qLXn45mT1rVlx79TXx4Ycf5nuccnXY178ek6ZMLvjnoLoTVQEAAAA2cu3VVyfnjDs7lixZku9RKkzrNm0iW5KNbElJDBg4sFIHvItnz07mXDwnXlm0KN+jlJt2Re1i2owZeTvdAtsmqgIAAABExMMPPZyMGjE8nnv2uXyPUu5q1aoVvQ466NPVqCVR1L6oysW6B+6/P5lz0cXxt3vuyfco5aJRo0Zx/tQp0adv3yr3XFUFoioAAABQrb248MVkzKhRcc/dd+d7lHLVqlWr9RtMlWRjUGlptQlzr776anL9tdfGrbfcGgvmz8/3OF9KjRo14tTTT4sjf/GLavP8VRaiKgAAAFAtLVu2LDlv4sS47M9/qRKbHtWsWTN69uq5YTVqh44dq32Ie3Hhi8ltt94at95yS8x7/vl8j7PDfnjEETFi9Khq/3wWElEVAAAAqHamTZ2aTJ08Jd5///18j/KltGzZckNELTssJ7ptxaKXX05uu/W2uPuuO2Pu03Nj7dq1+R4plZ69esXkC6ZGs2bNPM8FQFQFAAAAqo2/Xn9DMm7s2HjrzTfzPcoOqVGjRhzYo0dkS0qiOFsc++2/v8CW0qgRI5LZM2dVytXJrdu0iekzLoxO++3nec8zURUAAACo8v756KPJyOEjYu7TT+d7lNSat2ge/YuLI1tSEoce2i8aNW4kqO2Au+68Mxl2+tB466238j3Kl1K/fv249LK/RNdu3RwHeSSqAgAAAFXWopdfTsaMHh133n5HvkfZbplMJrp37x7FJSVRXJKNLl26iGdfwptvvpmcdcYZcecdd+Z7lHLTpEmTuOyqK6N9+/aOjTwRVQEAAIAqZ/ny5cn5502KS+fMiXXr1uV7nG1q2rRpFGezUZzNxqH9+0WTJk3EsnIwa8bMZOL48fHBBx/ke5Ry17lz57jh5pscJ3lSK98DAAAAAJSnGdMvTCafPyneW/VevkfZqq8ecEBkS9aH1G5f/ao4Vo6e/te/kiGDB8dzzz6X71HKVes2baIsVxZluVz07NXLMZNHoioAAABQJdxy883JuNFj4rXXXsv3KJvVpEmT6Ffcf/25Ufv1s4t7BTnjtNOTSy+5JN9jlJuioqIozeWiLJeLzl06O2YKhKgKAAAAVGpPPP5EMmrE8HjyiSfzPcoXdOnaNbIlJVGczUb3A7sLYhXolptvTs46Y1i8/fbb+R7lS+vStWuU5XJRWlYW7YraOW4KkKgKAAAAVEqvvvpqcvaYsXHLzTfne5QNGjVqFP3694/ikmz0798/mrdoIYhVsNdeey0Zetppcf+99+V7lC+l10EHRVmuLAaVlkabPfd03BQ4URUAAACoVFauXJlMOf/8mHPRxbFmzZp8jxP7d95/w2rUHj17imE70QVTpiaTzj03Vq9ene9RUqtVq1b06dsnSnO5+NrXvibAVzKiKgAAAFBpXDx7dnLexHNj5cqVeZuhQcOG0a9fvyjOZqN/tjhatmwphu1kjz/2WDLkT4NjwYIF+R4llbp160ZxSTbKcrkoKRkQjRo3cuxUUqIqAAAAUPDuuO32ZMzo0fHKokV5uf+OnTpFtiQb2ZKS6HXQQUJYnqxYsSIZN3pMXHH55fkeZbs1aNgwBg4cuP4cqbkyx04VIaoCAAAABWvu008nI4ePiH8++uhOvd/69etH336Hrl+NWlwcrVq1EsPy7PrrrktGnjU83n333XyPsk1NmzWL0tLSKM2VRf/iYsdOFSSqAgAAAAXnjddfT84Zd3b89YYbdtp9tu/QIYqz61ejHtL7ECGsQLz80kvJ6UNOi4cfeijfo2xV6zZtoixXFmW5XPTs1cvxU8WJqgAAAEBBGTdmTDJ75qz4+OOPK/R+dtlll+h76KFRnC2O4mw2WrdpI4QVmPMmTkymTp5SEBuSbU67onaffqw/F126dHH8VCOiKgAAAFAQLp1zSXLexIkV+vHudkXtNqxG7dO3rwhWoB5+6OHktFNPjUUvv5zvUb6gS5cuUZrLRWlZWRS1L3IMVVOiKgAAAJBX99x9dzJ65Mh46cWXyv2269atG3369o1sSUkUZ7OxZ9s9RbACtmzZsmTU8BFx/XXX5XuUTfTs1Wv9itSy0mizp2MIURUAAADIk2efeTYZNWJEPPLww+V6u3vvs8+nq1Gz0a9/fwGskrji8suTMSNHxapVq/I9StSqVSt69+kTZbmy+NqgQdG8RQvHEZsQVQEAAICdavHixck5486O6665plxur07dOnFI794bVqPutddeAlglMn/+/OS0wafG4489ltc56tatG8Ul2SjL5aKkZEA0atzIccQWiaoAAADATjPhnPHJjOnTY/Xq1V/qdtq2bRvZkpL1IbUkK35VUuPGjElmTL8w1q1bl5f7b9CwYQwcOPDTzabKHEdsN1EVAAAAqHCXX3ZZMuGc8bHsnXd26Pq1a9eOgw85JLIl2SjOZmOfffcVwCqx++69Lxk6ZEi8/vrrO/2+mzZrFqWlpVGaK4v+xcWOI3aIqAoAAABUmPvuvS8ZPXJkLJg/P/V1W7dpE9mSbGRLSmLAwIHiVxWwdOnSZPiwM+OWm2/eqffbqnXrKMuVRVkuF70OOsixxJcmqgIAAADl7oV585JRI0bG3x94YLuvU6tWreh10EEbzo1a1L5I/KpCLpkzJzln7Lh4//33d8r97bPvvpE7LBdluVx06drVsUS5ElUBAACAcrN06dJk4jnj46orr4wkSbZ5+VatWkVxNhvFJdkYVFoqfFVBzz7zbDJk8OCY+/TTFX5fnTt3jtLc+pAqylORRFUAAACgXEw699xk+gXT4sMPP9ziZWrWrBk9e/XcsBq1Q8eOwlcVNuKss5KLZs3ersC+o3r26hWlZWVRWlYWe7bd0/HETiGqAgAAAF/K1VdelYw/++xYunTpZr/esmXLDRG17LCc6FUN3HH7HcmZQ4fG4sWLy/22a9asGX369o2yXFl8bdCgaN6ihWOKnU5UBQAAAHbIQw8+mIwcPiLmPf/8Jv9eo0aNOLBHj09DanHst//+olc18eYbbyTDhp4Rd991V7nebt26daN/tjjKcrkoGTAgGjdu7Jgir0RVAAAAIJUFCxYkY0aOinv/9rcN/9a8RfP150bNZuPQQ/tFo8aNRK9qZsb0C5NzJ0zY6ukf0mjQoEEMGDgwynI5K5wpOJmKPKcFAAAAUHUse+edZOKECXHFZZdHkiTRvXv3KC4piWxJSXTu0ln0qqaeevLJZMjgU7+wYnlHNG3aNAaVlkZpLhfF2WLHFAVLVAUAAAC2aerkKcnVV14ZB/bosX41av9+0aRJE9Grmht62mnJny+59EvdRqvWraO0rCzKcmVx0MEHO6aoFERVAAAAYIteeeWV5LFH/xkdOnaIrt26CV5ERMRNN96YDD/zzHjn7Xd26Pr77Ltv5A7LRVkuF126dnVcUemIqgAAAABsl1dffTUZOuS0eOD++1Nft3PnzlGaWx9Si9oXCalUajaqAgAAAGCbppw/OTl/0nnx8eqPt/s6PXr2jLJcLkrLymLPtnsKqVQZoioAAAAAW/TPRx9NTht8aixcuHCbl61Zs2b07tMnynJl8bVBpdGiZQshlSpJVAUAAADgC5YvX56MGTUqrr7yqq1erk7dOlFcXByluVwMGDgwGjduLKRS5YmqAAAAAGzi2muuSUYNHxHLly/f7NcbNGgQJQMHRFkuF7nDDhNRqXZEVQAAAAAiIuKlF19MTh8yJB55+JEvfK1p06YxqLQ0SsvKorgkK6RSrYmqAAAAAMTE8ROSaVOnxpo1azb8W6tWraI0l4uyXFkcdPDBQip8SlQFAAAAqMYeevDB5LRTh8QrixZFRMTe++wTucNyUZbLRddu3YRU2IxMkiT5ngEAAACAnWzZO+8kI84aHn+94YbYv/P+UZbLRWkuF+3btxdSYRtEVQAAAIBq5orLL0/uuuPOOKR37yjNlUXbtm2FVEhBVAUAAACoRl6YNy/ZrWnTaNmypZAKO0hUBQAAAABIoUa+BwAAAAAAqExEVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBREVQAAAACAFERVAAAAAIAURFUAAAAAgBT+PxHUlgJ18bZuAAAAAElFTkSuQmCC';
+const ICON_SRC = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAABAAAAAQACAYAAAB/HSuDAADNc0lEQVR4nOzdd5gUVfr28bvjYEBylCRxYBhgGDIKohLFsCZUFNOqJJUgSBJcBCUoYFhzzgFzzrqirLquimJY3Z9xDSgo7iow09Pn/cP3FNU9PYkJXT31/VyXFzCxQ1VZz33OeU7AGCMAAAAAAFC7BdP9AAAAAAAAQPUjAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAAAAAPABAgAAAAAAAHyAAAAAAAAAAB8gAAAAAAAAwAcIAAAAAAAA8AECAAAAAAAAfIAAAAAAAAAAHyAAAAAAAADABwgAAAAAAADwAQIAAAAAAAB8gAAAAAAAAAAfIAAAAAAAAMAHCAAAAADgaZs3bzaff/65SffjAIBMF073AwAAAABK89NPP+mkk06SJJOdna22bdsqNzdXubm56tKlSyDdjw8AMkXAGMJUAAAAeNu9995rJkyYIEkqKChQMBjU7rvvrtatWys3N1cDBgxQnz591KlTJzVv3pxQAABSIAAAAABARpg8ebK57rrrFI/HZe9hQ6GQJKmoqEihUEj16tVTdna2evToof79+ysvL089e/YkEAAAEQAAAAAggwwcONC8+eabkqRAIOAU/kVFRQoEAgqFQorFYgoGg4rH44pEItp7773VpUsX7bffftpvv/00ZMgQAgEAvkQAAAAAgIzx7rvvmv33319bt251Cn9JCofDisViCoVCisfjpf6Mxo0bq0uXLurTp4/69u2rXr16qVu3boQCAGo9AgAAAABklDvuuMOcfPLJzlKAQCAgY0zCTIDS2K8zxigYDCoajapp06bq0aOHunfvrv79+6t79+7q2LEjoQCAWoUAAAAAABnnpJNOMrfddptCoZCMMYrH4woEAk4YUBobEBhjEr7W/b177rmnmjVrps6dO6t///7Kz89Xt27d1L59e0IBABmLAAAAAAAZ56effjKDBg3S559/nrDmX1KZMwDs/W8wGHT+bYMEO4PAzg6wIUEgENCee+6pFi1aqGfPnsrLy9PAgQPVtWtXNWvWjFAAQEYgAAAAAEBGeuGFF8zo0aOdwr+oqCghCChJJBJxegfYr7f3xO7CPxAIODML7NfZWQb2c3vuuafat2+vvLw8DRgwQLm5uRo4cCCBAABPIgAAAABAxpo5c6ZZs2ZNmUV/KsnLBdwzB2wAYL/Gve2g3XnA/f3uZoQNGjRQ586dlZ+fr969e6tnz57q1asXoQCAtCMAAAAAQEbLz883GzZsUCwWq/D32kLe3RTQjvS7Jd8zu3sPSEqYGRAIBJzHEggEFI1G1axZM+Xk5Cg7O1v5+fnq2rWrevfuTSgAoEYRAAAAACCjffDBB2bAgAH67bffErYGLE3yUgH3en9p57aCyV+b/PPdDQXt10pKCBHsx+wSBWOMs/OADQT69u2rHj16sPMAgGpFAAAAAICMt2bNGjN9+vRi0/jdxbu7OK+M8jYZLOnr3UsHbC8BSapbt66aNm2q3Nxc5efna8CAAcrOzlarVq0IBQBUCQIAAAAA1AojR440zz77rNO0z07RL09jwIqobACQqqGgnX1gew9YdevWVfv27dWzZ08NGjRIeXl5atu2rZo0aUIoAKDCCAAAAABQK3z99demd+/e+umnnyQlbvNXlfe8lQ0A3J8vaftC99IC99eHw2E1atRI2dnZysvLU+/evdW7d2/l5OQQCAAoEwEAAAAAao0HHnjAHH300QoGg8V6ASSv199V1RUASDt7DNhZDO7dBWxzwXA4rKKiIuf7dtttNzVr1ky9e/dW3759lZ+fr5ycHLVs2ZJQAEACAgAAAADUKhMnTjTXXnttyoaAkUhEhYWFlfr5VdEDIPnrkrcjdC8FcG9BGI/Hnd4GyTMc3DMJGjRooDZt2qh79+7q16+f+vTpo86dO6tRo0aEAoCPEQAAAACg1unevbvZuHFjwnr75KaAu6oqZwAki0QiisViCUW/DTFs0e/e7tAdCri/3v19djZBs2bN1KFDB3Xt2lVdunRRTk6O8vPz1bhxY0IBwCcIAAAAAFDrvPXWW2bfffd1Rvvd2/R5KQAobWeCUCikQCCQUMjb0f5U3+duKGh/dvLMAPv7I5GIAoGAWrdurVtuuUX77rsvIQDgA8F0PwAAAACgqvXt2zdwwQUXKBQKFZte7wWBQEDhcFjSH0V8KBRy/m0ZY1RUVJQwxd8+F/vvQCDgFPPJSwrcMwfsx+zztz0EvvzySx133HFav349o4KADzADAAAAALXWfvvtZ15//fViI+X2Hjh5aUBVbxmYDuWZoeCeLRAKhdS6dWs9/vjj6tatmzcSEgDVggAAAAAAtdbnn39u8vLy9Ouvvzrr4ksq+JNH0TNVeQIAuzzA/luS9tlnHz399NPq3LkzIQBQS7EEAAAAALXWPvvsE7j88ssVCoWc5np2SrzlniKf/LnaKBAIJDRGtP7zn//o8MMP11dffZX5KQiAlGr/FQ4AAAC+NmHChMCJJ56oSCQi6Y819/F4XOFwOOOn++8KuwTAzoCwYrGYPv74Yx1yyCH65ptvCAGAWoglAAAAAKj1tmzZYvLz8/Xtt99KkgoKCoqNgNeG9f8VFYlEnIaAgUDAWSbRr18/PfLII2rWrBnLAYBahBkAAAAAqPUaNmwYuO+++xSPx1VQUODsDmCLXknOrIDazo7629cgHo8rGo3KGOMsk3jjjTd05JFHasuWLYwWArUIAQAAAAB8oW/fvoGLL75YwWBQRUVFTgFst8uTVCuaAJbFznIoKipSLBZz+iNIUjgcdpoIvvbaazrqqKO0devW2v+iAD7BEgAAAAD4ypFHHmkeffRRpxeAXQpgt8bzyzKAYDCoYDDoFP9u7u0Rhw0bpueff56lAEAtQAAAAIDPPP3002bu3Llq3ry5OnXqpG7duqlHjx7q3LmzGjduzE0+ar2ffvrJ9OnTR//5z3+c4teOevspACiLDUSMMTrkkEP0yCOPcH0AMhwBAAAAPrJ06VKzbNky/f777wl7n4dCIdWvX1+dO3dWp06dlJeXp+7du6tHjx5q0qQJN/2odV5//XUzePBgSf5s/leWSCSiwsJCZ6cEY4wOO+wwPfTQQ1wPgAxGAAAAgA9s3brVzJ49WzfeeKOz3tnd+MxOf7Zsk7A999xTrVq1UufOndW9e3fl5eWpY8eOatWqlRo0aEAhgIx23nnnmdWrVysejyf0AUAie20IBoP605/+pPvvv59zH8hQBAAAANRyn376qTn11FP12muvJUxvDgaDCgQCKQsfuxWYpISt0gKBgLKystSoUSO1b99eubm56t27t/Lz89WuXTvVr1+fwgAZpVevXmbDhg0KBoNOR3zslLxVYigU0vjx43XrrbdyrgMZiAAAAIBa7Omnnzann366vvnmG2easx3Nczc9s/+WEtdAu2/+7YwBY4yMMU5IYIxRNBpVo0aN1LFjR3Xq1El9+vRR165d1blzZ7Vs2ZJCAZ71wQcfmL59+yoWiykWi7Ec4P+zU//j8bgzI8j+3Rij0047Tddffz3nNpBhCAAAAKilVq1aZebMmaNAIKDCwsKU25slhwH2Y+4AIHlkNHlE0H6NnTFgC6hwOKw99thDbdq0UdeuXdWzZ0/l5eWpS5cuat++PYUDPOPyyy8306ZNc84Dv98fh8NhxWIxhcNhJ+SzbPAXCAQ0bdo0rVq1inMZyCAEAAAA1EJnnXWWueqqq5yiPRKJSJIKCwslld70zN78Syo2O8B+zM4AkJTwc+zX2dDAjhxKcvZdj0Qiat26tTp06KAePXqoR48eysnJUZs2bdSwYUOKCaTF2LFjzZNPPun74t/NvRWgeyZAOBxWQUGBJOniiy/WnDlzOG+BDEEAAABALfLDDz+YCRMm6Pnnn09Y3+9u4uUeqZdU4mi//bf9OcnFffI9hDsscC83cH9fKBRSYWFhsQAiEolor732UseOHdWlSxf17dtXubm5ysnJYWtC1IhNmzaZ7t27a8uWLTQEdEkOAVJ97qqrrtKkSZM4T4EMQAAAAEAtsXHjRjN+/Hht2LCh0qOY7h0BUimp+K8qxhhFIhHVq1dPbdq0UXZ2tvLy8tS3b1916tSJvgKoFg888IAZN26cJCXslmEDr5IKYT9yzwQKhUK64447dPTRR3NeAh5HAAAAQC3w4IMPmilTpuj777+vkjXM6Q4AbAMyyz1roU6dOtpnn33UpUsX5efnKzc3V9nZ2erUqRPFBypt0qRJ5oYbbnAaAlL4l8xea6LRqILBoG677TZCAMDjCAAAAMhwF110kVm8eLF27NiRsH6/MtIdALiXDdjCyxZf4XBYkhL6FGRlZalZs2bKzc1V165dneUDvXv3phhBhbVv39589913KioqUmFhobNbBgFAIvdOAeFwWHXr1tU999yjESNGcN4BHkUAAABABjvmmGPM2rVrq7x7eboDgJK2InT/2z06GwgEFA6HZYxxgoHdd99d9erVU7t27ZwdCHJzc9W+fXs1a9aMAgUlevvtt82QIUP0+++/Jxx/BAF/sK9JqnOxbt26euyxxzR06FDOMcCDCAAAAMhAH3/8sTn++OP17rvvOs367Eic3aarMtIdALh/vm1EmFx0pXoMyY0I7ceNMSoqKlI0GlWDBg3UsmVLderUSbm5uerZsydLCFDMJZdcYmbNmiVJCbtZpGqA6Ufu7QClnedjOBxWo0aN9Pjjj6tPnz6cU4DHEAAAAJBh7rjjDjNjxgxt3rzZ6epvC+SqWqfspQAgmXuHgdK+1z09OXnkNnlUNxqNqnnz5uratau6dOmi3r17q0uXLurYsaMaNWpEEeNTI0eONM8991yx0W6/zwBwS94i0P69cePGeuqpp1iGA3gMAQAAABnkL3/5i1mxYoV+//33hELEjsZVxei/5N0AIFUhHwqFJCVuZ+h+DZK3O7T/th3M7d/d32NDgQYNGqht27bKyclRjx491KNHD3Xs2FGtW7emqPGBL774wvTr10+//PJLyu0r/Sp5m0/3LCRp5wyc1q1b65lnnlGXLl04XwCPIAAAACAD/PLLL+bUU0/Vww8/XGy9f3V0Kk93ACAlFuru52cLfBsGpJqSnfx43KP99jVKfh3t50oLUgKBgOrUqaN27dqpU6dOysvLU05Ojrp27aru3btT5NRCTzzxhDn00EMTjhfun3dyzwCwr43tx2GMUZs2bfTkk0+qa9eunB+ABxAAAADgcR9++KE54YQT9N5771XpNH8/qWhAUVagYPeGt0FCOBxWkyZNlJ2drQ4dOqhPnz7Kzs5W165d1bRpUwqfDHf22Weba6+9VrFYLCEAcAdIVTX7pjbKycnRo48+qvbt23MuAGlGAAAAgIc99NBDZvLkyfr+++/T/VAyWlUHAO714O4lBslToOvVq6fWrVurS5cu6tGjh3r37q0OHTowJToD9evXz/zzn/9MmD0i7dyxIrkzvt+5GyfG43H16tVLTzzxhFq2bMmxD6QRAQAAAB61YsUKs2DBAsViMYXDYRUWFkpipHFXVHUAUFqPAkkJzRnt3+3Hd9ttNzVv3lwdO3ZUz5491atXL/Xo0UM5OTkURh720UcfmR49ekja2TMiuSElTQL/EAqFnNfFvhbhcFh9+/bVY489RmNNII0IAAAA8KBjjz3W3HvvvSWu9UfFVFcAkDza6y743dsXlvQ10h/FUiQSUf369dW1a1fl5OSoZ8+e6tq1qzp27KhmzZpRLHnEDTfcYM4888xiI/7uQpcAIJE93iWpqKhI++67rx5++GFCACBNCAAAAPCQb775xhxzzDF64403KCKqUFUHAMlfU9bn7dfY/5JncNiPSzt3K4hGo6pbt66zhKBr167q1auXunfvrg4dOlA8pckRRxxhHn74YWdWjjsASN5xojpk2hIDOxtA2rlrx4EHHqi77rpLDRo04DgGahgBAAAAHrFu3Tozfvx4ffXVV5LkrC+PxWLOvwkFdk11LgFwT/9OVtIsAPd7mbwTgV3iEQ6HFY/HE8KCUCikrKwsNW3aVB07dlRubq5yc3NtKKCGDRtSUFWzLVu2mD59+uibb75xZgLEYjEFAoGEpTpVzX0Mev3+Pbk5oiRnSYz9+JFHHqm1a9dyvAI1jAAAAAAPuO2228xZZ52l//3vf8W21LIFYWmFJkpX1QGA+/0paTlA8sfK2rbQ/kx3MJDcSM2957o7GIhEImrQoIE6deqkDh06KD8/X926dVNOTo5atGhBkVXFnn32WTNmzBjn/XJvhVddIV0mBQCSis2GSF7OFI/HddJJJ+mWW27h+ARqEAEAAABpNnfuXLN8+fJiRZ2UetSfJoAVVx0zAOzovn0vSiriy5otkPx9Jc0OsL/PHTwkLytIPl7q1aundu3aqWvXrurZs6ezPWGrVq0ouipp/vz5Zvny5QmzO6orAChvE0qvcB/n4XDYmSGR3BDTGKNp06Zp1apVHI9ADSEAAAAgTbZu3WqmTJmiu+++m6n9SFCegq+0UMMdFrgDimg0qmg0qo4dOyonJ0d5eXnq1q2bsrOz1a5dO4qwCurTp4955513JMlZrpNpa/TTwb17QigU0pIlS3Teeedx/AE1gAAAAIA0+Pe//22OPfZYvfvuu87+8RQOsMo73bukEMDOEknuLWCPMXvMSX8sH9h9993VvHlz5eTkKDs7W7169VKXLl3Uo0cPirJSvP/++2bgwIH67bff6NFRAba/hZ25Eo1GtWLFCp1zzjkcb0A1IwAAAKCGPfbYY+aMM87QTz/9lFD82ymytukf/Ksi670rsgNBcl+J5M+57bHHHmrUqJHat2+vHj16OA0HO3bsSLNBl8svv9xMnz7dKWYJ8soneVvTYDCoq666SmeeeSbHFlCNCAAAAKhBixYtMhdeeKGzftv9/2F3sz/+/+xvFT0GSloyUFbjSDsrwM4WsI3b7IwBuwuBu6P7nnvuqdatWys3N1e9e/dW165dlZ2d7eutCQ8//HDz2GOPMQOgnEprmHnLLbfopJNO8u2xBFQ3AgAAAGrI0UcfbdauXZuwzZtdM2wLtVAopFgsRgCACkm1S4G7OV1yEOAOm8LhsLMsoKQdCkpaamCbFtatW1ctWrRQdna2srOz1bNnT2dHgvr169f6Yu6bb74xvXv31ubNmwkBKsD2qpB27hYQjUZ111136Ygjjqj1xw2QDgQAAABUsw0bNpgTTjhB77//vvMxW1TZm173lGy6/GNXuIt0O3rv3k3AvQQgufBKvh90r2dPnqpt12+7l6vYmQTu5SvhcFgNGzZUu3btlJOTo759+6pnz55q06ZNrdyF4OmnnzajR4/m/C2nUCjkBE/22LSvXb169XTnnXfq4IMPrnXHCZBuBAAAAFSjBx54wEyaNEk//fRTqZ3cUy0JACoq+Xiy3MdVckGfzD07wB1SJX/ezf0zbS8LGxK4lxhEIhHtscceat68ubp06aK8vDzl5uaqc+fOatWqVcbPFjjrrLPMNddcQx+Pckq15WU0GlVBQYHq1aunhx56SMOGDcvoYwLwGgIAAACqyaJFi8zFF1+sWCzmTO23kot9uxwAqCz3sVXaWms7S6CkPezdhb67wE9uIGi5i38bINi/259tf6f9evszotGoGjZsqA4dOqhDhw7Kz89Xt27d1K1bN7Vo0SKjCsDc3FzzwQcfpPtheJ772HQHRu6ZJ3Xr1tWzzz6rfv36ZdQxAHgZAQAAANXgqKOOMo888kjCSKktkFKNqgK1WXIPgZJ6Clg2LKhXr55at26tLl26qGfPnurTp486deqkffbZx7MF4TvvvGMGDx6swsJCGWOcAMTOhED52ICgWbNmevzxx9WnTx/PvudAJiEAAACgCm3cuNFZ7+/u6M8e4fCzsgr+ZLYxoSSniJb+GBWuU6eO2rZtqzVr1mjEiBGeLAovv/xyM2PGjGIzLCRxHSiH5JkrrVq10rPPPquuXbt68v0GMgkBAAAAVeTZZ581EyZM0I8//qh4PJ4wrd893Zrp/vCbkrYpLO/3uZcL2C0KGzZsqHXr1qljx46eLAoPP/xw88QTTzjnui1q6fVRtkgkolgslrCbRefOnfX888+rdevWnny/gUxBAAAAQBW47LLLzJw5c7Rjxw5JSljzn9zhGvCbXQ0ASvo5dlZNfn6+3nzzTU8WhD/88IPJy8vTd999l+6HkrGSe0p0795dzzzzTMb1hQC8JJjuBwAAQKabPn26mT59urZv3+4UNrb4t83T3MLhcI0/RiDT2OLPPepvz6dgMKhgMKi33npLEydO9ORoVrNmzQLXX3+9IpGIE1zY54Ky2SUT7h0p3n//fR1zzDH66aefPPmeA5mAAAAAgF20adMmM3LkSHPZZZcpGAwqFApJ2jk6KcnpbB0Oh53Rf6b/A+Vjdx6wfQDcuw/Yv1977bW6/fbbPVkQHnzwwYEzzjjDKWCZeVt+9n2PRCIyxjjX0tdff13HHHOMtmzZwosJ7AKWAAAAsAvee+89c8IJJ+iDDz5IWNPv3u7M3rS6sQwAflTRUW93iGYLQVtEu4t/G6zVq1dPb775pjp16uTJ4fWePXuajRs3OiEA14DS2ZkeqXZMsa/h0Ucfrfvuu8+T7zfgZcwAAACggm644QYzZMgQffjhh5LkNKuyN6v2T3vjaosfW/wzBRgomy383f92n1fuxpq//PKLTjnllHQ91DLddtttysrKUiwWo/gvB/seu99/e421HnzwQf35z39mJBOoIAIAAAAqYN68eebMM8/Ur7/+mjAy5d7uK1XhIsm58ffD7Dv3aG2q/+Av7qn85fkv+XuSf5YN09xb7P3973/Xueee68mTq2fPnoG//OUvkuQsFZLk9DZw/zvTz4+qePx2lN+9+0PysRCPx3XjjTdqyZIlnnzPAa9iCQAAAOXw448/mjPOOEMPP/wwa3nLoawigNcPlWGn/tulAjaMi0QiuvXWW3Xcccd5sooeNWqUefHFF1VYWKhoNKqCggJJxbvdZ+r5kbxtY2XYpVX2T/fyqUgk4ryGgUBA11xzjU4++WRPvueA1zADAACAMvzrX/8yo0aN0sMPP0wHf8ADYrGYU2Tanhv275MmTdLGjRs9WUFff/31atCggQKBgAoKCpwRf3fxn6mq47EHAgFniVVRUVHCThDW0Ucfrf79+1f57wZqKwIAAABK8dhjj5mhQ4fqn//8p4LBYELhASA9bBBni86ioiKnSNy6dasmTJiQzodXotatWwduuOEGZ2tA2+jO3RcgE68v1VH8u2d4uF8nY4xisZhyc3N1//336/bbbw907do1c5MToIYRAAAAUIJLL73UHHfccfrhhx8kyRl9Amv8kV52VNjdA8D+J0n//Oc/ddJJJ3mykj7kkEMCU6ZMSbie2FkAmVj8Vwe79Z9UfP1/kyZNdOGFF+rVV1/VoYceysUGqCB6AAAAkMKZZ55prr/++pQ35O41x35V2SKf+w9Ulj0P3SPp9s9QKKRYLKbVq1dr2rRpniwSBw8ebF5//fWEj2Xi+v9U14KqeA7ukf9AIKCsrCwdf/zxmj9/vtq1a+fJ9xTIBAQAAAC4/Pjjj+a4447TCy+8kNB0yr3lGAgAkF7uYt/+Z89V9yyUYDCo5557Tvvvv7/nCsaPP/7Y9OvXT7///ntC8z/3dcfrSroOVPb8tq9BJBJRUVGRBg8erBUrVmjAgAGeex+BTMM8RgAA/r/169ebwYMH65VXXpGkhJtwW/yzBABIP/dWgfF43CkWpT+KUnu+xuNxHX/88fr88889lzhlZ2cHVq9enXBNsX0MMkF1LvWxP7tFixa6/vrr9be//S1A8Q9UDWYAAAAg6d577zVTpkzR5s2b0/1QysVL6+xLupdwT9FO/jqvbxPo9ceHstl19fF4XMOGDdMLL7zgnZPGZdy4cWbt2rWlniuZeLzZx23fA9ujwQYc7p4Hyc83Go1q0qRJmjt3rpo0aeLJ9w3IVAxjAAB8b968eWb8+PHavHmzM4qIyrGjsO5u56FQSOFwmFkUqFHGGL388suaMWOGJ6voq666Si1atHC2MnRzfywQCCgcDnsq/CtNcmhhZ2TY64Ht6O8OOIwxOuCAA/Taa69p1apVAYp/oOoxAwAA4GtHH320eeihh5x/M/224lLdS4TDYcVisRLXNXt9hN3rjw/l5z4Wb775Zp100kneOXn+v6efftoccsghisVikoo3OHQ3Hs3EHgH28bvPGxtmFBUVKR6Pq0OHDrrgggt0wgkneO79AWoTAgAAgC+9//77Zty4cfr444+LdRDPhP83pjsAKOk1cj8uO8XXvWNC8rKAiv78muL1x4fys+9lIBBQvXr19Le//U3du3f3XJE5ffp0c/XVV2vHjh3OxzKp2E9mH3vyn+7Px+Nx1a1bV1OmTNG0adPUtGlTz70vQG1DAAAA8J0HHnjATJw4UVu3bnVGBt1FaiaEAF4LAJIfj/vz7jXAqb63PD+/phEAZDb3VoCWDaRyc3P13nvvebLQ7Natm/nss8+c65H90x5vNRUIVNXx776WRqNRxWIxGWNkjFE4HNbo0aN18cUXKycnx5PvB1AbsQgPAOAr8+fPN0cffbR+/fVXFRYWOqP+kor9iYpzb8Fm/4zH4wqFQopEIglBC1BdAoGAE+5JiVPQ33//fZ144omeTHBuu+22YjsB2ALavdWh1wWDQYXDYeexRyIRFRQUKB6PKxwOq2vXrrr33nv16KOPBij+gZpFAAAA8I1jjjnGLFu2TIFAQAUFBc7H7U21XatOkVoxqYKTYDDohAFZWVmSpFgspjp16hCwoNrF43FFo1En4LPN9MLhsCTpjjvu0DXXXOO5EKBPnz6BJUuWKBQKyRiTsLVhJjUojcfjzuwLOxMjFAqpUaNGmjNnjj788MPAEUccwYUASAOWAAAAar3PPvvMHHPMMfrggw9UWFhY7PMlNarzsnQX0am29HM/JjvqHwgE1KZNGw0aNEjHHHOM6tevr+XLl+vJJ58s989PB5YA1A7u5nnJ9thjD7344ovq16+f5wrR4cOHmxdffNE5j4qKilJuEVhdKnv82y3/7GsfDod1xBFHaOnSpWrfvr3nXm/ATwgAAAC12quvvmpOPPFEffnllwqHw4rH454Y4a/qArOigUByw0P3zbq9eXevn3b/HvdjC4VCzqwJG57svvvuysnJ0dChQ3XYYYdp8ODBxR7c3XffbWbMmKEffvjB6dJeUl+BVOufKdBRGfaY69Gjhyf7AXz99dcmPz9fP/30kzOTxh77pYUa5VWR8yf5OuHesi+5yHdfM+z1tnfv3rrooos0fPhwz73OgB8RAAAAaq1rr73WnHvuudq+fXvCHtReWEtb3QFAWU367Mfsa2LXHbv/bm/2kxv62e8NhULOUoomTZooPz9fY8aM0YEHHqhu3bqVebP/448/mrlz5+rGG28stt1ZSduglTfo4P4GpXEf2yeffLJuvvlmzxWna9euNePHj1csFlM8HlckEkkZlO2KipxHdiaPu7h3h3Pua4b9XCgU0l577aX58+drxowZnnttAT8jAAAA1Epz5swxK1eulLSzk7aXpvjXdABQkZ+TXHDbEX53g7+ioiK1bdtWAwcO1KGHHqqhQ4eqRYsWu3Sj/+yzz5opU6boq6++UjAY1Pbt253P2ULN3VAwHA6X+T5yf4OKuPLKKzVlyhTPFaqnnXaaufXWW50GhlWlPNcfe97bfgTuAt/dmNB9XbAhxVFHHaWLLrpI++yzj+deU8DvCAAAALXO0UcfbR544AFnVMrewLpHltMt3QFA8rReOxsg1Wi7/do6deooNzdXgwYN0hFHHKHu3burQYMGVXaDP3/+fLNy5cqEUU77WOwopF3CwRIAVJY9poqKilSnTh299NJL6t+/v6cK1l9++cUMGDBA//rXv4rtDlAZ5Tl/kmfhSIkzgOyMIffX9ujRQxdffLHGjBnjqdcRwE4EAACAWuPTTz81xx9/vN5++21nn2k7bdU95dcLIYBXAgD7utgu6bFYzNm+yxijRo0aqW/fvs7U/uzs7Gq9sX/vvffM1KlTtW7dOmVlZamgoCBh9N/9+EvD/Q3Kyxa1nTp10vr166s01KoKr732mhk+fLgKCgqcpTk10QMgud+H/T736L/9s2HDhpo1a5Zmz57tqdcOQHEEAACAWuHRRx81kyZN0nfffSdJCaP/Ja1nT6d0BADur7Gj6e5u3fF4XLvttpv22WcfDR06VKNGjdJ+++2XloLor3/9q5k1a5ZisZizc4N7JgcBAKqKu+/EYYcdpgcffNBzRexll13mnA810QPABgD2OpHq+21weOyxx2rp0qVq27at5143AMURAAAAMt7KlSvN/PnzZYxJaFSVPJXdS//PS/cuANLOLt177LGHevbsqdGjR2vUqFHKy8vzxI38119/baZPn65HHnlE4XBYO3bsSGhWWBovvdfwHjvqb0PBSCSioqIiGWO0bNkyT45kjx071jzzzDMpd+eoqPJcL5J3+5D+6P2xxx57aNu2berfv7+WLVumIUOGeO61AlAyAgAAQEYbP368ueeee1KuYU81Vba0Le5qUk0GAKk+16FDBw0cOFAjR47UkCFD1KpVK8/exD/zzDNm0qRJ+vLLLyWJGQCoMslT2u3146mnntKIESM8dU5s3rzZdO/eXZs3b3Zmxeyq8p4/yWv8Jalt27aaP3++Tj/9dE+9PgDKhwAAAJCRNm7caE455RS99dZbkhL3xk61dtVLkh9fWWt6k2cwlOf5udfxS9Jee+2lrl27asSIERo+fLgGDx6cUTfvW7duNRdffLFWr16tUCjkLA1wr0Mu6f1PPjZKmtbsJekOONL9+6tbWc+vRYsWeuONNzwXjD300EPmqKOOUjwed3pkuDv2l7R2vyTJu33Y2TXu8yUcDquwsFB77LGHpkyZolmzZqlx48aeel0AlB8BAAAg49x5551mxowZ2rRpk3Oz627452W28LA9CZK7bEtKuJl3s7MX7FTl5GI2HA47sxvi8bjat2+vAQMGaMyYMRo2bJhatmyZ8Tft7777rpk4caLeeOONlO+5e9eAoqIi52vslG8v7QRRmnQX4On+/dWtrOcXDAY1dOhQvfDCC547Z8455xxz9dVXq7Cw0NnJwH0elDcASDW6b9kp/8YYRaNRjR49WhdccIF69OjhudcDQMUQAAAAMsqiRYvMRRdd5BR19sY1EomosLAwodDzGnfRUdL/fwOBQMI6d/t10WjUKezD4bAkOSGBXcsfiUSUl5engw46SGPHjlW/fv1q7c36HXfcYebPn69NmzapsLCwxO3RkhsHVuVWatUp3QV4un9/dSvr+dlgbd68eVq6dKnnzqPc3FyzceNGSTsb9lX02C4pKMjKynKuNXl5eVqyZIlGjx7tudcAwK4hAAAAZIyjjz7aPPTQQwk3uXYPe/sxr07/T9Wl3z7WVCNx7pkC9rkl9zYIh8Nq0aKFBg0apEMOOURDhgxR69atfXOjvmXLFjNv3jxde+21CbMBkpdMuHeA8GJDyFTSXYCn+/dXt/LMALAzSO68804dc8wxnjqvPvroI9OvXz/973//q/TPcnf0t+dJs2bNNGPGDM2aNctTzxtA5REAAAA87+uvvzbjxo3TG2+8UerIvpendpcnALBfZ6ff2lFIO3odj8dVv359derUSaNGjdKIESO07777+v4G/aWXXjKTJk3Sp59+6iyLsDNEQqFQsZkhXj5OrHQX4On+/enmDuUaNGigdevWKTs721Pn2hVXXGGmT5+ecH0oTwDq/hr3khk7i+ikk07SBRdcUCuWDAEojgAAAOBp69atM+PHj9dXX32V8HH3qK7775L3ZgGkKqaSm9S51/O7ZzQEg8GEUf799ttP7dq148Y8hfPPP98sW7ZMRUVFTg+A5P4QmdYroiQEANUreVbOwIED9frrr3vuvBs5cqR58cUXy3VMJy9BSp5lNGzYMC1dulQDBw703PMEUHUIAAAAnnXDDTeYs846Szt27EhYC19YWJhQgKQa0fKKkgop+zjtHuTukf6srCx17NhRw4cP19ixY5WXl6f69etzU14O//jHP8yMGTP02muvOd3Lk2dZ2HDAy9JdgKf793tFNBpVQUGBgsGgzj77bK1evdpT5+EXX3xh+vXrpy1btiQ0vUzF/Z66r6Pt27fX/Pnzdcopp3jquQGoHgQAAABPmjx5srn22mudKdzutdvuLvmpCn6vjPKWVkQlj8Dttttu6tWrlw4//HANHz6cbtuVtGbNGrNgwQJt27bNeZ29XvS7pbsAT/fv9xLbYFSS7rzzTh1//PGeOjcfeughc8QRRyRs6Zf8/iS/n4FAQHXq1NGECRO0aNEiNW/e3FPPCUD1IQAAAHjOuHHjzH333Ze235+qW787aLAjyMnb9dn1+zZ8cH9PNBqVJBUUFDg/v0OHDurbt69GjBihAw44QG3atOEmvAr961//MhMnTtQrr7ySsKxCSh0SuZugZfr9UWUL+HR/f7olL8mxgV29evW0fv16z/UDmDhxornhhhtK3FpU2rmNaCwWU9++fbVkyRKNGDHCU88DQPUjAAAAeMb//d//mSOPPFLvvfde2goEW7gk30Dbf7tH7i13AOD+Wvtv29QvFAqpe/fuGjp0qI488kh16dJFDRs25Aa8mt1yyy3mnHPO0X//+99iPQHca71rQ+FvpbuAz/QAQFKxY8IGen379tWbb77pqfN269atZsiQIfrggw8SrlPua1BhYaFatWqlhQsX6vTTT/fU4wdQcwgAAACe4G72l4412iUV9am+JtXn3KNrtsAMBoNq3Lix+vbtq0MPPVQHHnigOnTowI13Gnz77bdm+vTpWrt2bbHRf1swZUJvgPJKdwFfGwIAyzbptIqKinTyySfr5ptv9tS5/P7775t+/fopFos5PUWysrKca9GZZ56phQsXqkmTJp563ABqFgEAACDtrr32WjNt2jRnerx7Wn11K6lQSbWHvP1694ixLQ7sDXedOnW09957a+TIkRo5cqT23XdfRvk95NlnnzWTJ0/Wv//9b+djycGO1xpJ7op0F/C1IQBINY3e3bDziiuu0JQpUzx1bt94443mz3/+s6Sdx/GIESO0YsUK9ezZ01OPFUB6EAAAANJq6tSp5q9//avz79JG2atSRQoUO4XfFgR2lNiOGNerV0+9e/fWiBEjNHz4cOXn53Oj7XEXXXSRWbNmjbZs2eL0B+CeCG6BQEDBYFDSzgaS9hoQjUYVDAb1/PPPa/DgwZ463ydMmGBuv/129ejRQ7Nnz9b48eM99fgApBcBAAAgLf7zn/+YE088Ua+88krCaKu7+VZ1KikAcAcQdoTf7pPt3kauTZs22nfffTV69Gjtt99+atWqFTfZGebf//63Oeecc/TUU08lzDypDTMAUHVsCGCb67l7fLRt21br169Xs2bNPHP+//zzz+app57SyJEj1ahRI888LgDeQAAAAKhxb7zxhjn++OP15ZdfOt30bffqmpJqW6zkf9sb/Xg8rj333FO5ubk65JBDtP/++2vAgAHcWNcSd999t5kxY4Y2b96scDisbdu2pfshwQPcvSLcW+xJO7fxNMbo6KOP1n333cf1AEBGIAAAANSoq666ypx33nn6/fffFY/HneJfkhMApFp7W9XKCgAkqVWrVho0aJDGjh2roUOHMspfi/38889m7ty5uu6665wZH/A390i/uweInS3inimybNkynXfeeVwfAHgeAQAAoMZMmTLFXHXVVZX6GXY9vrtAS952z271Zpt1uW/g7bp9O7XfPesgEomoZ8+eGj58uA455BD179+fG3qfeeedd8zJJ5+sDRs2JOwKYP9eU0tUarva0CRQ+uOaYYxRJBLRU089paFDh3LNAOBpBAAAgGr33XffmRNOOEEvv/xysZGz0rjX3kqld2sva9ZA8lp+O/OgadOm6tevn8aMGaMDDjhAnTp14gYeGjdunHnggQeKNX+jP0DVqA0BgHvrz0gkolatWunVV1/V3nvvzTUEgGeF0/0AAAC124YNG8zRRx+tf/3rX8UK+rK4i/vkUVe7DV8q7rW7oVDI+dpYLKY6depon3320ZAhQ+wovxo3bswNOxzLli0z69evd2aKuI/D5Bkl8Cf31p+BQECxWExfffWVJk+erEceeSTdDw8ASsQMAABAtbnjjjvM1KlT9euvv+5ywZRcbKXaJtDdsM+O0kpyRvz33HNP9e/fXwcffLCGDRvGfthI6cMPPzSTJ0/W3/72N2eWiJ32b5eYMP2/atSWGQDJs5MkafHixVqwYAHXGACeRAAAAKgW8+bNMxdffHFCAW9H4svz/x47Rd/99almEESjURUVFSkejyscDjsFW8uWLXXAAQfo0EMP1aBBg9S8eXNuyFGiFStWmCVLlui3335LGOUPh8MyxjhLAVgCUDUyPQBwzzJyHytFRUWKRCJ6+OGHNXr0aK45ADyHAAAAUKV++eUXc/LJJ+uRRx5RNBpVQUGBQqGQM022IlIV/MFgUIFAQMFgUIWFhU5Btvvuu6tbt24aNWqURo4cqX333Zebb5Rp48aN5tRTT9U///nPhGUj7j3f3bMApJrZpaK2y/QAwB4btgeAZa9HrVq10rp169S2bVuuQwA8hQAAAFBlPv30U3PCCSfozTfflJQ4Xd8W7vF4vNw393ZEzXbZlqTCwkLn882aNVPv3r11yCGHaPTo0WrXrh032yi3iy66yCxZskQ7duxwjslUx2ZyT4mKHMNILdMDAEkJu0RIxXuVHHTQQXruuee4JgHwFAIAAECVeOGFF8yECRP07bffJnw81RZ9yTfOqQQCAWcZgB2FNcaoU6dOOvDAA3XYYYepX79+atiwITfYqJDXX3/dTJ06Ve+8847zseTlKakCK6b/V51MDwDc1zX3n+5tRuPxuM4991ytXLmSaxQAzyAAAABU2nXXXWdmzJihbdu2JWzzlzxt2kq+YbbfYz/nHo3da6+91KNHD40aNUojRoxQ3759uZnGLps+fbq5+uqrnUApuc8EUFXsNe+GG27QqaeeynULgCcQAAAAKuWss85yCiopdaM/98ip/bw7EAiHwyooKJAkRSIRNW7cWPvuu69GjhypUaNGsa82Ku3RRx81s2bN0meffeYsSXEHTdwPoSq5ZzCFw2GtX79eeXl5XMcApB0BAABgl2zZssWcdNJJevLJJxWPx0uc1u8u+N2j/oWFhc73RKNR5eTkaMSIERozZox69Oih+vXrc7OMStu0aZM555xzdM899yRM60+FeyJUh1AopOzsbH3wwQdc0wCkHQEAAKDC3njjDXPSSSfps88+K9YQzXb8t1OsU+2VbYzR3nvvrT59+mjUqFEaNmyYunTpws0xqtQtt9xizjvvPG3atMlp5GdHZZNDgOQ16dwfoTJsuOleBjV+/HjdcccdXOcApBUBAACgQm677TYzbdo0bd261Smm7I2uu6hyF/uStMcee6hDhw466KCDdNhhh2nIkCHcCKNafPHFF2by5Ml65plnUhb6qe59CAB2YpvDqpPc+2T16tWaNm0a1z4AaUMAAAAot1mzZpnVq1cndOa3kpcABINBNWnSRHl5eTr44IM1cuRIderUiRtfVKtVq1aZCy+8UFu3bk1oMmnXYsdisXKFAH68P/L7869KgUBAwWDQ2RHA7cUXX9TQoUO5FgJICwIAAECZtm7daiZOnKj77rtP8Xg8YV909zZYoVBIHTt21L777qtDDz1U+fn5atmyJTe6qHbvv/++mTRpkl577TVJcooue7wmF2JlbUPpRwQAVSd5BxT3FoHt27fXG2+8ocaNG3NtBFDjCAAAAKX69NNPzfjx4/WPf/yj2CiqJGVlZSk/P18jRozQyJEj1b9/f25qUaPmzJljrrzySm3btk2SUjb5c6/9Z4p7cSyBqH7hcFjxeFzxeFwHH3ywHn/8ca6VAGocAQAAoERPPfWUOe200/TDDz84zfzi8biaNm2q/v37a/jw4RozZow6dOjAjSxq3Msvv2ymTZum9957T4FAQOFwWIWFhRT4Kl7QJ8v01yfTnl+qgOXCCy/UggULuHYCqFEEAACAlFatWmXmzp2rgoICRaNRtW7d2tmmb9CgQWrYsCE3rkiL77//3sybN0933HGHYrFYwlRryXvFXzpkWoFcUZn2/JIfrw2pnn76aY0YMYJrKYAaQwAAAChmxowZ5t5771X37t213377adSoUerTpw83qUi722+/3Zx33nn67rvvUo70u/tT+FmmFcgVlWnPL9UMgEgkoubNm2v9+vXae++9ub4CqBEEAACABJ999pn55z//qf79+6tt27bclMITvvjiCzNx4kQ9//zzTuHvbuQXiURkjCm1y7+fZFqBXFGZ9vySH28oFHKCqrFjx+qxxx7jWgugRhAAAAAAT1u1apVZunSptmzZkrCtnySnNwUj/4kyrUCuqEx7fqlmALh3qrj44os1Z84cQgAA1Y4AAAAAeNJbb71lpk2bpvXr1ztTpgsLCyUlbrPmDgFso0q/y7QCuaIy7fmVtMtCIBBwGlg+8cQTOuiggwgBAFQrAgAAAOA5CxcuNKtXr9Zvv/1WbPtJ971Lqr3rWQKQeQVyRWXa8ystALAzAVq3bq23336bBqsAqhUBAAAA8IzXX3/dTJw4UR988IGk0ov6UCiU0AcAO2VagVxRmfb8Uj1e92O0s1jGjBmjJ554ggAAQLUhAAAAAJ6wcOFCc+mll+r3339P90PJiAKztMdY2cdX1vMvS1m/v7Kvb2UfX7oZY5zp/5KcZSvRaFQLFizQ+eefn9lPEIBnEQAAAIC0evXVV82UKVP0/vvvp/uhODIhAJBKfpwEAN5mjEmYwZI8m+XJJ5/U6NGjM/tJAvCkYLofAAAA8Keff/7ZnH322WbUqFFO8R+JRNL8qDKLV4IIVJwd9XcX/1lZWZKkiRMn6ptvvuHNBVDlmAEAAABq3P3332/OPfdcffXVVwmN0IqKipz10OmUKTMArJKazFXVz6soZgCUzv387O4VgUBARUVFzm4Xw4YN04svvpjZTxSA5zADAAAA1JiPPvrIHHLIIebYY4/Vf/7zH0l/rHsuKipyRkHTXfwDlWWMKfU/aecOAPZjRUVFCgQCisViCofDevnllzVnzhxvJU0AMh4zAAAAQI34y1/+YlavXq2tW7c6H3N3949EIioqKvJEAJBpMwCk1FsiVsXP2hV+nwFQnsdfUiPA5K95+OGHddhhh3n7CQPIGAQAAACgWv397383Z511lt5+++1ihZF7ur+d+swSgF1nHzcBQHqV5/UPBAIKhUKKxWKSdvYCiEajKigocD7fuHFjvfbaa2rfvr23nzSAjEAAAAAAqs2MGTPM1VdfrR07djgjnpaX70EyNQCQEmdVVOZnVAYBQPlff/cygFAopHg8LmOM83FJGjJkiF5++WVvP2kAGYEeAAAAoMo99thjJjs726xevdop/t2FjpcLaC9xF7ru6eK2aaL9uPvfoVCo2Ne4hUIhBYPBYkW0/Tk2QKjMf/axlvRfedbIV0Zlf1Z1P/9gMOj85+4JUFRU5PzbNgaUpFdeeYV+AACqBDMAAABAlfn+++/NjBkztHbtWhUWFioUCskYk/Yp/RWV7hkAqUbxbUFvC8PSHkOqpQD2eyKRiGKxmFN82vfG/T3V/fyre4ZBWb+zumcYVMUMiN12203btm2TtHN5zB133KHx48czE6AKbdmyxTRs2JDXFL5BAAAAAKrEfffdZ6ZPn64ff/xRhYWFCofDzvpm+/eqWqNe3bwWANjHY0eP3dPE7e4J9uP2TzvS7/5a+x4kP/6KbiNY1utT3VP0KxooVfXzq+jvS+Z+/MmzPCQ575UViUQUj8e122676dVXX1WvXr0oWKvAvHnzzM0336y8vDwdeuihGj58uDp06MBri1qNAAAAAFTK119/bc455xw9/vjjKiwsTCjy3aPW0s5p7F6fEZDuAMA+hlSFep06dZSVleW81gUFBc6sADvrwv262/chHA47TRbdyzFsszn7vhQVFTnLCEpS1vOv7OfLUtbxk6qorkkVeX7ucMey75UNfAoLC7X77rurqKhIubm5+vvf/06RWgkvvfSSmTFjhjZs2OAcS8FgUHvssYf69u2rI444QiNGjFCnTp14nVHrEAAAAIBddvnll5slS5boxx9/lKRSO/hXRXO6muL1AKB9+/Zq0aKFevfura5du6p58+baY489FI/HFY1GtWPHDmd2QDgcdgp6+95s27ZNkUjECQoCgYDC4bDzO0vqH2AVFBSU+dgr8/myVHQEv6IzAMoKQMpS1s8vKioqVvi7H6MNaWwoY9+beDyueDyuvn37Upjugi+++MIsWLBA9957ryQV24HBrW7dusrPz9ehhx6qMWPGqEuXLrzmqBUIAAAAQIVt2LDBnH322frb3/7mfMwWnKmmomdaH4B0BwBlLQGQ/iheotGo6tatq1atWik3N1f5+fnq1q2bunfvrpYtW1KwAP/fypUrzcqVK/Xjjz8mLE+y51o4HE5YemGvZ8YY7b777urRo4cOO+wwHX744crOzubcQsYiAAAAABUye/Zsc9VVV2n79u0JHcvtqKkdSbNFq3s6s+T99f+S9wIAqeQmgO7O/TZ4qV+/vlq3bq3s7Gz17dtXffv2Vbdu3dS4cWMKF/jK3//+dzNt2jT94x//cGZehEIhxWIxJ5y055L7nHPPmnGfa1lZWerXr59GjBihww47TDk5OZxTyCgEAAAAoFxeeOEFc+aZZ+rzzz9XKBRSYWFhiV+bakqtnRGQCUsB0h0AuB+He5s49+92bwvo7rEQDAadAsc966JBgwbq0KGDcnJy1K9fP/Xs2VODBw+meEGtdfrpp5ubbrrJue64m2aWNMsm+dy2u2YYY5zrmv0zGo0qLy9PRx55pI466ijts88+nE/wPAIAAABQprPPPttcffXVzs2vu0N5dUj3NnQ1McJflb+/rDXvqUSjUTVp0kRdu3ZVnz591KdPH/Xs2VPt27eniEFGu+eee8ycOXP05ZdfSio7fNzVnhR29k0sFtNee+2l/fffX4cccojGjBnDEhx4FgEAAAAo0TPPPGMmT56sL774QtFoVNu3b09YP1tdCAAqFwCUl90NwC4dqFu3rurVq6eePXuqV69e6t+/v7Kzs9kaDRnh008/NTNnztTTTz/t7Ihhj207/b+qAoBUS3DsrhoNGzbUwIEDNW7cOB100EFq1qwZ5w88gwAAAAAUs2XLFjNz5kzdeeedztZwUuqp/dWBAKB6AwD3VGj7b/fSAls0GWO02267ae+991bXrl3Vv39/9erVSzk5OWrbti1FDTxjyZIl5pJLLtF///tfxeNxRSIRZ5mSewZA8rEv7XqA5t7S1DYRLCgocIKHUCikxo0ba99999UxxxyjoUOHqmnTppw3SCsCAAAAkGDt2rVm9uzZ+uqrryTtbOpX2hZ/VY0AoHIBQEW+393szBZI7gZpye95OBzW7rvv7uw8MHDgQPXt21edO3emySBq3DPPPGNmz56t999/31mnn9y4z90jQyp+flQ0AEi1DMrOBLA7odjzyG6xWVhYqGbNmmnYsGEaN26cDj/8cM4VpAUBAAAAkCR9/fXXZtasWVq7dm3CPuX2XsHeWLs/Vl0IAKo3AHAXSbaZoLsbuvRHoW+MSZj9If0RCNl96YuKipzgoFGjRurSpYu6d++u/v37q2vXrsrOzlb9+vUpdFDlPv/8c7NgwQLdf//9CQ1JU23xZ4twe7wmq2gAYH+mewmN++e4r5nur7XbCgYCATVr1kzDhw/XUUcdpSFDhqhevXqcJ6gRBAAAAEBXXnmlWbJkiX744QdJJU/1r6kO/gQANTMDIFXxn6o7uvvf7pFO+2/pj8IrHo87xVcoFFKTJk3UpUsX5eXlqXfv3urVq5dyc3MpdFApF154oVm1apUz3T/52A2Hw5ISt/AzxiRspem2KwFAMvuz7ch/8nniDiOSdyNo2bKlhg8frnHjxmnUqFGcH6hWBAAAAPjYxo0bzVlnnaV169Y501XtutaSRoWruwGgRABQEzMA7HvrbmKWXEzZn+UOCtzrnqWdgYD9XvdMkeRtCvfcc0/ttddeys7OVm5urvr06aOcnBzl5eVR9KBMzzzzjJk1a5bef/99ZWVlaceOHZISQ6rSlipVVRNA93HtvmaW5/e4i387q8bdQLBjx44aOXKkxo4dqxEjRnBeoMoRAAAA4FNz5swxV1xxhX7//feUn7c30sk31DUxC4AAoPp3AUge5U8OfErqAeAOApLXXLuPDffPTPW7bZgUCoXUsmVLdezYUfn5+erdu7d69+6tLl26UPxA0h/Lk6ZPn65HHnnEGV2Px+PFpvvbP1NNyXcfr5VtAmh/nv17Kvb8sWxYYL/Hzhhwh2/u5xMOh9WyZUsddNBBOu6443TQQQdxPqBKEAAAAOAzjz32mJk1a5Y+/fTThAK/Jpv8pduudv0uL6/fX1U2gKjo9yd/fVnfH4lE1KpVK3Xt2lU9e/ZU3759lZeXpzZt2lAE+czq1avN0qVLtXnz5nQ/lHKr7PXFPQvL/qxWrVpp9OjRGjVqlPbff396a2CXEQAAAOATX3/9tZkxY4bWrl3rjIK5u1W7/17bEQCkNwAoi3sZgfTH6Oluu+2mjh07qlOnThowYIB69OihXr16scd6LfW3v/3NnHvuuXrrrbckKWHGSE1sRVoZVRUAuP/tPqdsz4Dx48dr+PDhHP+oEAIAAAB84IYbbjDz58/Xpk2bnG7YqfbD9sssAAKA9AYAZf182109+XuSlxXUq1dP7du3V69evdS3b1/16dNHHTt2ZHQ0w02ePNnccsst2r59e8IyE/un169Rlb2+uPsZpFpSY//LyspSu3btNGrUKB1zzDEaNGgQxz3KRAAAAEAt9umnn5rJkyfrhRdeSCio3Ou7kxv/Sd4vYCuLAMDbAYAkZ0aK3TrNfkza2VQwEokkbO0WiUS01157qXPnzurTp48GDhyonJwc9ejRg8IoA6xdu9bMnj1bn3/+uSQlXJukmmtCWlmVvb6EQqFiWxm6f7btoeHeVjAQCCgnJ0eHH364Dj/8cPXu3ZtjHikRAAAAUEtddtllZsGCBdq2bVtC1+nkTu/uvayTt67KVNVd4FdWuu+/MiEASBVGJReEdsaK+zi2e74XFhYqHo8rGo2qRYsW6tSpk9NLoEePHjQZ9JD//Oc/ZuLEiXryyScTRvdTFfw1tRVpZVTVDIBUz9W9BCLV5+3x36tXLx166KE67LDD2HoTCQgAAACoZd566y1z9tln66233lIgEHBuoKPRqAoKCiQV7+Tu/lhtQABQukwLAAKBQML0b/exmrxbgQ0Ckrc6dE8dD4fD2nvvvdWzZ09n54EePXrQZDANVqxYYZYuXarff//dWeNvp/u7O/5L/pkB4J7p4j7+JSXMiEn+fckzA6Q/tt7My8vTEUccoSOPPFKtW7fmGPc5AgAAAGqRRYsWmVWrVmn79u0pG/ulWuNfG6f9EwCULt0BQHmUth2huxiy3LNXkpcKuH9/coM1e07stttu6tSpk7p3765Bgwape/fuys3NVcOGDb19MGWof/7zn+bss8/Wa6+9lnL7SKukbSi9rCquP6leD3fIZYMS92wAe2y7d3ax50phYaH22msvDRw4UCNGjNBBBx3E0hifIgAAAKAW2LBhgznppJP07rvvOh8rae2o/buU2GzK6421KoIAoHReDwDczc4sW9RLcoqb5N/jbmyZfPy7QwFbFNl/uz/vDhDq16+v7Oxs9e3bVwMGDLBNBr19cGWAM844w9x2223asWOHpMTrT6r3LdO2Ka2qJQDJP9MdBLhfF/sx9++254KdNREMBp2lMcYYNW7cWLm5ufrzn/+s448/nmPaRwgAAADIcMuXL3em0NriJd03yl4vMKv6/qeyv7+iU+Qr+/qWpbp/fnWriiZsdsmA+3yqV6+e2rVrp169eqlPnz7q27evOnfurAYNGlBAlcMdd9xh5s6dq//85z8lfk1VHFuZfPyW59hNnh2QHJi5ZwJIO0Mvu6QgGAyqXr16GjNmjKZOnaoBAwZw/PoIAQAAABnqzTffNJMmTdI777yTMF3aCw38CAAq9vsJAKpWVezDnlxU2SUGgUBAhYWFCoVCTiHVuXNn5eXlaeDAgerVq5dycnIoqFw2btxoZs+erSeffDLlzA2rqo6rTD1+y3vcljRDIPlzNryyM17i8bgaN26s448/XlOmTFGnTp04Tn2IAAAAgAzz008/mUWLFunGG2+UMUYFBQUKh8OS5JkGWQQAFfv9BABVqyr3YS+pK727N4F7SUEkElGzZs3UuXNn9e7d22ky2KFDB18WW4sXLzbLly/X77//LklOk7pkVXlMZeLxW5FjNnkXF/fOLjYEDofDzrFZVFSkpk2b6pRTTtGZZ56ptm3b+vJYxB8IAAAAyCDXXnutWbBggTZv3uxM5XRv2+eVBlkEABX7/QQAVasqm7CV1DjTvX2m/TrLFl12GnZWVpYaNmyonj17qnfv3urbt6+6d++u9u3b19pC7KWXXjLTpk3TBx98kHCtisViu7QrREVk2vG7K9cP2+DVdvx3/78gEokoFovJGKPWrVs7hX/Lli1r7fGG8iMAAAAgA2zcuNFMnTpVr732WkLnZymx6E/VMT0dMjkA2JUQhQDAW6qiB4A9x2xhZZcDJJ9b7nXW7qUDyeellLiF2x577KGWLVsqOztb/fv314ABA9StWze1aNEio4u0TZs2mdmzZ+vuu+92Gs4lhygEAImq6vpltwuMxWJq2bKlJk+erEmTJrGTBRIQAAAA4HELFy40l156qQoLC1VYWFjs8+6bazsqme7/v2diAOD+GQQAmVVAJauuLuySinVdd3+9/Zx7q0F353Z3J3d3Uzb7tXvuuafatGmjXr16KS8vT/369VOnTp0yJhS49tprzZIlS/Ttt986z8mGKcmd/q3qOJYy6fjdlWPVfXy5w6VIJKJGjRpp8uTJmjhxopo0aZIRxw1qFgEAAAAe9eabb5opU6boH//4R8KIpHuEUSp+M8suAGUjAChdJhVQqVRFAOA+z9wFlyRn+rUxptg+7CUFcO7ZOeFw2Pka+/Xu77ejuIFAQA0bNlSHDh2Um5urfv36KScnR4MGDfJUYffee++Zs88+W+vWrUsII+2U9ORzq6RrV1XJlON3V49Teyy5n0fr1q112mmn6fzzz/fUsQHvIQAAAMCDpk2bZq6++moVFBSknNafat/s6r6prohMCwAqOyWZAMBbqqIHgFtpU66TP+8u4m044D6HUwUK7uUC7s7ttoB2r/GOx+Nq1KiROnTooPz8fOXn5ysvL095eXlpKfzOPvtsc/3116uwsNDpeeBeouS+VrkbAFbnMZQJx29ljlF30NShQwedccYZOvHEEzNmpgjSiwAAAAAPeeKJJ8ysWbP00UcfpfuhVEpNBwBe+/7Kqu7HX1l+v39Md0CVPNMgFAqpefPm6t69uzp37qx9991X2dnZ6tGjR7UdCHfddZdZsGCBvvrqK2cpg1eakJalOpaIVPTnJ/+MVEsl7M9yf61dOrLPPvto+vTpOuGEE1S/fn0Kf5QbAQAAAB7w3XffmfPOO0933XVXyi2yMk26C/B0f39lEQB4m1cCACmxJ4H7+6LRqJo1a6Zu3bqpT58+6tu3r3Jzcyu988Abb7xhzj//fD333HPOVnP2MSfPbPAqLwQA0WhUO3bsKNbNX9pZ5LuXgtiAoHv37jrrrLN0zDHHqF69ehT+qDACAAAA0uyuu+4y8+fP1xdffCEpca/xTJXuAjzd319ZBADe5oUAQFLCMiD3MgP7/e4lCoFAQPXr11fDhg3Vp08f5ebmauDAgcrJyVGzZs3KfIBbt241ixYt0jXXXKMdO3YU+/mZJN0BgA1Kkl8/97XfveQjHA4rNzdXs2fP1rhx4yj6USkEAAAApMm///1vM23aND3xxBPF1v9munQX4On+/soiAPC2dAcA5Xn93U0F3R9Lbh635557Kjs7WwMGDNDQoUPVq1cvdezYMeEX3nLLLWbRokX69ttvnRFpy45SZ5J0BwCp3l87C8B29bdBzr777quZM2fq8MMPp/BHlSAAAAAgDZYtW2YuueQS/fzzz85IUG36f3K6C/B0f39lEQDULlXdZNLuQOD+We5R/+SiP9XvjEQiCbsY2EaDderUUfPmzdWzZ08NGDBATz75ZEJ3/+TZB+7HY4xRNBpVQUFBhZ5fTfNCAGBH++10f/f3BAIBDRw4UPPmzdPo0aMp/FGlCAAAAKhB69atMzNnztSbb75ZrEt4qgZQmSrdBXi6v7+yCABql6oOANzFfvKovu0J4P4a9zXFduJ3d+svbZcCe01KXpqUydesdAcA9mfYr7PT/SU5hf+oUaMo/FEtwul+AAAA+MW0adPMTTfdpP/973+SpKKiIme0rKioKGFEqDY0AgRQvdyFvw0C3KPJqf603+Pu2p+8bZ/73/br3GvTJSUU/+6tSDOlEWC6hcN/lGHBYFAFBQU64IADNHfuXB100EEU/qhWBAAAAFSzl156yZx55pn67LPPEkZ9JKmwsFCSnBtsu+83AJQmFAo51wv3dcUdCiRvzWf/bYv4VMsDjDHOOnRJzvXIFvv257uDyuSfj9K5G/wNHjxYc+bM0YgRI3jhUCNYAgAAQDWaPn26ufbaa1VQUOCMzvlBpk+hz3Q1sQTAve47mZ3NUp716O6Pub8v+fe5pXuJRGWPn3Qfn+l+/tWtJkKI5JkSNlSRlLB8wj0zw/1vO9V/zJgxFP6oUcwAAACgGjz11FNm+vTp+uSTT4oVQUzxR6ZLLuTtiLGdFl7SUhZbNNlRaDui7O6C7m5wB3iVPbZtT4XkpRCWLf4jkYiKioo0dOhQzZw5k8IfaUMAAABAFZs6daq59tpri+3Bbf+k+EemS9V0zh7XdvTTbmlm14XbqeqhUEihUEiFhYUJMwns9zGNHF5nj1G7BWIwGCx2Hthj3Z4nQ4cO1Zw5c3TggQdycCOtgmV/CQAAKI8HH3zQdOjQwfz1r39VPB5PmMrsDgHcU0WBTOZuImcLfftxSc7IaGFhoYYMGaKrrrpKI0aMcIomaed+58FgMGHtOeBlyb0WpD+O5Wg0qkAgoHA4rGAwqJEjR+r555/Xc889F6D4hxfQAwAAgEr6+uuvzcyZM/Xoo486a/3t9Ge7x7N7tLS29wEo7xZY6XwMmX7/k+4Rcvfopp36nHxsBwIBZWVlaejQoZo/f7723Xdf50G///77ZsmSJXrssceckMD+Z8+Z5N/nRg+Aykn3869uNbkNprupontZwKhRozRr1iwNGTKEoh+eQgAAAEAlXHLJJWb58uXasmWLU7S4R/rtx9zroe3Wf7VNRW66013gZPr9T7oDgOR94t3i8bj22msvHXbYYZo2bZp69+5d4oN96623zLJly/Tggw86I6Z2Zww3AoCqle7nX92q+/ywx7+9rts+AFlZWTr00EM1Y8YM9e/fn8IfnkQAAADALti4caOZNGmSXnvtNUmJXZ+TCyP3uv9UXdBrCwKAmpPuAMDdsV+SIpGICgsL1alTJx1xxBGaOnWqWrVqVe4H+fbbb5uVK1fqwQcfVCgU0o4dO4r9PjcCgMpJ9/OvbjURANhlXeFwWJFIRH/60580Z84c5eTkUPjD0wgAAACooFmzZpnLLrvMWePv3uZJ2nlzmIq7aKpNKnrDne4CJ9Pvf9IdAITDYWekvk6dOho4cKDOPPNMjRs3rlIP7L333jMXXXSR7r///oSPEwBUrXQ//+pWEwFAIBDQnnvuqaOOOkqzZ89W586dKfyREQgAAAAop8cff9zMmjVLn3zyScbfANf2x5/uArEs5Xn9K/MY7M93j1S6/0zm3nrP3bXffk76Y5ZLOBx21uq3adNGhx12mM4888wqH/V8++23zerVq/Xggw9KkgoLC51eGvZ5uKdhu5+z3W89Va+NVNu07Qqvnz+1TVUGjPYYsGGs+5xItXVlqnOmQYMGOumkkzRp0iQKf2QcAgAAAMqwefNmM2PGDN1+++2SMuPmnwAg8wOAyjwOuz2Zlbw0xTbxc29hVlRUlPCn+3tsILDXXntp//3314QJE3TggQeqfv361fpCvffee2b16tW6//77tW3btoQwwgYA7jDA/fzdAYb766TKH/9eP39qm6oKAJJ3ZbF/dx9XVqpjqE2bNjrhhBM0ceJEtW7dmsIfGYkAAACAUtxzzz1m9uzZ+vbbbxO2OvN6J38CgNoRAEi79ljcu07YY9a9ZCV5lNzduNI9G8Bua5aTk6Px48fr6KOPTkvh83//93/msssu06233qrffvtNklIupbGjuu6lNvZ5upsVEgBklqoIANw/I/kcCIVCxcIh+/lgMKhmzZrp9NNP18SJE9W0aVMKf2Q0AgAAAFL4+uuvzdSpU/XYY48Vu5nMhK38CABqTwAgVb4AsluVuXtVSDtnAxhjnN0p7Mhnp06ddNRRR+nII49Ufn6+J4qeb7/91lx55ZW66aab9OOPPyYsVXAX/e7RW/fIv7Rz9kBleP38qW2q4vhP/rx7i1b3Nd02tAyFQurYsaP+/Oc/66STTlKTJk08cQ4AlUUAAABAkmuvvdbMmzdPP//8s6Tiez4nf8yLCAAIAOz3pZqxYmcGuEc/Y7GYWrRooZEjR+q4447T8OHDPVvwbNq0yVx77bW6+uqr9cMPPzhFmw0zpOLLHtwjvgQAmaWqAwD3EpnkbVsDgYCys7N1xhlnaNq0aZ49B4BdRQAAAMD/9+mnn5ozzjhDf/vb3xKajaUqKLyOAKB2BQBS5ZYCuL/f/mmP5b333lsHHHCAjjnmGA0ePFgNGjTImKLn559/NjfeeKNWr16tb7/9VpFIRPF43OljkNwjwI76VpbXz5/apjIBQKrvdfePCIVCzsyY7t27a/LkyZo4cWLGnANARREAAAAg6a9//atZsGCBfv3114RRRGnn9OmioqKEm0UvIwCofQGAVLHHZb/WPR3eTn1u2bKlDjzwQB199NEaMGBARhX9JbnsssvMlVdeqX//+9/afffdtW3btoSi3717AD0AMktlZsCU9PMikYgkqaCgQN27d9e5556rCRMmZPx5AJSFAAAA4Guff/65Oe200/TKK69IUrGmaO51xZmEAKB2BgBS+R+bu9FZMBhUdna2xo4dq1GjRmno0KG1ttC54oorzIoVK/Tdd98VG/V3n9+V4fXzp7bZlQCgtO+xn8vOztbMmTN16qmn1trzAUhGAAAA8K3rrrvOzJ8/X7/88ouztzm8wcsFuFTy4yvr5yZvLWab2NlmfO71+nbmiaRie5OHw+FS97mPx+Nq1KiRevTooTFjxmj06NHKycnxTZHzyy+/mFtuuUVr1qzRV199pVAoJGnn++NeIiDtfF/C4bCz20dy/wC3dAdUma6yzz/V+VKSSCSiWCyWsKSrY8eOOuecczR+/PhaMfsFqAgCAACA76xfv97MnTtXr7zySsIIv10Pmokj/rVNTYzQlvY7KrNG330cubfWcxfx7r4S9t/uacupmpjZj9llKHZk293lvmPHjho8eLAOPvhg9e3bV3vvvbevi5vNmzeb22+/XatWrdLXX38taedr6Q5j3NcB21DQvq62yDTGKBKJqKioqMzjgwCgdNX1/O176g50bMgWj8eVl5enqVOnMuIPXyMAAAD4yrRp08z111+vbdu2Jdxk2pt+KXUBhtqlrOnBZY0qJo8Kl7TNXknFvKRSC347Yu3+Ohsm2IImFApp7733Vn5+vvbff38deOCB6tatG4VNClu3bjV33HGHVq1apf/7v/9TVlaWCgsLnRF/96wMu2zAHdgkhwXJMzKSEQCUriqef6pdHuzPtmGNbQiZl5enGTNm6IQTTuD8gO8RAAAAfOGxxx4zs2bN0ieffCIpcRu05PWi/L/Rf1LtE17W1yc3irQfSx5dLul7LDtF2QqHwyosLHRGm+PxuMLhsKLRqFq3bq3u3btrv/3206BBg9S3b18Kmgq65ZZbzIoVK5xrQWlhj30f3aFNeWanEACUrqqev/vn2Nk09uNFRUXq06ePZs+eraOOOorzBPj/CAAAALXa5s2bzcyZM3X77bcXK/jdhVryVmFljfChditPgeIe9U/eOcJKXmfu3l7SjlAaYxSLxYrtR96kSRN16tRJ+fn5GjBggHr16sUIfxV6/PHHzbJly7R+/XpFo1Ft3749YccPSc7yjVgsVmyUuTQEAKWr7BIfG5LZot8uhbHX9P79+2vWrFk6/PDDOV+AJAQAAIBa66677jLz5s3Tl19+KSn12l9JFPy1UHUXaGX1D3AX++6wwI70u5uYZWVlac8991SrVq2Ul5envLw89evXTx06dFCjRo0oYKrZ888/bxYvXqy///3vzrKAWCyWMhyUyle8EgCUrqp6fLj7NBhjNGTIEM2cOVNjx47lvAFKQAAAAKh1vvvuOzN58mQ9+uijxUb0k0dZk0f13NO4kT7VvQtAWb+rvF3I3WuQ7X+SFIvFnOPLNgQMBAJq2rSpWrRooaZNmyonJ0f5+fnq3Lmz2rRpo6ZNm1K0pNGzzz5rLr30Ur300kvOdcGuIZeKLwcoDQFA6ari/I5GoyooKFAwGNT++++vmTNnavTo0ZxDQBkIAAAAtcpll11mFi5cqF9//dUp5pOn9Vruzt8SAYCXuNfzVoeSChD78fI0eUvuIyFJderUUZ06ddS4cWO1atVKbdu2Vbt27bTPPvuoS5cu6tSpE6P6Hvfmm2+ahQsX6rnnnlM8HncahLIEoOpUNgCwwdoBBxygmTNn6qCDDuKcAsopnO4HAABAVfr555/13//+N6Grv3u0313cJ2/356XCv7oLjLLURAFT2s848cQTlZOTo48++ki///67Nm3apB9//FH/+9//9Msvv2jbtm0qKioqtja7vMs5Um2/Zz+ePK1Y+iMs2m233bTnnntqt912U5MmTdSoUSM1b95cTZo0UZMmTdSqVSt16NBBLVq0UIsWLShIMlS/fv0CTz/9tN544w2zbNkyPf30085xlqrfg3sduvu64/68XaNe3uPT6wFBZR5f8i4YVknXafs5u4QmKytLw4cP1/Tp03XAAQdwngEVxAwAAECtc9xxx5l77rlHkpy90t2N/zJhmz8/BACl/Zw999xThx9+uJYtW6aWLVs6X/TLL7+YzZs3a/v27dqyZYt++eUX/fLLL/r111+1fft2bd68WUVFRfrtt98Ui8W0Y8cOFRQUOFO33dP0Q6GQotGo899uu+2mPfbYQ1lZWWrQoIF222031atXT/Xr11f9+vW11157aY899lCDBg0oOnzknXfeMStWrNDDDz+s7du3O9cUe+wmLyGy/06eYeRW3ednddvV899+n/sabP90hyNZWVnasWOH0yyzoKBAderU0VFHHaXp06erd+/enIPALiIAAADUOj///LPp16+fPv/884S1/+XZ390r/BIAlPWzmjdvrqlTp2revHnc8COtNm7caC6//HKtXbtWW7duVSQS0Y4dOxJ6ikiJMwKkP4KAoqKihK/zYwDg/h57LXaP7LsD2lAo5HzNHnvsoSOOOEKzZs1iFwygChAAAABqpQ8//ND069dPv/32W8LHS5p+6jV+CgBS/bzkng0DBw7UihUrtO+++1IAIK2++eYbc8UVV+imm27STz/95Iz02+Uj9rgNh8MKBAIqLCxMCCDtFPfKSPf1q6Lnf/LXp3r87iaLxhg1bNhQJ5xwgqZNm6Z99tmH8x6oIgQAAIBa66677jInnHCC8297A84SgLJ5IQCwxVJRUZEikYhCoZDOOOMMzZ8/n475SLvvvvvOXHPNNbruuuv0008/KRgMqqCgQJKKXWPcfSXcIcGuqu7rV1VfP1IFAO6tMO15boxR48aNdeqpp2rixIkU/kA1IAAAANRqM2fONKtWrSp38y2v8FsAkPwzk3s1uEdQ99lnH61YsUJHHXUUxQHS7ocffjBXXHGFrrvuOv3444+KRCIqKipSKBQq1hDQNgn0+hKAqnx8qX6W3RpT2hn2tWnTRuPHj9fEiRPVpk0bzm2gmhAAAABqvQMOOMC89NJLCofDzt7eXufHAMD9c90jhO4mYXb01BijY489VmvWrFGzZs0oFpB2P/74o7nssst0ww03OEFAYWGhsztAPB5P6ElSGZkSAJT0c4wx2nPPPfW///1PzZo105lnnqmJEyeyewZQAwgAAAC13ubNm03Pnj317bffSkr/+tny8GsAYH92qi3CbBjgns3RrFkzrVixQhMmTKBwgCds2rTJXHLJJbrpppu0efNmRaNRZ2mApIzoAVAV14/SfkYgEFDjxo11+umna+rUqWrevDnnL1BDCAAAAL7wyiuvmBEjRiTciFu2iZeXGgRWdwCQzgK/PMrz+223dWOMjjvuOF100UVq27YthQQ84ZtvvjErVqzQXXfdpc2bNzszWNzXmuStBO0x7f6YXSMvyWmSl27JTTqlxN0O3F9nv9Yu4WnWrJkmTJigyZMnq127dul/MoDPEAAAAHzjyiuvNNOnT3c6dsfj8YTRZHfjuXQvE0h3AZ8JAYAVCoUkSQ0aNNAFF1ygKVOmUFTAM7755huzevVq3Xzzzfr5558l7QwdU11/QqGQ4vF4sT4Y7uuSV0IA+xjd3fvtY0u+xjZr1kynnnqqJk+erL333jv9TwDwKQIAAICvnH766eamm25KuKk2xqTcszud0l3AZ0IAEAqFnGUB9t/xeFz9+/fXqlWrNHDgQIoMeMZ3331nrrvuOl177bX67rvvEpYGuIt793aC7jDAikajxZoL1rRUoYS7waFt8heNRlW/fn2dfPLJOvvssyn8AQ8gAAAA+M6IESPMc889V6wpIEsAqu77K6us3588Bdm9h7j9/DnnnKPzzjuPLQPhKVu2bDG33HKL1qxZo6+//lpZWVlOEOAeQU+1jaBXZgC4e3GUFF60aNFCJ510kqZOnUrhD3gIAQAAwHd++eUXM3jwYH388ccJhaQdtUrVhK6mpbuA93oA4J4B4C4+3H83xqhdu3ZasmSJjj/+eAoQeMrWrVvNI488opUrV+qDDz5wRvaNMc4SAUkplySlOwCwYYR7GYD9WIsWLXTGGWdo4sSJ7NABeBABAADAl7744gszZMgQff3115J2jiC71+SmU7oL+EwJAOyov7upmvt9tEs6DjnkEC1fvlzZ2dkUJPCcm2++2Vx88cX67LPPnCDSHQK4lwLYv6eTe5tO++8uXbro9NNP1ymnnKKGDRtyngEeRQAAAPCt9evXm5EjR2rbtm2eGfm30l3Aez0AcE+HTtVILdXH69atq1mzZmn+/PkUJ/CktWvXmqVLl2rDhg1OkR2Px52Qy06598J1yj62rl27aurUqZo0aRLnFZABCAAAAL72wAMPmKOOOkqSEm620/3/x3QX8F4PAOxjcO/cYJsBRiIRxWKxhM9LO7dY69Gjh5YvX64RI0ZQsMCTbr/9drN69Wq98847KRsBpnsJgCT17t1bU6ZM0SmnnJL+BwOg3AgAAAC+t3LlSjNv3jynUEyeXptcRKZj+m3yDX+6A4CyeP3+IhwOa8KECVqyZIlatGhBAQNPuueee8yqVav0j3/8wwmw7LllZwRIibuX2KUDJTU1tQGne4aM+3uSO/zbACIQCCgcDqt///4655xzdOSRR3LeABmIAAAAkDYfffSR6dq1qyduIs866yxz9dVXF1tT7i72kztx1yQCgKoVDAYVDAbVokULXXzxxRo/frwnjkMglUceecSsXLlSr732WkKnfTf3Dhh2qUDy17lDAXeY6e43YLl3J4hEIjrggAM0ZcoUjR07lnMFyGDBdD8AAIA/zZo1y+Tn52vSpEmeqBSvuOKKwNixYyXJmUoej8cVDocl/XGD7IWlAagatvD55ptvdNJJJ+mQQw4xH3/8MW8uPOmwww4LrFu3LvDiiy9q1KhRkqQ6deo4RX4oFJKUOCsgHo8nbI1p2ZF8O7ofCASc4t8dftru/mPGjNGzzz6rp556KkDxD2Q+ZgAAAGrUPffcY/7yl7/o008/VSgUUmFhoY455hjdc889nrixHDBggHnrrbdSLgOwo2bp2CWAGQDVIxKJqLCwUJK011576bzzztO8efM8cSwCJXnrrbfMJZdcoocfflgFBQUplybZcECSM4Xffo0t9EvqkxGJRDR27FjNmTNH+fn5nA9ALUIAAACoERs3bjQzZ87UM888k3LLveHDh+vuu+9Wo0aN0nqz+dVXX5lhw4bpq6++StkTwF0w1iQCgOphn6d7BDU3N1eXXHKJhg0bRuEDT9uwYYNZvny5Hn74YcXjcRUWFpYZUKZqKmgbZ+6+++7605/+pFmzZqlHjx4c/0AtRAAAAKhWW7ZsMUuXLtVf//pX7dixI2VDvTp16qigoEB9+vTRY489pqZNm6b1xvPjjz82+++/v3788ceExxoMBovtz11TCACqR/Je5lYoFNIpp5yiiy++WI0bN6YQgqe9++67ZuXKlVq7dq1isZgz4i8lNg20/3aHAOFwWJFIRMcdd5zOPfdceaUvC4DqQQAAAKg2t956q7ngggv09ddfO+vq3Vvtubfcs3/27t1bDzzwgNq1a5fWm9B169aZI444Qlu2bHH6AaQTAUD1cPd1sMGOLY4kqUWLFrrwwgt16qmnUhTB82wQ8Nhjj2nHjh2S/pjBFIvFFAwGFQ6HVVBQoGg0qqKiItWpU0cnnHCCZsyYoc6dO3OMAz5AAAAAqHLvvPOOOeuss/Taa6850/zd+7RbJTXVa9++vZ566qm035A+8cQT5sgjj1RBQYFTFLpDi5pEAFA9kkdF3cGUbQIZi8U0evRorVq1Sl26dKFIgud98MEH5pJLLtH999+v7du3O4W/VbduXZ1yyimaMWOG2rZtyzEN+AgBAACgymzatMksWbJEN9xwg7Zt21ah700uOPfZZx89/PDDys3NTevN6a233mpOO+00p5t28jRxScXW06ZqyFXTqjsA8MP9g30fg8GgQqGQ9txzT82dO1ezZs2iYEJGeP/9982qVat0//33q7CwUHvttZfGjx+vadOmpX2WFYD0IAAAAFSJv/71r+aiiy7St99+m9Dcr7xSbVXVuHFj3X///RoyZEhab1SvueYaM2XKFGcGgy38Uz1HLxT/EgFAVcnKylIsFnOaVsbjceXn52v16tXad999KaCQEd566y2zfv16HXrooRT+gM8RAAAAKuXll182CxYs0Ouvv+4UhbtSBCcXnHa7vbp162rt2rUaMWJEWm9aL7zwQrNo0aKEx2ZnBCQ3BfRCCEAAUHn2fbSBln2/bQA0ZcoULVy4MO07VwAAUF4EAACAXfLxxx+bhQsX6tFHH3W6+7v3nK7o/19SrXG3HwuHw7rrrrt01FFHpbXQWrhwoVm6dGnCTICKznSoKQQAVcf9PofDYaenRVFRkdq2batly5bp2GOPJQQAAHgeAQAAoEI2bdpkli5dqptvvln//e9/ncLf/v9kV0e+UwUA7sIrGAzqmmuu0emnn57WQmv69OlmzZo1TlNDO0rs3skgHU0CkxEAVE4oFHKCnuTn6t7Jwn7dYYcdpmXLlqlTp04EAQAAzyIAAACU2+WXX25WrlypH374QYWFhZJUbBQ8EAg4HdQrIlUPAPfPsAX38uXL096Ebfr06eaKK66QlDjbIRAIJAQC6UQAUHnJU//tx2zxbz9uP7fXXntp3rx5mj17NiEAAMCTCAAAAGV64YUXzIIFC/T3v//d+ZgtEJPXw7u3VauIVD0AbADgLsTi8bjOP/98LV68OK1F1qxZs8yaNWucYt/9fJN7AqQDAUDViEQiKioqcmZ7BAIBZ091e3y6ewPYJoEXX3yxDjroIIIAAICnEAAAAEr01VdfmVmzZumhhx5SUVFRylH9YDAoaden/lupCs5wOOzMNLBskTVt2jStWrUqrQXWvHnzzPLly5394m2h6AUEANXHPSPAvRzAPUvAGKPTTjtNF110kRo3bkwQAADwBAIAAEBKixcvNqtXr9bWrVsTOt17YX27dfrpp+u6665La3E1e/Zsc+mllyoQCJTYEDAduwKkOwAo6/u9rrLHuJ210qJFCy1ZskSnnnpqZr8gAIBagQAAAJDggQceMIsWLdLGjRsl/TEF2o7C7+r6/uoSCAQ0btw43X333WktrhYtWmQWL15c7OO2J4ANBmxR6H5NqwsBQOVU9v7IvYVgPB7XoYceqpUrV9IkEACQVgQAAABJ0kcffWRmzZqlp59+WsaYhP3P3bwyAyAajaqgoECBQEBjx47Vo48+mtbC6rzzzjMrV65M6IHg3hGgtK7y1YEAoHIq+x7Z5x8KhZx+EA0aNNDcuXPT3sQSAOBfwXQ/AABAev30009m2rRppnfv3nriiSecrc0kqaioSKFQSJFIxPl6rxR2BQUFikajMsboySef1KhRo9KaSixfvjywYMEC59922YQNAWwPhXA4nMZHiZpig55YLOacT1u3btXs2bPVp08f88ILL6Q/RQMA+A4BAAD42A033GD69euna665RgUFBZL+aOZXWFiYMJJt/52OteylsSOrRUVFeu655zRkyBDz/fffp62wWrx4ceC8884r9hoFAgGn8K/uqf/wjnA47IQ/dimAJL399ts66KCDNHXqVLNlyxaCAABAjWEJAAD40PPPP2/mz5+vf/7zn6VuV+fe2s+99t8LywBKegw5OTl68skn1aZNm7RNVVi8eLFZtGhRQtFX068XSwAqpyqWANitA0sKzYLBoDp06KClS5fq6KOPzuwXDACQEZgBAAA+8sUXX5jx48ebkSNHFiv+7XZ+bnbfc3fxHwwG0178u7kLzWAwqI8//lgjRozQJ598krYHuXDhwsDChQsVCoWckX87Ddz+idrNLgGR/njP7XHqXgISj8f16aef6rjjjtNJJ51kvvnmG++cWACAWokZAADgExdeeKG59NJLtXXrVudj7qLfFvh2uz8r1Z7nXlgK4C78U/2/rG3btnrssceUm5ubtpHV5cuXmzlz5qRspljdmAFQOVXVBNC9haYkZ1aI/fnhcNg5p5o0aaJly5ZpwoQJmf3iAQA8iwAAAGq5Rx991MybN08ffvih05HcCwV8dQsEAmrRooXuuece7bfffmkrqNasWWNmzpzpBCmpXnd3QGD/XtkCPNOlO8CoSe4tA4PBoI444gitXr1aLVq0IAgAAFQpAgAAqKXeffddM3fuXL3wwgsJjee8sH6/JkSjUcViMdWtW1d33nmnDj744LQVU3fccYc58cQTS50JYIvA8jZbrO3voR8DAPefLVu21KJFi/TnP/+ZEAAAUGUIAACgFpozZ4656qqr9Pvvv0uSU3TaNf3uKci1lbsJWyAQ0M0336wTTzwxbcXUww8/bCZMmKD//ve/JU4Pt0sybBBQGj+8f6XJ9AAgEok4wZw78Ek+HkaPHq1Vq1apc+fOBAEAgEojAACAWuSOO+4wixcv1r///e9iI8jhcFhFRUVpL3zSwTbeW716tc4666y0FVLr1683Y8eO1a+//lrqUozyNFqs7e9jbQ8ArFTHQFZWloqKihSLxRQIBLT77rtr4cKFmj17NiEAAKBSCAAAoBb4+9//bubPn6+XX37Z2Xdc2llIuq/17lHm2swWgLbpml1jff7552vRokVpK6Q2bNhgRo8erW+//VZZWVnOKHDyFouZUsBWl9oeAKRqqJmq/4P7WBg8eLCuuOIK9erViyAAALBL2AYQADLYN998YyZOnGiGDBmil19+WcFgMKGZnJ3qb5uLSSqxEV1tY4MPO4oq/bEU4i9/+Ytmz56dtuqvR48egTfffFP9+vVzir3kLRbZKrD2swGEu/mfPXeTAzsbArz++usaPHiwli1bVrvTHwBAtWEGAABkqJUrV5oVK1Zoy5YtCoVCCY3+LHfR78frvXu2g7sBXzAY1JQpU3T55ZenbST1l19+MRMmTNDjjz+e8HH7Pnl9BLu61fYZAFLxLTel4k06U31NMBjUwIEDdeWVVzIbAABQIQQAAJBhHnzwQXP++efrww8/lLSzyJWUMJW4tJH+dOxLn07J0+rD4bAKCwt1yimn6KabbkprATVp0iRzzTXXFPt4JhSw1ckPAUAgEHAep/tcLWsXCDtDJBAIaMGCBWld0gIAyCwEAACQITZs2GDOPfdcvfzyy4rFYp4oYDKZLaKOOeYY3XXXXWktoC644AKzdOlSSXKWBbhnbbgLwvJsEVgV0l1ApzsASPfzL0s4HJYkxWIxDRgwQFdeeaXy8/MJAgAApSIAAACP27Jli1m0aJFuueUW/f77775Yv19T7EyIsWPH6rHHHktr8XT99debqVOnqqCgwPlYVlaWduzYoWAwqGAwWGwqeHVKdwGc7gI+3c+/POzxGwwGFY1Gde655+rCCy8kBAAAlIgAAAA87KabbjKLFy/Wl19+mdDRv6ZGgWszd/EUj8c1evRoPfnkk2ktnp544glzwgkn6H//+5+zc4G7j0Hy+vDqlO4CON0FfLqff3m5j49wOKy+fftqzZo16tevH0EAAKAYdgEAAA9av3692W+//cxpp52mr7/+OqFTvPvv2HVFRUUKh8MKBAIKBoN6+umnNXjwYPPtt9+mrbI7+OCDAy+//LLatm2bEPTYYpMdApDMHQrFYjG98cYbGjZsmP7yl794I6EAAHgKMwAAwEM2bdpk5s+fr9tuu82ZCm4LVHchyAyAynMXTu711L1799batWu1zz77pG0E9fvvvzeHHXaY3n77bWfWR03//zrdI+iZ/v01wV4HbCjk3uUiHo+rT58+WrVqlfbbbz9mAwAAJDEDAAA846qrrjK9evXSDTfcoMLCQmd0Wvrjxt52sS+rMEH52AIuFAopFospFospGAzqvffe0wEHHKCPPvoobRVe8+bNA2+88Ubg2GOPdYr/QCDA6D8c7gArVUAUDAb1zjvvaMSIETrvvPPSn1YAADyBAAAA0uwf//iHGTJkiDnrrLO0adMm58Y+FosVW/NtAwAvjD5mOne4EggEFIlEnNf2yy+/1OjRo7Vx48a0vtB33HFHYOHChQqHw87jkxK3foQ/JfcDsTOCwuGw8+9AIKDt27drxYoV6tevn1m3bh0XDgDwOZYAAECafPfdd+aCCy7Qrbfeqh07djgfj0ajKigoSNi73hijcDgsY4wzzReV4w5SbGGdHLY0bNhQTzzxhPr375/WaRf33nuvmTBhgtO0sLCwsNp/Z7qn0Gf699eEkraHDIVCxZYMSX+EA9OnT9eyZcuYRgQAPkUAAABpsGLFCrNq1Sr997//1e+//y6p+E17psuEAqosgUBADRo00F133aWRI0emtWh65ZVXzPjx47Vp0yZnhkhyLwh3kJHpr39FH39Fl8Z4/flXVnLvELvrRSQSUbdu3XT55ZdryJAhBAEA4DMEAABQgx599FEzf/58ffjhh8Wm8rtH8qLRqLZv356uh1klMr0AzcrK0o4dOxQOhxUMBnXXXXfpyCOPTGvB9Pnnn5tx48bprbfecj5mGxjaPhG26Mv0158AoPJCoZCMMQnHgz1GgsGgzj77bF166aWEAADgIywiBIAa8NFHH5k//elP5uijj9YHH3wgScW2d7Pi8XjGF/+1gV2WEY/HVVBQoGOPPVa33357WqvGffbZJ/D000/r5JNPVjAYLFb828cLSEoo/m3PANsjIBAIaNWqVerZs6d56aWXan8aAgCQRAAAANXql19+MQsWLDCDBw/Www8/rHg8rmAw6IzMWX4Yjcw07hFlW2hPmDBBa9asSeub1bBhw8DNN98cuOKKKxQOhxWLxVJ2gAfsMRwIBBLColAopMLCQkWjUW3YsEHDhw9npwAA8AmWAABANbnrrrvMwoUL9e9//7vYWm3LrtO1jf3cXf4z/fqc6VPQpZ2NAoPBoDN6WlRUpEWLFmnhwoVpnzr92muvmRNPPFFff/11sZ4Amf76swSg8tzLjJJ7jCR/TpK6du2qyy+/XMOGDUv7sQ0AqB4EAABQxdavX28WLFigF198UZKKFWXuztyBQKDYTbn9WKbL9AI0FAo5HfeT+zUEg0HNmTNHS5cuTXuh9P3335sJEyboxRdfTAiSyuL1158AoOrZ64v7upMcOoZCIU2bNk2XXHJJ2o9tAEDVY44gAFSR7777zpx55plm2LBhTvFvb7TtCJttviX9sVY7eUs/997eSK+ioiJnu73k7QKDwaCWLVum6dOnp72KbN68eeDZZ58NzJ07V3Xq1FE0GvVlcYtE9poTCAScv1vu60yq2UaXXnqpevXqRW8AAKiFmAEAAFVg6dKlZtWqVdqyZUtCge8ebbMzAdyfL0nyiHMmyvQZAMmzNSQ57597tPTPf/6zrrnmGk+Mlr744ovm2GOP1ebNm8t8fTPh9S8NMwBKV9psIvcxnGp5kv3ecDiss88+WytXrvTE8Q0AqDwCAACohPvuu89ccMEF+vjjjxMKitpQwFdWRQuyZF5//eyaakkaP368br/9dk8USV9++aWZOHGinn76aWVlZSkWiyXMNEkOoqSdI8LupnGZvgylugOo2hBwuZUWqOTm5mrNmjX0BgCAWoA5pgCwC9atW2eGDRtmxo0bp08//bTYSLHXb/5ReXbrvXA4rDvuuEPjxo3zxJvetm3bwFNPPRWYN2+eCgsLnWMyEolI2jkzJR6PO0W+eztKu3Uc/CPV9coGQsYYbdiwQaNHj9aMGTM8cYwDAHYdMwAAoAK+/vprc/755+vuu+9WQUFBwjRbuyVbSR3//aa2zwBwv8/2vT/00EN12223qV69ep4YKX3++efNKaecok2bNikWiyXsCS/98bhtoReLxZyP2b9nMmYAlM79+Et6rPZr3Dtg9OrVS6tXr9bQoUM9cYwDACqGAAAAymnlypVm9erV+uGHH5zCzz2dOlWnfz+r7QGAfZ/d73cgENCQIUN03333qWnTpp4okH766SczdepU3Xvvvc6yheQp/jYIKCoqKlePikxAAFC6sq5T7uNb2vl87O4YZ599NjsFAEAGIgAAgDI8+eSTZvHixXrzzTedj7m3zXKzHw+FQsU6/PtNbQ8ApJ3vdzAYVCgUckbS8/Ly9PDDD6tVq1aeKZCuu+46M2vWLG3fvl2FhYXF9oMPhULO9P/aEGJVtkD3w/FbFnsc2NF/6Y+wyG6N2atXL11xxRUaPHiwZ45zAEDpCAAAoASffPKJmTVrlh5//PFiU6btHtrhcDhhRJXif6faXkC5O6mn6rjerVs3PfTQQ+rcubNniqOPPvrIjB8/Xhs2bEg4Rt3HLEsAyvf9ZfH68Vse9liw4ZC0s4eE9MdzzMrK0vz583X++ed75jgHAJSMAAAAUli0aJG54oor9Msvv0hSse2ybOGfvBQAO/mhgHLPAJASp80Hg0G1a9dOjzzyiLp37+6p4mjevHlmxYoVqlOnjgoKClRYWOh8LnnKd6YiAKgagUDAub65lwHY2S42PBo2bJhuuukmtWvXzlPHOgAgEQEAALjcd999Zv78+frss88SPp68zru0Lf/cU6n9zA8FVPJxISXODDDGqGXLlnrkkUfUp08fTxVGr7/+ujn11FP16aefKh6PO4Wc+/FnMgKAyks+voPBoHOMpGooWbduXa1atUonn3yyp451AMBOBAAAIOmzzz4zc+fO1eOPP67t27en++EgAyUXjO5ZIXXr1tXtt9+uQw891FOF0datW82MGTN02223SZIzqyW58AuFQs6ygEzpD1DdAUAmvAbVLRgMOseDPW6CwaDGjx+v1atXq2HDhp463gEABAAAoPnz55trrrlGW7ZskaSU67mBsqQKACQ5o+l16tTRddddpxNOOMFzRdGTTz5pTjnlFP30008Jo//u3gDuv2fCkhcCgJqT3Pw0FAqpY8eOWrVqlcaMGeO54x0A/IwAAIBv3XTTTWbFihX65JNPihVrQEUlF4yplomEw2Fddtllmjx5sueKou+//96cffbZeuSRR5zi3t0osLRlL15EAFC93CFQKBSS9MfxEolEFIvFZIxRJBLROeeco/nz56t+/fqeO+YBwI8IAAD4zhNPPGHOP/98vfPOOykLGbr4Y1ekCgCSO+rb5mkXXnih5syZ48mC6N577zVTp07VTz/9lLIhYKY0CSQAqH7u66e7d0QwGEwICHJycnTNNddo0KBBnjzmAcBPgul+AABQUz755BNz1FFHmbFjx+qDDz5QOBx21je7G7hR/KMquI+laDTqfLyoqEjz5s3TwoULPVlBjhs3LvDBBx9o3Lhxkv4ILZLPEYpfJB8HtpGknU3lvo6+//77Gj58uBYvXsyBAwBpxgwAALXeL7/8Yi655BKtWbNGv/32W8Ln3J2t3SObzAJARaWaAeCeGm1Fo1EVFBRIkubOnauLLrrIs6Oijz/+uDnzzDP17bffOh/LlF0CmAFQvew1MhAIKBwOJ2wl6f68WzAY1H777acbb7xRHTp08OxxDwC1GQEAgFrtzjvvNEuXLtUnn3zi3LAbY1JO/bdTVpOnbQPlUVoPAHe39OTi+ayzztLll1/u2WJo06ZNZu7cubr11lsVDoe1Y8eOdD+kciEAqH6prqPu66dtqGqXw9iQoHHjxrr00ks1YcIEzx73AFBbEQAAqJXeeecdM3PmTL300ktljuy7R7LsdmeZ0OUc3pJcMLoL/lQft9PqY7GYTjnlFN10002eLoZefPFFM2nSJP3rX/9SJBIpNuLrNQQA1ctd2Esqdt0sqX+E3WElEAjo+OOP12WXXaZGjRp5+tgHgNqEAABArfLll1+aJUuW6K677tLvv/+e7oeDSvByAWcLmUAgkLBNXjweL3OGSfLf69Spo+3bt+vEE0/Ubbfd5ulCaOvWrebyyy/XqlWr9Ntvvznd3qWdzynVshpp5+vtleU1ZR0fZUn3/VOmBxQ2RMrOztZVV12lYcOGefrYB4DaggAAQK2xbNkyc/nll+uHH35g9L4W8GoAUFoX/OTiN1Vx7J5lEgqFVFhYqDp16sgYoz/96U+6++67PV8I/d///Z+ZN2+eHnjgAUlypnzb7u/u0WCv9gwgAEgv9+MPBAJavHix5s+f7/ljHwAyHbsAAMh4jz/+uOnZs6eZO3euvv/+e6cbNVDVUk3zd//dGKOioiJnzb/9uA2kjDFOEGBnC0h/NAYcNGiQ8vPza+iZVE779u0D99xzT+DFF19Uv379JP0xk8EuaZCUEMLZ4MP9b/ibPV9saHb++edr1KhR5osvvvB2cgEAGY4ZAAAy1saNG83s2bP13HPPKRaLJRRcXphijMrx2gyAVE3+wuGw4vG40zzS/t0Wu+590d3F8e677662bduqX79+Ovzww9W3b1/tvffeGVsV33DDDWb27Nn6+eefiy1/cL8uwWBQkUjEE40EmQGQfpFIJCEICwQCatSokVauXEmDQACoJgQAADLO5s2bzeLFi3XzzTfr999/TxhxpfCvPbweANip/CV9nbsJYDAYVMuWLTVo0CAdeuihGjRokPbZZ59aVeD88MMP5vzzz9ctt9wiKbEpnB3pdUv3/Ud1BwDVXaDXhgAg1SwZe96cccYZWr58uerXr1+rzhMASDcCAAAZ5corrzQrV67UN99849wwupuK2b/TxT/zeSkASPWz3KOWdj2/McZpjBcKhdS9e3cdcMABGj16tIYPH+6LQubNN980M2fO1Lp167Tbbrtp27ZtkhKnfHvh3oMAwPtoEAgAVY8AAEBGWLdunVmwYIHWrVvnjCjaqcX2OubuMm7XWiNzeSUAKOnn2HXt9vOxWEzRaFT5+fk68MADddRRRyk3N9e3hcudd95pFi9erM8//1zhcFjbtm1L2HIz3fcfBADp5w5q3eGt3WEjFospEolo4cKFWrBggW/PJQCoSgQAADzt22+/NTNnztRDDz3krBt2d1S3I612BoAXCgtUDS8EAOUpEhs0aKD8/HwddthhGjVqlDp06ECh4rJgwQJz2WWX6X//+5+nZgEQAHiH3RLQcu+0YXeROPDAA3X99derXbt2nF8AUAkEAAA8a82aNWb58uX64YcfEop8rluZobo7vbun4LuPCXfxkJWVpYKCgmJr0O0MkpLW8Lu377Mj/UVFRU5B0r59ew0ePFj777+/DjzwwIxu4FcTPv30U3P++efr4YcfdhoC2lk67t0BioqKnPcl1ftqt1i0/y4N14nMl3wuNm/eXFdeeaX+9Kc/cb4BwC4iAADgOa+++qqZO3eu3njjDWcKaFFRUcI+6oFAIGHECN5T3QGAu8me9EeBICnhY+4CIrmgDIVCCUtI7NIRY4yi0WhCOBAOh9W9e3eNHDlSY8eO1cCBAylAdsH69evN7NmztW7dupSzAdyzelK9N3a3hfI0++T+JrMln692JkA4HNakSZN02WWXcQ4CwC4gAADgGd99952ZN2+e7rzzTqfgTzVK6x7hhXdVdwDgHpWXdo7WuwtH+/GSQgFbaLqLi1gspng8rvr166tv374aPXq0DjzwQPXo0YOCo4o8+uij5uKLL9Zbb73lvAd2Fw+7Jty9PtyuCXevFy+rxwfXh8xmrx92t41wOOwcA/F4XPn5+br11lvVrVs3zksAqAACAACesHz5cnPppZfqxx9/dKb6ugu55CDAC2uIUbqamgGQzH3MGGOc0eJgMKhgMOgUE3b6uZ1uHolE1LRpUw0dOlSHHHKIhg4dqmbNmlFcVKMnn3zSLF68WG+88YYzu8e9faBbSUs9SsL1IfPZ99weD+7/D4RCIUWjUa1Zs0ZnnHEG5ykAlBMBAIC0evzxx80FF1ygd9991xmltVN83dcnrlXeU90FflnK04Qt+Wvsx2whsdtuu6lLly4aPny4DjnkEOXm5rLveBrcf//9Zvny5Xr77bcTdvdwj/onF4EEALWfOwhyz9IpLCxM2FHi1FNP1Q033MB5CwDlQAAAIC3eeecdc/755+upp55ypv9a7s7P7nXeyTeDbPOXXl4LAOw0cfeSAPeWkdIfW/U1b95cPXv21MEHH6whQ4aoZ8+eFA4ecd9995kLL7xQH3zwgdP7wy4NcC/lKM+xx/1NZrPns5V8vU/e7rV///667rrrWKoDAGUgAABQozZv3mwWLlyom2++Wdu2bUvo0p7c+MtKngYaiUQUi8W4wU8zLwQAyUWC/bc9Zuz6/latWmnIkCEaO3asBg0aRNd+j7vtttvMypUr9dFHHznvr3vpRnJomArXh8yWKsxL9Xn3zIC99tpLV155pY499ljObwAoAQEAgBpzxRVXmIsuukg//PCDU/Dbkb3S1vu6u36XdkOImuWFACAYDDrbyLkbxIXDYXXr1k3Dhw/XwQcfrO7du6tevXoUBRnmrrvuMhdddJE2btxYbGeGsu5fuL/JfKl6v9jrjrt5p90e0vaRmDRpki6//HLOdwBIgQAAQLV7+umnzZIlS/T666+X2uQLVauyBXpV/f/Bbs8nKWHkNjnMcW8Ll7zFn72xd0/5tV3/7ceaNm2qfv366eCDD9aBBx6ojh07UgDUEg8++KBZs2aN3njjDWcGgLvwc+8KUNpxm7zUqLTPl6U8PSi8/P2Vle77x7Ke37Bhw3TjjTeqXbt2XAcAwIUAAEC1+eyzz8zcuXP10EMPJYzOJG/rh+qR7gCgtJ0akot8W8wnzwhJ3v7NHR6Ew2F17txZ++23nw4++GANGjRIjRo14ma/FnvxxRfNJZdcohdffFEFBQXOCLF7RpH7uHOPGLsDpZIQAJRfuu8fy3p+wWBQLVu21HXXXadRo0ZxXQCA/48AAEC1WLx4sVm1apX++9//JozYSsWbOaF6pDsAKI0t1iKRiAoLCyUpYX233bLPPSvAGKPddttN/fr10/Dhw3XggQeqT58+3Nj70IYNG8ytt96q++67T99++60ikYjTS8S9NlwqXviXFUyVV7oLeAKA0p+fDZuj0aiWL1+uadOmca0AABEAAKhiDz74oJk/f74+/vhj50bbPXU7FAopFAqpoKAg3Q+11kt3AJDcxMu9dte9FZ87GLKBQDQaVWFhoSKRiFq0aKGBAwdq7NixGjJkiFq3bs2NPCRJW7ZsMffcc4+uu+46vffee5IS1427zwG7Xtxeh8paMuD1Ap4AoOzXx90j4NRTT9V1113HtQOA7xEAAKgSH374oZk5c6aef/55Z49u9w138pr/0kbhUDXSHQBIO4uuVD/PPWXbNvIrKipSVlaWOnfurDFjxmjEiBEaNmwYN+0o01NPPWWuueYaPfnkk87H3D0j7L+lxOMy+XNVhQAg/ZKXhey///66+eab6QsAwNcIAABUytatW82SJUt0xRVXaMeOHZISO/TT7C99vBAA2Btvu5ODe3TW/fMbN26s3r176+CDD9bw4cPVtWtXbtCxSz766CNz00036e6779a3334rY4yi0agKCgoUCAQUjUa1Y8eOhCUC7j+rCgFAermvPe7Gs3vvvbduueUWHXTQQVxjAPgSAQCAXXbXXXeZhQsX6v/+7/+cm2pJzvptW+glN3hzfw7VJ90BgB1ltQWYHYmLx+OKRqPae++9td9++2n06NEaMmSImjdvzg05qszPP/9sHnvsMd100016++23VVhYqHg8rsLCwoSdKaTqCQEIANLL3UA0uTFkJBLR6tWrNXnyZK45AHyHAABAhb366qtm/vz5evXVV53i3q7rdks1zZ+p/zUn3QFAKBRSIBBQLBZTOBxWKBRSbm6uDj74YI0YMUKDBg3i5hs14r333jNXXXWVHnroIf3444+SErenJACoOK9fx93/r7FLjJL7Ppxzzjlas2YN1yEAvkIAAKDcNm3aZObNm6fbbrvN6dzuZZW9ga5uVf34KnrDn7z9nvvnuG+c7efc26klb89nv1ZKvMlu3ry5evXqpTFjxmjUqFHq1KkTN9tIm02bNpm1a9fq/vvv1/r164vNRLI9A9y7T7g/lyrAtDNd3KPN9usrw2/Xr5oWCAQUDod1yCGH6MYbb1T9+vW5NgHwBQIA/L/27jTKyupMG/BTIyTaH6KIqAiIOEejggICQlFVVBXFIKNkdf9KdwZjHKMgQY0alTj1UmO0XbYdpyRGMzjFxCSd7rg0aWOrGYxJaxyiRiNxjB0VqDrv98Pex7cOBaIMNbzXtZYL69SpgSrdZ+97P/vZsFEuvPDC7OKLL44XX3yx20Vjb9TbJ6hbOgDorvpiQ18jnZFNTfkqm6dVLvzzC58UFGRZFqNHj45DDjkkjjzyyJgwYUKMHj3axJpe59FHH81uvfXWuOmmm+LRRx8t96jIVzOl/9bzvSuS9wrPNlXRxq+ekMatQw89NG655ZYYOXKksQro9wQAwAbddddd2emnnx4PPfRQubN/b1/4J719grq1A4CN/Rzpn3z37Ih3FjzpSsf0tTo7O2PgwIGxxx57RENDQ7S3t8chhxwSQ4YMMZGmz/jFL36R3XLLLXH77bfHk08+WW4al+9dkt/dj4jyFaednZ1drjdVAfCOnv7+Nla6enT33XePb3zjGzF+/HhjF9CvCQCAbj322GPZ8uXL49Zbb+32Gr++oLdPUHs6AKhc3Kdd/rz8gr+6ujrWrl0bVVVVMWjQoHLX/paWlth///1NmukXfvazn2Xf/va34zvf+U786U9/KvewSMeeKqsB8sdkNuc4WbTxa2vLj3mpimngwIFx/fXXx7x584xnQL8lAAC6eO2117JLL700Lr300njttdfKE980yU1d/FO5d2/W2yeovSEASCFA/sx/bW1tebGfFjp1dXUxfPjwOOKII2LOnDkxfvz42HXXXU2S6dfuueee7NZbb43vfe978cQTT5SPB6RxsFQqdQlIN+f4WLTxa2tLAUBE1/4mAwcOjMsvvzw+/vGPG9+AfkkAAJTdeOON2WmnnRZ//OMfu0zuampqoqOjo8uOcXdnYnub3j5B7YkAIP+cfBf09LtNu5fV1dXx4Q9/OPbdd99obm6Otra2mDRpkgkxhXXfffdld955Z9x5553x+OOPl4PRVBmQQtLN1QegaONXT0v9H9JRj/PPPz9OOeUUYx7Q7wgAgHjooYey5cuXxw9/+MOI6NoMLl8i3teOAvT2CWpP3wKQfr9pJ6xUKsXQoUOjoaEhpk6dGs3NzTFmzBgTYKjw9NNPZ6ecckp861vf2mJXmxZt/OoJ6XdXedtJ+t7PPvvsOP30042BQL9S29PfANBz/vjHP2Zf+MIX4hvf+Eb5bHe+HLy7CVw6E94XJne8q7vJeqlUim233TZGjx4dU6ZMiZaWljjssMNip512MuGF9Xj11Veza6+9Nu6///4ux2iS1FSO3i2Nid31Qkm/1zPOOCPeeuut7LzzzjMmAv2GCgAoqHPOOSe74IILYvXq1bFmzZp13r+ldrV6k/e7Y/5+bew1fClUSZUV+d2ovMoS1fXtXOXPs9bU1HT5XtIu/9ixY2P69OnR3NwcH/3oR01uYSPccsst2YoVK+Lxxx/f4l9rU3fYe/rje9qmju/5QPy4446LSy+91DgJ9AsqAKBgvv71r2dnnnlmPP744zFgwIAtdoc1G6+zszPq6urKk830O8nvJFY2FstPTtNEN53pL5VK5b4NqcR/1KhR0dLSEjNnzoyxY8fGsGHDTGZhI73wwgvZZz/72fjud7+7TvBG/5Tv73DFFVdEZ2dndvnllxs3gT5PAAAF8fDDD2ennXZa3H333eV7q9esWbNOF2QhwNaT/zmn7uJJ6sJf2Wk8/5x807HUlLG2trYcChx88MHR2toas2fPjokTJ5q4wgfw1a9+NVu2bFn85S9/KVfUWPz3f/nmjh0dHXHFFVfEwIEDs4suushYCvRpAgDo51atWpWdc845ce2118Ybb7xRfnx9E1iL/62vqqqqS/f9qqqq8u8n//tId1WnIwCdnZ3lhf/atWtjyJAhcdhhh0VLS0u0tLTE3nvvbaIKH9AzzzyTHXvssfG9731vnV3/vtQMlQ8u/3vOsiwuvvjiqKqqyi688EJjK9BnCQCgH7vyyiuzc845J55//vnyY2kSm5/YdLfrLwjY8vI/9/wZ/XSXeHo7v+tYU1MTtbW1sXbt2qirq4tRo0bFhAkTYv78+TF+/PjYeeedTUxhE1199dXZaaedFqtWrSo/lj9TbvHf973Xa1z+NbK6urr82nnRRRfFNttsk5155pnGWqBP0gQQ+qH//M//zE4++eR46KGHyovJVE6ezoTnd7Iiijmh7S1NANd37CL97jo6OiLinSaAAwYMiAMPPDBmzJgRLS0tsd9++8WgQYNMRGEzePrpp7NPf/rTcffdd5fHxu5uRdkaR6V6uolff28CuDF//w1Vflx44YVx8sknG3uBPkcAAP3Iq6++mp1yyinxta99LdasWVMuE6/c7U//pPdFdA0AitIHoKcDgPzksrb2nYKsmpqaWL16ddTV1UWpVIrOzs7Ycccd49BDD422trZobW2NMWPGmHTCZnbNNddky5Yti5dffjnq6+vLt6N0Vy21NZoA9vQCXgDw7u86hej5vivbbLNNXHfddTF//nzjMdCnCACgn7j66quzs88+u1zuX7ngT6XklZPW/JVxEcWqCOjpAKCqqirq6+vj7bff7rLgqKmpiZEjR0ZDQ0O0t7fH1KlTY/vttzfJhC3g+eefz/7xH/8xfvCDH0TEugFoqpxKR2+21hjZ0wv4ogcAKfjZ0GvksGHD4vbbb49DDz3U+Az0GQIA6OMefvjhbPny5fGjH/2ofH48on8s4Dd1gb4p49t7VUHkJ4epS3T+Y1Lwsr638x9fKpXiwx/+cOyzzz7R2NgYra2tcdBBB8XgwYNNKmELuuGGG7JTTz21S58Ueof3u4DvrsIq4r1D7coS/8rnpgAoHdfK/9PR0RGHH3543HbbbTFkyBDjNdAnaAIIfdSTTz6ZfelLX4obb7yxy13x/WHh39O6uxIxdedP1/Xlm0OlM/rpuakzf+UENV+V0dHREUOGDImxY8fGrFmzorm5Wdd+2EoeffTR7OSTT47vf//7UVtbW/5/vSjHn4okBa35ng75m1fS2+m5EVF+fv4K1vQxVVVVMWDAgBg8eHAceeSRMXnyZIt/oE8RAEAftHLlyuySSy6JVatWdTlDnhaigoAPLr+LlH62affnvZ6fdHR0xMCBA2PNmjVRV1cXHR0d0dnZGfX19TFixIhoaGiIxsbGmD59euy4444mjrAVnXPOOdnKlSvjrbfeKgd4+QWf8bP/yB+BW98Yng9x6+rqIsuy8jn/JP13sfvuu0d7e3vMnj07ZsyYYewG+iRHAKAP+eY3v5mdfvrp8cQTT3R7NjHi3d3nrdGkakvb2kcAKr9e/raE9P7uOoGnHcR0TV++WdS2224b++23X8ycOTNmzpzprCj0kPvuuy87/vjj45e//GX5/9X8nxHvjJ9pAUjP2tQjAOt7TuVjNTU1XY7P5Rvn1tbWxsiRI6O1tTUWLVoUU6dONX4DfZ4KAOgDfvWrX2Wf//zny02q8mWK6c98k7+0GO3ttnQTvk3VXYCQ/5lX7iylUGbEiBExadKkaGtriwkTJsSee+7Zu/+i0M8tXbo0u/LKK+Nvf/tbl74cEdFl8Z/+3VGALW9rNGGtDMnzv/v0/vxuf1r877bbbjFz5syYM2dOtLa2Gr+BfkUAAL3Y888/n61cuTKuueaaeOuttyLind2KNHmpvLqvLyz6e6vuJqP5x7rr4J92jQYMGBD77LNPNDU1RVtbWxx88MExaNAgk0boYT/5yU+y448/Ph555JHyY2n8zDfuTH05lP/3L/kGfhHvvH6m18507CMt+ocPHx5NTU2xZMmSaGpqMn4D/ZYAAHqpf/mXf8nOOuusePHFFyPLsvJEJt+tON+ILl8BYBL7/qxvJyr9LNOkMf3sBw4cGB/60Idi3LhxMWvWrGhpaYm99trLhBF6kaOPPjq7+uqr1xkL8zv7+R3h/GJQoNo/5Bv31dXVRWdnZ7m0v7OzM0aOHBnNzc2xZMmSmDZtmjEcKAQBAPQyP/7xj7MVK1bEL37xi/LCM9+xuLI0NU1k0nNqa2st/t+HDZWhprOha9eujfr6+hg1alRMnjw5Zs+eHRMmTIhddtnFhBF6mTvuuCM78cQT44knniiPoWlRn7/OLT1e2ejT+Nm/5K/sq6qqigMPPDAaGxtjzpw5Fv1AIWkCCL3Ek08+mZ122mlx8803lycrvd3WbtJX+bXzE/rK+5srqyC6uyUhf59zZQ+F6urqqKuri7Fjx8aUKVOivb09Jk2aZLIIvdRrr72WnXzyyXHdddf1ifGzt9vc4/uGmvR112A1vT9fxl9TUxMR0aX3Sv72hnzYk8byurq6GDNmTLS2tqZr+4zjQKEJAKAXOO2007IrrrgiXn/99fJEJnWT7816KgBIX7eyS//6ntdd5/60u58/NpFlWQwbNiwOP/zwaGxsjBkzZsTo0aNNFqGX+9a3vpWdcsop8fTTTzsCtZls6QAgPz7nG/ZVfmx3v898w8b0ufJVcvX19bHPPvtEW1tbLFiwIMaNG2ccB/g/AgDoQTfccEN29tlnx9NPP93lLuq0c9Hb///siQCgu0livhqgu/elxX2pVIr6+vrygr+joyPq6upijz32iKamppg1a1aMHTs2dthhB5NF6AOef/75bOnSpXHLLbfEmjVrevrb6Ve2dACQf3/a2U+L+vzb3Y35qeKrtrY21qxZE9XV1fGhD30odt9995g5c2YcddRRccghhxjHAbohAIAecM8992RLly6N+++/v8vCNb873RcaUG3tAGBDE8i8fCloel7+rO+OO+4YH/3oR6OpqSmmT58ehx56qIki9DHXX399tnz58njhhRe6HAfKH/fhg9saRwDyz6s81pUey1d61dXVxdq1a8t/Dhw4MEaPHh2zZ8+O+fPnx2GHHWYsB3gPAgDYip5++ulsxYoV8e1vf7tc3p/KFvMN/1QAbNzXy5d9Rryz8E+L//T504Jg5MiRMWnSpJg7d25MmjQphg4daqIIfdDjjz+efe5zn4s77rijSw8Ppf+b15YOALobq/PPTa+HNTU15ed2dHREfX197LXXXuUz/YcffrixHOB9cAsAbCVf/OIXs8suuyxefvnlLl2o0wSn8g7qvhAAbE3dTUbTpD8tAiLevbpv4MCBccABB0Rra2u0trbG+PHjTRKhjzvvvPOyiy66KF599dUuDeHyf9I3VFa55cfx/GthuoJ1v/32izlz5sS8efNi7NixxnOAD0gAAFvY97///WzFihXxq1/9qstuf2dnZ7mMsbOzs9yUzlVU61rfTlTq1N/R0RGlUimGDBkSBx10ULS3t8eMGTNin332MUmEfuDXv/51dswxx8R9993XJUDNN4/rLkild8v/rurq6qJUKpV/hzU1NbHHHnuUz/Qr7wfYPAQAsIU899xz2XHHHRd33HFHeUITEV2umkvHANIOR/79zrG+Y0NlqKVSKYYPHx4TJ06M9vb2aGpqiiFDhpgkQj+yYsWK7JJLLok333wzIt49LpXfIU5/9pX+KUS5tD9VwXV2dkZnZ2fsvffe0djYGEuWLIkpU6YYzwE2Mz0AYAu44IILsosuuij+8pe/9PS3skGbesYzNWdKVzKl8SQ/CV/f1U7pfflz/Pn7nvPd+9MkMXXt/+hHPxpTpkyJ1tbWOOigg2LHHXc0SYR+5mc/+1l2wgknxAMPPFDeKU5VU7z3+L2lmqx2d71qPrDOH29b3+dJgXipVCr3aGloaIiFCxdGS0uL8RxgC1IBAJvRXXfdlZ166qnxyCOPlCc4/VlauOcrFdKivruOzhv6HEkKD/LXIW6zzTZxwAEHxJw5c6K1tTUOOOAAE0Tox5YtW5Zdfvnl8eabb3Y5G27x3zPSLn2pVIpSqVT+faQxPr/4z/evyXfzz78/ImLUqFHR1NQU8+fPd/0qwFakAgA2gz/84Q/Z0qVL47bbbuuyo93b///aXF2e0+7c+hoXVu70J2lCme/e39nZGfX19bH99tvH1KlTo6mpKZqammLkyJEmh9DP3XfffdknPvGJeOyxx8q9UVI1UQpV000pRbc1KgDWF+SmMTst/CsD73wVV/572XHHHWPmzJmxePFiO/0APUQAAJvg1Vdfzb74xS/Gv/7rv8Ybb7zR5zr3b2oA0N2ivrvFfv7nks59pp2k9O8DBw6MvfbaKxoaGmLWrFkxduzY2G677UwQoSD+6Z/+Kbv++uu7jA2pGui9KomKaEsHAOv7HJW/j+5+P+lIQFVVVYwYMSJmzJgR8+fPj8MOOyy233574zpAD3IEAD6gSy65JLv88svjySefLN81nxpT5btU92f5CWPaqctPBPM3G+TP9Kcy3u222y7Gjx8fLS0t0dTUpLQfCug73/lOtnTp0njqqae6nB3Ph4ipwV91dbVjAFtZem1LVRf5Mb6urq78upcW/TU1NTF06NBoaGiIxYsXx5w5c4zrAL2IAADep3St3y9/+csuOyD5JnhFuYYqH3Tkr3KKeHfyXnld16677hqNjY3R1NQU06dPj2HDhpkcQgH96U9/yk4++eT45je/GRFRbviZHzsiuo4lbkbZetLrWeVrW01NTaxdu3adgHfo0KExbdq0WLx4cUydOjUGDRpkbAfohRwBgI30zDPPZMuWLYubbropIt7ZFcmXqqZFbuqIH1GMHgD5pn3pc6Zz/B0dHbHNNtvE7rvvHs3NzTFv3ryYNGmSSSEU3Fe/+tVs+fLl8eKLL3bbOK4yRM2/3xWp79iatwDkK7jS76ezszOGDx8eTU1NsWDBgjjssMNi6NChxneAXk4AABth5cqV2QUXXBCvv/56lx3t/A5IX7Q5egDkd4NS1/5ddtklDjrooGhra4upU6fGRz7yEZNCIB577LHss5/9bPzoRz9ap0Fc+vd847+IKMRxqg9iSwcANTU15cV+dXV1rF69OiIi9t133zj88MPjyCOPjAkTJsSQIUOM7wB9iCMAsAG333579vnPfz5++9vflnc/8nccb+1O1Bt7T/P6Pq6yaVNld+d8V/7u/m7V1dXlBn/559TX18eoUaNi6tSp0d7eHhMnTrQTBHRx/vnnZ+edd1789a9/jYh1rwBNKseeoi7+N3WBn3+tSuN2/nPm+y3kXwe6e2y33XYrN/LToBWgbxMAQDd++9vfZqeddlrccccd5clo5XnUvjApzTfmS4v+iK5/h7Toj3i3l0G6fis9Nz+BLJVKUVNTE9tss00ccsgh0dzcHLNmzYoDDzzQhBBYxwMPPJCdcMIJ8bOf/Wyd++P54Lq7oi9fpp//+eavac2X86fxPB1d6+joiOrq6qirq4tdd901WltbY/HixXHEEUcY3wH6CUcAoMLy5cuzK6+8Ml5//fWIiC5n3Cu7+2/t/38+SAVAKuPMN9LqLgxI70uBQPpa6a7n2traGD58eEycODHmzp0bU6ZMiZ133tmkEFivFStWZJdddln87W9/iyzLoq6ursuRIdZvYysAUhAQEV3C3HxfmhTepvelCrb869qAAQNi+PDh0dbWFnPnzo3p06cb3wH6IRUA8H++/vWvZ2eeeWY8/vjj5cfy59rTDnjlTktvtr4ztmniXVvbdQhIE8G0K1RfXx8HHHBATJs2LVpaWmLs2LE6OwPv6ec//3n2qU99Kh555JEupebpCj+L/82j8paV/M5+RKzzdn19faxZs6a8619TUxO77757tLa2xpFHHhlTp041vgP0cyoAKLwHHnggO+OMM+IHP/hBRLx7hV/aqYroGgTU1NT0WAfq99u0b0P/f+fP++evcho8eHCMGzcu2traoq2tLfbee28TQmCjnXTSSdmVV14Zq1evXqeTfESUd6X7eyf/zXGG/72kkLe7pon5Kq40zqfjXXvttVe0tLTEnDlzoqGhwRgPUCACAArr6aefzr70pS/FtddeG6tXr+4yOV1feWpPl61+kABgfaWgdXV10dHREVmWxe677x4NDQ3R3NwcRxxxROyyyy4mhMD78tOf/jQ79thj4ze/+c0678sfnerpcXRr2dIBQHcfn458pZ93Cnmrqqpi7733jvb29pg3b15MnDjRGA9QUI4AUEinn3569uUvfzlef/31qKmpWefO6cpz8emfNGmtfH5vlSoWUgCQdtwGDRoUI0eOjKamppg7d64GT8AmOf7447N/+7d/izfffDMiYp0d/nwAUITF/9aSfs6pEqC2tjZWr14dtbW1UVVVFWPGjIm2trZYsmRJTJgwwTgPgAoAiuWWW27Jli5dGs8+++x7TkLz5+fTTnp+0d8TIcAHrQAolUoxePDgmDx5csyaNSuOOOKI2GeffUwGgU3y05/+NPv0pz8d//M//9PtjnS+f0qiAuAdm+MIQDrTP2DAgHj77bejuro69thjj2hubo6FCxcq7wdgHQIACuH3v/99tnz58rj11lt7+lspy++I5cv0N+Z6rHyn/lKpVG7ml8o90+fabbfdYvLkyTFv3ryYNGlSDBs2zGQQ2CxOOOGE7Morr4w1a9aUG9D1pSqpTV2gv9fnSz+P/Jgc0X0Akh/305V8+XP8+Y7/+eeno12jRo2KhoaGWLBgQbS0tBjnAVgvRwDo11599dXs3HPPjauuuirefvvtiIh1rkTqCZUTxfz3kt+1X1+jrMp7n9PfZ8CAATF69Ohoa2uLmTNnRmNjo4kgsFl9+9vfzk466aR47rnnolQqRX19faxdu3adG1OKLn/Van7Mz1/JWtmwL39Ua0NKpVLsscce0djYGAsXLoyxY8fG9ttvb7wH4D2pAKDfuvHGG7OzzjornnjiifKiOqLr5Ksn/vuvXPynyXJdXV25S3P+++vu6EH6HJ2dnTF48OA48MADY9asWdHa2hof+chHTAKBzW7VqlXZCSecEN/4xjfK42lNTU35tpSI7kv+e6stXQHQ3c+h8nWo8uNSz5b0OlBTU9Olm//QoUOjvb09Fi5cGE1NTcZ6AN43AQD9zoMPPpidcsopce+998batWu7LKAryym3tsoJYmWX/vzz8iWf6WaCVFI6YsSImDBhQsydOzcmTJgQo0aNMhEEtpgbbrghW758eTz//PPdXoWaH2f7Qvl/xJYPACo/PoUjEdHtzyc/7uevoR05cmS0trbGggUL4tBDD43tttvOeA/AB+YIAP3GqlWrsjPOOCOuv/76WLNmzToTrMpSy94iH06kiXNa8FdVVUVHR0d86EMfiv333z8aGxtj9uzZMWnSpN71lwD6pRdffDH7zGc+E7fddls5qExjVjrLXhmy2ljoKj+WV/5s8s1mU7CSdvobGhpiyZIl0d7ebrwHYLMRANAvXHLJJdkFF1wQL7zwQkR0PVvZXffp1ERva05UNxQ85HeGUlOnHXbYISZOnBjTp0+P1tbW2HPPPU0Cga3mqquuyr7whS/EK6+8Uh43U4l6RHRZ/FeW/gsC3pG/Pjbina79EVFunFhTUxMR7/wshwwZEtOnT4/FixfHlClTnOkHYItwBIA+7c4778zOPPPMePDBBzf4vHwzvRQC5Esst7T1Lf5TWf+aNWuipqYm9tprr5g+fXq0t7fHxIkTlXoCW90zzzyTHXvssXHHHXd0e1NJd/I9SyK6L3HvbbZGD4AUilRVVZX7vKRd/lKpFEOHDo2pU6fGUUcdFZMmTYqddtrJmA/AFqUCgD7pwQcfzFasWBF33313RLw7OY2Idc7Op4V+mpimnayeXvxHRGy77bYxduzYaGxsjJaWljjkkENM/oAec+mll2ZnnXVWvPrqq13G1crz/ZVVVPnFcnp/5VV3RZR+Rql/S6lUitGjR8f48eNj4cKFMXny5Nhxxx2N+wBsNSoA6FNeeuml7LTTTosbb7wx3nrrrc2yy7S5S1UrS/nT95g6/e+6664xbdq0aG1tjalTp8awYcNM/oAe9cgjj2THHnts3HvvvdHR0bHeK0h7k/e7g9/dDn3EuuFGel9lmBzx7nn+dLyssnlrek5ltcTIkSOjubk55s2bFxMmTFDdBUCPUQFAn3HRRRdlF198cfz5z3+OiPee/G2s/IK9uyv30s5Nek76mMrnp+emiV9q6PT//t//i3322SdmzpwZs2fPtssP9CorVqzIvvzlL8cbb7wREdFlzOvvSqVSeRxP/15dXV0OP/I9DioX/em1I5X3d3Z2lnf56+rqYrfddosZM2bEggUL4pBDDrHoB6BXUAFAr3f33Xdnp59+ejzwwANbpLHU+nZ6kg1daZUPD9KuT6lUil122SUOPvjgOPLII2PatGkxZswYEz+gV7n33nuz448/Ph555JHy4jWi7zTw29QKgMqFfP75+SMMlf+eApJ80BvxzmvFiBEjoq2tLebPnx9NTU3GfQB6HRUA9FpPPvlkdtJJJ8Vtt91Wfqyy3HJzTFLznyc/Icyf2cx3vq7cLSqVSlFfXx8jR46MpqamOPLII2PcuHE6OAO90ssvv5wtX748rrnmmi6720lfWPxvLuurAMuP76lTf0SUg5J0RKKqqirGjBkTra2tMXfu3Bg3bpydfgB6NRUA9ErLly/PLrnkkli9enV5IZ4vxaytrd0sTfy6a1SVnxCmBoIpEMgHBB/+8IfjwAMPjNbW1pg1a1YcdNBBJn1Ar/bd7343O+mkk+Lpp5+OiOjStb+7o009aVOPeW1MBUDa0U+L+cq/d7qqL3+mv6amJoYPHx4tLS0xb968mDFjhrEfgD5DAECv8vWvfz0766yz4rHHHouIdxfo6c/8TtXmnKTmg4DK+6zTYxERO++8cxxxxBExe/bsaGhoiJ133tnED+j1nn/++ezEE0+Mm2++OSLeGT/THfWVJfC9pYP/lg4A1vec1Lw1HemKeOcq2ZEjR0ZbW1ssWLAgpk2bZuwHoE8SANAr/O53v8uWLl0a3//+98sNlNasWdPt+fzKpkybIk2C85UFadKXmkGNGTMmpk2bFkceeaQznUCfc8MNN2TLli2LF154oby4T+NoPgiI2LzB6qbaWhUA+bCjtra2HIpUVVXFiBEjYsaMGfGxj30spk6davwHoM8TANDjTjrppOzqq6+ON998c71XMOWva9qcu1PpbGcKAEqlUgwcODDGjRtXvrLpgAMOMOkD+pwXXngh+8QnPhF33XXXRoWlRTsCEBExYMCAWL16dfm4V5Zl5X4uRx11VDQ3Nxv/AehXBAD0mCuvvDI7//zz47nnniuX+ecnnd39t1l5BCAiunxMflersrFfRHTZ4U8L/urq6hgyZEiMHTs2Zs6cGY2NjbHvvvua9AF91vXXX58dd9xx8fbbb8fq1at7+tvZKJUL9PWdyU/jfP7IQkR0OcaV110QUFn9tfPOO8f06dNjwYIFMXHixNhxxx29BgDQLwkA2Op+/OMfZ5///OfjgQce6NJluaqqqnydUn4Cl2VZlzOqqSlTatrU3Xn99E/azero6Oiyq1VXVxc777xzNDY2RktLSzQ3N+vaD/R5zz33XPaZz3wm7rrrrvI4ub5FdG8455+3oTP6+Uas6e/zXpUKqZx/fZ972LBh0dLSEosXL47x48fH4MGDvQYA0O8JANhqnn322Wzp0qXxrW99a50FeVL5WKoKSAv/7naEIro27ktn91OYkD7HgAEDYr/99ouWlpaYPXt2TJw40WQP6DeuuOKK7PTTT4+//vWv5fEvqQxR+0IAUNn/pbvnVp7jz1/Zmr/CNT02dOjQmDlzZixatCja2tq8BgBQOLU9/Q1QDOeee2522WWXxapVq6Kqqqp83rK2tjaqqqrKV/pVTvLyRwMq35eOAKTJXZro5RtaDRkyJA499NCYO3duNDY2xpgxY0z4gH7lD3/4Q3b00UfHf/zHf5THww01Sc2yrNct/rtTeTtBd+/PHwnLVwjU19fHmjVrorOzM3bbbbdoaWmJ+fPnx/jx41V7AVBoAgC2qHvvvTc75ZRT4v777y+fucyyLNauXVsu+U8hQL7UP1++ny/h7K4SoLa2Njo6OqKjoyMGDBgQu+yySzQ0NMS8efNi/PjxznIC/db555+fnXPOOfG3v/0tIt4dJ/NXp0asfxG9Kd6rSd/m+Jr51418aJGCjhQEJyk03mmnnaKhoSEWL14c7e3tXgMA4P8IANginn322eyMM86IG264ISLe3XFKuzT5RX2+VDXf7T+ia1OnVLaaPl/EO+We22yzTey///4xc+bMaGlpiXHjxpnsAf3az3/+8+z444+PBx54oMsiP42N+cVyd9UAvaXT/4bkS/nT95r6xXR2dnap+EqN/BobG2PJkiXR0tLidQAAuiEAYLP753/+5+yCCy6Il156qct9ypUL//RPfqKaL/XPn+WvrAYYOXJkHHzwwbFgwYKYMmVKjBw50mQPKIRly5Zll19+ebz99ttdbkNJJfDvtfO+qdfrbU35pn91dXXR2dkZnZ2d5Rtdhg8fHg0NDbFkyZIYN25c7LDDDn3nLwcAPUAAwGZz9913ZytWrIgHH3yw/Fi+bL+7M6cpIKi8qi91+E+PDxgwIMaMGRNNTU0xe/bsGDduXAwaNMhEDyiMn/70p9nRRx8dv/vd77ot9c8v/iuPUyWVnfR7s+rq6vKOf0SUw+A999wzpk6dGnPnzo3JkyfHdttt57UAADaSAIBN9thjj2Vnnnlm3HzzzV1279NCPt+UqvL+5oiujZ7SLn9VVVX83d/9XYwbNy5mzJgR7e3tsd9++5nkAYX0qU99KrvmmmvWWdinYLVy1z+9Xfn4piz8u+vSn76P7oLbyo/dUHPC/OP5irFSqRS1tbUxatSoaGlpiXnz5sXYsWMt+gHgAxIA8IG99NJL2cqVK+Pqq6+ON954o8sErlQqxdq1azd47jQt+FOZf1VVVYwaNSqOOOKIaG9vj8mTJ8dOO+1kkgcU1h133JEdf/zx8eyzz5YX+2mx3Rvkx/z82/njCPmQIB8A59/Ohwup8d+IESOira0tjjrqqGhoaPBaAACbQdWW6AxM/3fVVVdlK1eujGeeeSZqa2vLV/rlm/2lO5grS//zi/5tt9029t9//5gxY0bMmjUrDjvsMJM8oPBeeeWV7MQTT4ybbrqpHKamyqo1a9Zs8Jq/LaW7CoDKZoLpOfmeLfnXgaqqqvLVrqlvQXq8uro6hg4dGjNnzoxFixZFc3Oz1wMA2MwEALwv99xzT3bqqafGL37xi3Ua+qVSzbQzVV9fX77uL39l3/bbbx9Tp06N9vb2aGhoiBEjRpjkAfyf22+/PTvhhBPiqaee6hKmph31nnrd3tARgPxzKm9ziYjyoj8FAzU1NeX37brrrtHc3BwLFy6MCRMmKO8HgC1IAMBGee6557KzzjorrrvuuiiVSuvs7OR3gSonhNtss03sscceMW3atJg1a1YceuihJngAFV5++eVs2bJlcc0115TH1O52+nti9z993bzKUv7K/gLp+6zc5a+qqopddtklmpqaYsGCBdHa2ur1AAC2Ej0AeE/nnntudtlll8WqVasi4p3JXvqzo6OjvLOTbwK1ww47xLhx42L27NnR1NQUe+21lwkewHrcfPPN2dKlS+OPf/xjlwV+5e56qgDoLX0Aamtro7Ozs0sYkG4ZqKmpiY6OjnIwMHr06GhtbY2FCxc60w8APUQFAOv17//+79myZcviN7/5TaxZsyYi3m3slMo40yS0vr4+dt1115g8eXLMmzcvpkyZEkOGDDHBA3gP//AP/5DddNNN6y3xr+yl0psqAOrq6qKjo6Pc2yVViKXXiuHDh0djY2N87GMfixkzZnhNAIAepgKAdTz77LPZsmXL4uabb16n1L9yp/+AAw6IefPmRUtLiwZ+AO/D1772tWzp0qXx/PPPR8S6JfPpCEC6GjUiygFBdw1We0Lq4p8au2ZZFrvttlscfvjh8fGPf9yiHwB6GRUAdHHZZZdlK1eujL/85S/d7jhtu+22se+++0Zzc3PMnDkzJk2aZHIH8D48/fTT2THHHBN33XXXFv9aqdle5TV9aUzPVxPkH0sBQ3o738w1/3Y617/99tvHlClTYsmSJTFt2rTYcccdvTYAQC+kAoCIeOeu6bPPPjsefvjh6OzsjAEDBpR3nXbZZZcYO3ZstLa2RmNjo/P8AB/QJZdckp133nnx0ksvbZWvt75jBfkeA/nqgtSkL/UXSIv9/Menz7fTTjvFlClTYtGiRTFt2rQYOnSo1wYA6OUEAAX35JNPZmeeeWZ885vfLJea1tXVxW677RbTpk2L2bNnx6GHHho777yziR3AB/Too49mRx99dNxzzz3dLqq3lMqr+FJlVzqjn9/hT8e8ImKdIwfp4wcNGhTTp0+PRYsWxYwZM9zoAgB9jACgwM4888zs8ssvj1deeSUGDx4c++23XzQ3N0dzc3NMnDjRpA5gMzjzzDOzCy+8MN56662IWLep35aU+gnkewfkF/Xp/Z2dneX35Tv4V1VVxdChQ+30A0A/oQdAAd1xxx3Z+eefH88991yMHTs2Zs+eHVOmTIk99tjDpA5gM/nv//7v7Nhjj43777+/yzV5W/P6vqqqqqirq4tSqbTer5vvE5CuGNx+++1j8uTJsWjRomhpaYnBgwd7fQCAfkAAUCCvvfZa9sMf/jB+/etfx8EHHxyTJk2KYcOGmdQBbGannnpq9pWvfCX+9re/dSmhz1+R11NX+aWvn8r8U0O/7bffPqZOnRpLliyJhoaG2GGHHbw+AEA/IwAAgM3kv/7rv7JPfvKT8fvf/z7Wrl0bEe8u/Hvi6r58WX9a/Kd/L5VK5UZ+CxcujIaGBuX9ANDP6QEAAJvBcccdl1111VWxdu3aLmfs06I//1i+Od+Wkg8camtro7OzMzo7O2P06NExceLEWLRoUUyaNCmGDBli0Q8ABaECAAA2wQ9/+MPsM5/5TDz11FPl3fW0w76x8rcCpKv40pn8/PvSef3KSoL8c6qqqspN/NLH7LrrrtHc3BwLFy6MCRMm6N4PAAUlAACAD2DVqlXZiSeeGLfcckt0dHSUG+hlWbZRpf756wDzi/eIWG9/gHz1QL6cvzIAiIgYMWJENDY2xuLFi2P8+PExaNAgi34AKDgBAAC8T9ddd1126qmnxqpVq7rd9c8vyDdGd89Pj6WFfnV1dbmBXwoY0mI/4p1AYKeddor29vZYtGhRNDc3W/ADAF0IAABgIz3xxBPZMcccE3fffXe5VD812Yt47x3899LdDQHpc6by/46OjnKlQUTE8OHDu5T32+kHANZHAAAAG+GCCy7Izj333PjrX/9a3pVfX2f/jakASFUDEdGlX0B+5z81EazsDzBy5MhobGyMBQsWREtLiwU/ALBRBAAAsAEPPfRQdswxx8T999/fbXO/ysV+dXV1RMR7NgHsrllgvqS/8nPuscce0dLSEosWLYojjjjCoh8AeN9cAwgA63H22WdnF198cbz55psRse6iPi3+85UAG9v9P+3yp89R2UCwvr4+hg8fHq2trXHUUUdZ9AMAm0wFAABUeOihh7JPfOIT8fDDD3d7Hj+V5qfH8h34Kzv7r0+6ri81EUyfb88994zp06fH3//938eUKVMs+gGAzUYFAADkfOELX8guvvjieOutt7pdxKcS//zbafGenr+hxX9+4Z8aCO6yyy7R0NAQixcvjjlz5lj0AwBbhAoAAIiI+++/PzvuuOPigQceiIiuJfqV1/vld/yzLOvSuC89nj4m/znyVwYOGzYspk+fHvPnz4/p06fr3g8AbHECAAAK7+yzz84uvPDC+N///d9uO/iv73q/7p5bW1sbHR0d63xMVVVVDB06NNra2mLhwoUxadKk2G677Sz6AYCtRgAAQGHde++92QknnBAPP/xwlEqlqKuri7Vr127wYyo79ed3/7trALjbbrvFjBkzYsGCBTFhwoQYPHiwRT8A0CMEAAAUzmuvvZYtXbo0brjhhli9enWXTv75Xf3q6urywr7yur60+M9f55ce23nnnWP69OmxePHimD17tgU/ANArCAAAKJSvfe1r2RlnnBFPPvlk+bHa2toujfxSk770dlJdXb1Oh//a2toolUqx0047RXNzcyxatChmzZpl0Q8A9DpuAQCgEJ577rns5JNPjptvvjmyLCuX+1dVVUVHR0dERLkKIOKdhX8KBlKJf1r8V1VVRXV1dQwZMiSamppi8eLFMWXKFOX9AECvpgIAgH7v6quvzlasWBEvvfRS+bH1NfpL70uL/FKpVP4zy7IYM2ZMTJs2LebOnRtTpkzRvR8A6DMEAAD0W0888UR24oknxp133lle8Od3+dPCvrKbf/7turq6GDVqVLS0tMT8+fOjoaHBgh8A6JMEAAD0S1/5yleyM844I1599dV1Fv+Vpf35Hf608z969OhobW2NxYsXx6RJkyz6AYA+TwAAQL/yhz/8ITv22GPjBz/4wTpX9OU79kdEl7cHDhwYI0eOjLa2tli4cKFFPwDQ7wgAAOg3Lr744uycc86J1157rbzoT7v9tbW10dHR0SUQqK2tjX322Sfa29tj7ty5MXHiRIt+AKDfEgAA0Oc99dRT2Sc/+cn48Y9/XG7ml2/gl2VZede/trY2DjzwwJg9e3bMmjUrxo0bZ9EPABSCAACAPu2iiy7Kzj777HjzzTe7NPeLiPKiv76+Pvbaa6+YM2dOLFy4MA4++GCLfgCgcAQAAPRJjzzySHb88cfHT37yk4h4Z2e/VCp1Oet/wAEHRENDQxx11FExYcIEi34AoNAEAAD0Ka+//nq2cuXKuPTSS2PNmjXlkv/Ozs6oq6uLMWPGRFtbWyxatMiiHwAgp7anvwEA2Fg/+tGPsmXLlsWvfvWrcnl/XV1d+cq+BQsWxJQpUyz6AQC6oQIAgF7v5Zdfzk499dS49tpry4390k7/4sWL7fQDAGwEAQAAvdpdd92Vfe5zn4snn3wyPvKRj0RbW1vMnz8/DjnkEIt+AID3QQAAQK+1cuXK7L777ovx48fH3Llz48ADD7ToBwD4gAQAAPRKf/7zn7NXXnkl9ttvP4t+AIDNQAAAAAAABVDd098AAAAAsOUJAAAAAKAABAAAAABQAAIAAAAAKAABAAAAABSAAAAAAAAKQAAAAAAABSAAAAAAgAIQAAAAAEABCAAAAACgAAQAAAAAUAACAAAAACgAAQAAAAAUgAAAAAAACkAAAAAAAAUgAAAAAIACEAAAAABAAQgAAAAAoAAEAAAAAFAAAgAAAAAoAAEAAAAAFIAAAAAAAApAAAAAAAAFIAAAAACAAhAAAAAAQAEIAAAAAKAABAAAAABQAAIAAAAAKAABAAAAABSAAAAAAAAKQAAAAAAABSAAAAAAgAIQAAAAAEABCAAAAACgAAQAAAAAUAACAAAAACgAAQAAAAAUgAAAAAAACkAAAAAAAAUgAAAAAIACEAAAAABAAQgAAAAAoAAEAAAAAFAAAgAAAAAoAAEAAAAAFIAAAAAAAApAAAAAAAAFIAAAAACAAhAAAAAAQAEIAAAAAKAABAAAAABQAAIAAAAAKAABAAAAABSAAAAAAAAKQAAAAAAABSAAAAAAgAIQAAAAAEABCAAAAACgAAQAAAAAUAACAAAAACgAAQAAAAAUgAAAAAAACkAAAAAAAAUgAAAAAIACEAAAAABAAQgAAAAAoAAEAAAAAFAAAgAAAAAoAAEAAAAAFIAAAAAAAApAAAAAAAAFIAAAAACAAhAAAAAAQAEIAAAAAKAABAAAAABQAAIAAAAAKAABAAAAABSAAAAAAAAKQAAAAAAABSAAAAAAgAIQAAAAAEABCAAAAACgAAQAAAAAUAACAAAAACgAAQAAAAAUgAAAAAAACkAAAAAAAAUgAAAAAIACEAAAAABAAQgAAAAAoAAEAAAAAFAAAgAAAAAoAAEAAAAAFIAAAAAAAApAAAAAAAAFIAAAAACAAhAAAAAAQAEIAAAAAKAABAAAAABQAAIAAAAAKAABAAAAABSAAAAAAAAKQAAAAAAABSAAAAAAgAIQAAAAAEABCAAAAACgAAQAAAAAUAACAAAAACgAAQAAAAAUgAAAAAAACkAAAAAAAAUgAAAAAIACEAAAAABAAQgAAAAAoAAEAAAAAFAAAgAAAAAoAAEAAAAAFIAAAAAAAApAAAAAAAAFIAAAAACAAhAAAAAAQAEIAAAAAKAABAAAAABQAAIAAAAAKAABAAAAABSAAAAAAAAKQAAAAAAABSAAAAAAgAIQAAAAAEABCAAAAACgAAQAAAAAUAACAAAAACgAAQAAAAAUgAAAAAAACkAAAAAAAAUgAAAAAIACEAAAAABAAQgAAAAAoAAEAAAAAFAAAgAAAAAoAAEAAAAAFIAAAAAAAApAAAAAAAAFIAAAAACAAhAAAAAAQAEIAAAAAKAABAAAAABQAAIAAAAAKAABAAAAABSAAAAAAAAKQAAAAAAABSAAAAAAgAIQAAAAAEABCAAAAACgAAQAAAAAUAACAAAAACgAAQAAAAAUgAAAAAAACkAAAAAAAAUgAAAAAIACEAAAAABAAQgAAAAAoAAEAAAAAFAAAgAAAAAoAAEAAAAAFIAAAAAAAApAAAAAAAAFIAAAAACAAhAAAAAAQAEIAAAAAKAABAAAAABQAAIAAAAAKAABAAAAABSAAAAAAAAKQAAAAAAABSAAAAAAgAIQAAAAAEABCAAAAACgAAQAAAAAUAACAAAAACgAAQAAAAAUgAAAAAAACkAAAAAAAAUgAAAAAIACEAAAAABAAQgAAAAAoAAEAAAAAFAAAgAAAAAoAAEAAAAAFIAAAAAAAApAAAAAAAAFIAAAAACAAhAAAAAAQAEIAAAAAKAABAAAAABQAAIAAAAAKAABAAAAABSAAAAAAAAKQAAAAAAABSAAAAAAgAIQAAAAAEABCAAAAACgAAQAAAAAUAACAAAAACgAAQAAAAAUgAAAAAAACkAAAAAAAAUgAAAAAIACEAAAAABAAQgAAAAAoAAEAAAAAFAAAgAAAAAoAAEAAAAAFIAAAAAAAApAAAAAAAAFIAAAAACAAhAAAAAAQAEIAAAAAKAABAAAAABQAAIAAAAAKAABAAAAABSAAAAAAAAKQAAAAAAABSAAAAAAgAIQAAAAAEABCAAAAACgAAQAAAAAUAACAAAAACgAAQAAAAAUgAAAAAAACkAAAAAAAAUgAAAAAIACEAAAAABAAQgAAAAAoAAEAAAAAFAAAgAAAAAoAAEAAAAAFIAAAAAAAApAAAAAAAAFIAAAAACAAhAAAAAAQAEIAAAAAKAABAAAAABQAAIAAAAAKAABAAAAABSAAAAAAAAKQAAAAAAABSAAAAAAgAIQAAAAAEABCAAAAACgAAQAAAAAUAACAAAAACgAAQAAAAAUgAAAAAAACkAAAAAAAAUgAAAAAIACEAAAAABAAQgAAAAAoAAEAAAAAFAAAgAAAAAoAAEAAAAAFIAAAAAAAApAAAAAAAAFIAAAAACAAhAAAAAAQAEIAAAAAKAABAAAAABQAAIAAAAAKAABAAAAABSAAAAAAAAKQAAAAAAABSAAAAAAgAIQAAAAAEABCAAAAACgAAQAAAAAUAACAAAAACgAAQAAAAAUgAAAAAAACkAAAAAAAAUgAAAAAIACEAAAAABAAQgAAAAAoAAEAAAAAFAAAgAAAAAoAAEAAAAAFIAAAAAAAApAAAAAAAAFIAAAAACAAhAAAAAAQAEIAAAAAKAABAAAAABQAAIAAAAAKAABAAAAABSAAAAAAAAKQAAAAAAABSAAAAAAgAIQAAAAAEABCAAAAACgAP4/eD1VashrRrYAAAAASUVORK5CYII=';
+document.getElementById('main-logo').src = LOGO_SRC;
+document.getElementById('sample-logo').src = ICON_SRC;
+// Logo system section images
+document.querySelectorAll('.logo-sys-full').forEach(function(img) { img.src = LOGO_SRC; });
+document.querySelectorAll('.logo-sys-icon').forEach(function(img) { img.src = ICON_SRC; });
+document.querySelectorAll('.logo-sys-dont').forEach(function(img) { img.src = LOGO_SRC; });
+document.querySelector('.logo-sys-safe').src = LOGO_SRC;
+// Nav and footer logos
+document.querySelectorAll('.logo-nav-desktop, .logo-nav-mobile, .logo-footer').forEach(function(img) { img.src = ICON_SRC; });
+function switchPageTab(tabId) {
+  document.querySelectorAll('.page-tab').forEach(function(t) { t.classList.remove('active'); });
+  document.querySelectorAll('.page-panel').forEach(function(p) { p.classList.remove('active'); });
+  // Find the clicked tab by matching its text content
+  document.querySelectorAll('.page-tab').forEach(function(t) {
+    if (t.getAttribute('onclick').indexOf(tabId) !== -1) t.classList.add('active');
   });
-})();
+  var panel = document.getElementById('panel-' + tabId);
+  if (panel) panel.classList.add('active');
+}
+
+// Scroll-spy for TOC
+var tocLinks = document.querySelectorAll('.toc-link');
+var spySections = document.querySelectorAll('.section[id]');
+function updateScrollSpy() {
+  var current = '';
+  spySections.forEach(function(section) {
+    var top = section.offsetTop - 80;
+    if (window.scrollY >= top) current = section.getAttribute('id');
+  });
+  tocLinks.forEach(function(link) {
+    link.classList.remove('active');
+    if (link.getAttribute('href') === '#' + current) link.classList.add('active');
+  });
+}
+window.addEventListener('scroll', updateScrollSpy);
+updateScrollSpy();
 </script>
+
 </body>
 </html>


### PR DESCRIPTION
Reverts ui-treatment-deck.html from V3 (star logo, cream/cyan, Josefin Sans)
back to V2 (runner icon, dark plum/gold/periwinkle, Rajdhani) per brand decision.

Restored from commit 557defed.

https://claude.ai/code/session_011wJ9TJCmEHAtJqkbWp628e